### PR TITLE
[Fix] Agentic Analytics: Rename workshop title

### DIFF
--- a/agentic-workloads/agentic-analytics/README.md
+++ b/agentic-workloads/agentic-analytics/README.md
@@ -1,4 +1,4 @@
-# Agentic Analytics: Self-Service Analytics with Agentic AI on AWS
+# Agentic Analytics for Multi-tenant SaaS with AgentCore
 
 A reference implementation and [AWS Workshop Studio](https://workshops.aws/) deployable for building AI-powered self-service analytics on multi-tenant SaaS. Business users ask questions in plain English — by **text or by voice** — the AI agent selects the right query, enforces security policies, and returns formatted insights, including **generated charts**.
 

--- a/agentic-workloads/agentic-analytics/workshop/content/index.en.md
+++ b/agentic-workloads/agentic-analytics/workshop/content/index.en.md
@@ -1,5 +1,5 @@
 ---
-title: "Self-Service Analytics with Agentic AI on AWS"
+title: "Agentic Analytics for Multi-tenant SaaS with AgentCore"
 weight: 0
 ---
 


### PR DESCRIPTION
Renamed workshop title for agentic analytics workshop