### PR TITLE
fix(agentic analytics): harden fresh-account deploy on demo-mode

### DIFF
--- a/agentic-workloads/agentic-analytics/infrastructure/custom-resource-lambdas/bedrock_kb_ingestion/handler.py
+++ b/agentic-workloads/agentic-analytics/infrastructure/custom-resource-lambdas/bedrock_kb_ingestion/handler.py
@@ -107,7 +107,11 @@ def create_kb_role(kb_name, aurora_secret_arn, kb_docs_bucket=None):
     if kb_docs_bucket:
         statements.append({
             "Effect": "Allow",
-            "Action": ["s3:GetObject", "s3:ListBucket"],
+            # GetBucketLocation is REQUIRED: without it Bedrock's ingestion S3 client
+            # can't resolve the bucket region, falls back to the global endpoint, and
+            # gets 301 PermanentRedirect ("must be addressed using the specified endpoint")
+            # on every ingestion in us-east-1.
+            "Action": ["s3:GetObject", "s3:ListBucket", "s3:GetBucketLocation"],
             "Resource": [
                 f"arn:aws:s3:::{kb_docs_bucket}",
                 f"arn:aws:s3:::{kb_docs_bucket}/*"
@@ -381,7 +385,29 @@ def wait_for_data_source(kb_id, ds_id, timeout=120):
 
 
 def start_ingestion(kb_id, ds_id):
-    """Start ingestion job for S3 data source."""
+    """Start ingestion job for S3 data source.
+
+    Wraps the start + wait in an OUTER retry: a freshly-created S3 docs bucket can
+    return 301 PermanentRedirect to Bedrock's data-source reader for a minute or two
+    until the bucket's regional endpoint fully propagates, which surfaces as a FAILED
+    ingestion job (not a start_ingestion_job exception). Retrying the whole job clears it.
+    """
+    for outer in range(6):  # up to ~6 tries; bucket endpoint propagates within ~1-2 min
+        result = _run_one_ingestion(kb_id, ds_id)
+        if result == 'COMPLETE':
+            return True
+        # result is the failure-reason string; retry only the transient S3-endpoint race
+        if ('must be addressed using the specified endpoint' in result
+                or 'PermanentRedirect' in result or 'Status Code: 301' in result) and outer < 5:
+            print(f"  Ingestion hit S3 endpoint-propagation race (try {outer + 1}/6): {result[:160]} — retrying in 20s")
+            time.sleep(20)
+            continue
+        raise Exception(f"Ingestion failed: {result}")
+    raise Exception("Ingestion did not complete after retries")
+
+
+def _run_one_ingestion(kb_id, ds_id):
+    """Start one ingestion job and wait for it. Returns 'COMPLETE' or the failure-reason string."""
     print(f"Starting ingestion job...")
 
     # The Aurora RDS Data API (HttpEndpoint) can take a short while to become
@@ -407,11 +433,11 @@ def start_ingestion(kb_id, ds_id):
             raise
     if response is None:
         raise RuntimeError("start_ingestion_job did not succeed after retries")
-    
+
     job_id = response['ingestionJob']['ingestionJobId']
     status = response['ingestionJob']['status']
     print(f"  Ingestion job started: {job_id} ({status})")
-    
+
     # Wait for completion
     for _ in range(60):
         time.sleep(10)
@@ -423,15 +449,15 @@ def start_ingestion(kb_id, ds_id):
         status = check['ingestionJob']['status']
         stats = check['ingestionJob'].get('statistics', {})
         print(f"  Status: {status} | Scanned: {stats.get('numberOfDocumentsScanned', 0)} | Indexed: {stats.get('numberOfNewDocumentsIndexed', 0)} | Failed: {stats.get('numberOfDocumentsFailed', 0)}")
-        
+
         if status == 'COMPLETE':
             print(f"[OK] Ingestion complete")
-            return response
+            return 'COMPLETE'
         elif status == 'FAILED':
             reason = check['ingestionJob'].get('failureReasons', ['Unknown'])
-            raise Exception(f"Ingestion failed: {reason}")
-    
-    raise Exception("Ingestion timed out")
+            return str(reason)
+
+    return 'Ingestion timed out'
 
 
 def load_content_from_s3(bucket, key):

--- a/agentic-workloads/agentic-analytics/infrastructure/custom-resource-lambdas/glue_crawler_trigger/handler.py
+++ b/agentic-workloads/agentic-analytics/infrastructure/custom-resource-lambdas/glue_crawler_trigger/handler.py
@@ -92,22 +92,42 @@ def wait_for_crawler(crawler_name, timeout=600):
             last_crawl = response['Crawler'].get('LastCrawl', {})
             status = last_crawl.get('Status', 'UNKNOWN')
             print(f"[OK] Crawler completed with status: {status}")
-            
+
             if status == 'SUCCEEDED':
                 tables_created = last_crawl.get('TablesCreated', 0)
                 tables_updated = last_crawl.get('TablesUpdated', 0)
                 print(f"  Tables created: {tables_created}, updated: {tables_updated}")
-                return True
+                return 'SUCCEEDED', ''
             elif status == 'FAILED':
                 error = last_crawl.get('ErrorMessage', 'Unknown error')
                 print(f"  Error: {error}")
-                raise Exception(f"Crawler failed: {error}")
-            return True
-        
+                return 'FAILED', error
+            return 'SUCCEEDED', ''
+
         print(f"  Crawler state: {state}")
         time.sleep(15)
-    
-    raise Exception(f"Crawler timed out after {timeout}s")
+
+    return 'TIMEOUT', f"Crawler timed out after {timeout}s"
+
+
+def run_crawler_with_retry(crawler_name, attempts=4):
+    """Start + wait for the crawler, retrying on transient Glue InternalServiceException.
+
+    A Glue crawler against a JDBC (Aurora) target intermittently fails the RUN with
+    'Internal Service Exception' — especially right after creation. The run itself
+    (not start_crawler) reports FAILED, so retry the whole start+wait cycle."""
+    for attempt in range(attempts):
+        start_crawler(crawler_name)
+        status, error = wait_for_crawler(crawler_name)
+        if status == 'SUCCEEDED':
+            return True
+        transient = 'Internal Service Exception' in error or status == 'TIMEOUT'
+        if transient and attempt < attempts - 1:
+            print(f"  Crawler {status} ({error[:120]}) — retry {attempt + 1}/{attempts - 1} in 20s")
+            time.sleep(20)
+            continue
+        raise Exception(f"Crawler failed: {error}")
+    raise Exception("Crawler did not succeed after retries")
 
 
 def send_cfn_response(event, context, status, data=None, reason=None):
@@ -159,11 +179,11 @@ def lambda_handler(event, context):
             crawler_name = event.get('CrawlerName') or os.environ.get('CRAWLER_NAME')
             wait_for_completion = event.get('WaitForCompletion', True)
         
-        start_crawler(crawler_name)
-        
         if wait_for_completion:
-            wait_for_crawler(crawler_name)
-        
+            run_crawler_with_retry(crawler_name)
+        else:
+            start_crawler(crawler_name)
+
         if is_cfn:
             send_cfn_response(event, context, 'SUCCESS', {'CrawlerTriggered': 'true'})
         

--- a/agentic-workloads/agentic-analytics/infrastructure/stacks/bedrock-kb-stack.yaml
+++ b/agentic-workloads/agentic-analytics/infrastructure/stacks/bedrock-kb-stack.yaml
@@ -48,7 +48,11 @@ Resources:
     Type: AWS::S3::Bucket
     DeletionPolicy: Delete
     Properties:
-      BucketName: !Sub ${EnvironmentName}-kb-docs-${AWS::AccountId}
+      # Region in the name avoids S3 global-endpoint stale-region-cache 301s when the
+      # same account previously held this bucket name in another region (e.g. a prior
+      # demo in us-west-2). Bedrock ingestion uses the global endpoint and won't follow
+      # the 301, so a region-distinct name is required for reliable multi-region reuse.
+      BucketName: !Sub ${EnvironmentName}-kb-docs-${AWS::AccountId}-${AWS::Region}
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true
@@ -180,7 +184,12 @@ Resources:
                   send(event, context, 'SUCCESS')
                   return
               try:
-                  s3 = boto3.client('s3')
+                  import os
+                  # Pin to the regional endpoint with path addressing: a just-created bucket
+                  # isn't consistently resolvable on the us-east-1 global endpoint yet, so a
+                  # default client gets PermanentRedirect on CopyObject. (us-east-1 fresh-deploy race.)
+                  s3 = boto3.client('s3', region_name=os.environ['AWS_REGION'],
+                                    config=boto3.session.Config(s3={'addressing_style': 'path'}))
                   p = event['ResourceProperties']
                   s3.copy_object(CopySource={'Bucket': p['SrcBucket'], 'Key': p['SrcKey']}, Bucket=p['DstBucket'], Key=p['DstKey'])
                   send(event, context, 'SUCCESS', {'DstBucket': p['DstBucket'], 'DstKey': p['DstKey']})
@@ -248,6 +257,9 @@ Resources:
                 Action:
                   - s3:GetObject
                   - s3:ListBucket
+                  # Required so the S3 client can resolve the bucket region; without it,
+                  # us-east-1 ingestion gets 301 PermanentRedirect on the global endpoint.
+                  - s3:GetBucketLocation
                 Resource:
                   - !Sub arn:aws:s3:::${ArtifactsBucket}/*
                   - !Sub arn:aws:s3:::${KBDocsBucket}

--- a/agentic-workloads/agentic-analytics/infrastructure/stacks/glue-stack.yaml
+++ b/agentic-workloads/agentic-analytics/infrastructure/stacks/glue-stack.yaml
@@ -331,7 +331,12 @@ Resources:
                   send(event, context, 'SUCCESS')
                   return
               try:
-                  s3 = boto3.client('s3')
+                  import os
+                  # Pin to the regional endpoint with path addressing: a just-created bucket
+                  # isn't consistently resolvable on the us-east-1 global endpoint yet, so a
+                  # default client gets PermanentRedirect on CopyObject. (us-east-1 fresh-deploy race.)
+                  s3 = boto3.client('s3', region_name=os.environ['AWS_REGION'],
+                                    config=boto3.session.Config(s3={'addressing_style': 'path'}))
                   p = event['ResourceProperties']
                   s3.copy_object(CopySource={'Bucket': p['SrcBucket'], 'Key': p['SrcKey']}, Bucket=p['DstBucket'], Key=p['DstKey'])
                   send(event, context, 'SUCCESS', {'DriverUri': f"s3://{p['DstBucket']}/{p['DstKey']}"})


### PR DESCRIPTION

Surfaced deploying a fresh demo to a clean us-east-1 account. All four affect the base stacks that run in BOTH workshop and demo mode, so they fix workshop events too (events deploy to us-east-1).

1. KB docs bucket name is now region-distinct (${AWS::Region} suffix). The bare ${EnvironmentName}-kb-docs-${AccountId} name, if the same account previously held it in another region, leaves a stale region mapping on the S3 global endpoint — Bedrock ingestion uses that endpoint, won't follow the 301, and every ingestion fails with PermanentRedirect. (root-caused; the decisive fix.)

2. Glue driver-copy + KB docs-copy custom resources: pin the boto3 S3 client to the regional endpoint with path addressing. A freshly-created bucket isn't consistently resolvable on the us-east-1 global endpoint yet → CopyObject 301.

3. Bedrock KB ingestion role: add s3:GetBucketLocation so the client can resolve the bucket region instead of falling back to the global endpoint.

4. Retry loops for two transient service errors that previously failed the whole deploy: Glue crawler 'Internal Service Exception' (run-level retry) and the KB ingestion job's S3 endpoint-propagation race (outer job retry).
