### PR TITLE
Add Bedrock AgentCore + Temporal DAG multi-agent sample

### DIFF
--- a/agentic-workloads/bedrock-agentcore-temporal-dag/README.md
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/README.md
@@ -1,0 +1,196 @@
+# Declarative Agent Flow (DAF)
+
+> **日本語版は[こちら](docs/README_ja.md)**
+
+A sample architecture for executing multi-agent DAG workflows using independently deployed AgentCore Runtimes, orchestrated by Temporal Cloud.
+
+## Overview
+
+DAF composes multiple AI Agents as a directed acyclic graph (DAG), executing them sequentially or in parallel based on dependency order. Each Agent runs independently on AgentCore Runtime and communicates via the A2A protocol. The Orchestrator is a thin, deterministic runner — it interprets the flow definition and executes the DAG without using an LLM.
+
+## Architecture
+
+<p align="center">
+
+```mermaid
+graph TB
+    Client["Client (demo.py)"]
+
+    subgraph TC["Temporal Cloud"]
+        direction TB
+        TS[Workflow State / Retry / Timeout]
+        TQ[Query API / Visibility API]
+    end
+
+    subgraph AWS["AWS Account"]
+        direction TB
+
+        subgraph ECS["ECS Fargate (ARM64)"]
+            Worker["Temporal Worker<br/>(Orchestrator)"]
+        end
+
+        subgraph Support["Support Services"]
+            direction TB
+            SSM["SSM Parameter Store"]
+            SM["Secrets Manager"]
+        end
+
+        subgraph AC["AgentCore Runtimes"]
+            direction TB
+            Gather["Gather Agent"]
+            Analyze["Analyze Agent"]
+            Evaluate["Evaluate Agent"]
+            Synthesize["Synthesize Agent"]
+        end
+
+        Bedrock["Amazon Bedrock<br/>(Claude Sonnet)"]
+    end
+
+    Client -->|SDK gRPC| TC
+    TC <-->|gRPC mTLS| Worker
+    Worker -->|GetParameter| SSM
+    Worker -->|GetSecretValue| SM
+    Worker -->|A2A SigV4| Gather
+    Worker -->|A2A SigV4| Analyze
+    Worker -->|A2A SigV4| Evaluate
+    Worker -->|A2A SigV4| Synthesize
+    Gather --> Bedrock
+    Analyze --> Bedrock
+    Evaluate --> Bedrock
+    Synthesize --> Bedrock
+```
+
+</p>
+
+## DAG Flow
+
+<p align="center">
+
+```mermaid
+graph TB
+    START((Start))
+    gather[Gather]
+    analyze[Analyze]
+    evaluate[Evaluate]
+    check{score < 0.7?}
+    re_analyze[Re-Analyze]
+    synthesize[Synthesize]
+    END((End))
+
+    START --> gather
+    gather --> analyze
+    gather --> evaluate
+    analyze --> check
+    evaluate --> check
+    check -->|Yes| re_analyze
+    check -->|No| synthesize
+    re_analyze --> synthesize
+    synthesize --> END
+```
+
+</p>
+
+- **Gather**: Information retrieval (web search, content extraction)
+- **Analyze / Evaluate**: Fan-out — run analysis and quality evaluation in parallel
+- **Conditional**: Re-analyze only if the evaluation score is below 0.7
+- **Synthesize**: Fan-in — merge analysis and evaluation results into final output
+
+## Key Design Decisions
+
+- **Deterministic orchestration**: The Orchestrator does not use an LLM. Branching, retries, and fan-out/fan-in are handled deterministically
+- **Independent scaling**: Each Agent is deployed as a separate AgentCore Runtime and scales independently
+- **A2A protocol**: Agents communicate via JSON-RPC 2.0 with SigV4 authentication
+- **Temporal-managed reliability**: Retry, idempotency, and timeout logic are delegated to Temporal Cloud — no custom implementation required
+
+## Differentiation
+
+All existing public samples use either "LLM-based dynamic routing" or "all Agents co-located in one container." DAF fills the gap: **deterministic DAG execution × independently scalable Agents**.
+
+| Existing Sample | Approach | DAF Difference |
+|---|---|---|
+| agentcore-samples (multi-runtimes-with-boto3) | LLM decides routing (Supervisor) | Deterministic DAG, no LLM |
+| temporal-community/amazon-bedrock-temporal-samples | All Agents in one container | Each Agent scales independently |
+| sample-strands-agent-with-agentcore | A2A but LLM-dependent routing | Declarative flow definition |
+
+## Use Cases
+
+- Research pipelines (gather → analyze → evaluate → synthesize)
+- Document processing (extract → classify → summarize → review)
+- Code generation workflows (requirements → implement → test → review)
+- Data quality checks (validate → detect anomalies → suggest fixes)
+
+## Cost
+
+- Temporal variant: ~$150/month + Bedrock usage
+- YAML variant (lightweight PoC): ~$30/month + Bedrock usage
+
+## Prerequisites for Deployment
+
+Before deploying, update the following files with your own values:
+
+| File | Field | Description |
+|---|---|---|
+| `cdk/cdk.json` | `context.region` | Your AWS region (e.g. `us-west-2`) |
+| `cdk/cdk.json` | `context.temporal_address` | Your Temporal Cloud gRPC endpoint |
+| `cdk/cdk.json` | `context.temporal_namespace` | Your Temporal Cloud namespace |
+| Environment variable | `TEMPORAL_API_KEY` | Temporal Cloud API key (store in Secrets Manager for production) |
+
+## Quick Start
+
+```bash
+# Start Agents locally
+cd agents && source .venv/bin/activate
+PORT=9001 python -m gather.main &
+PORT=9002 python -m analyze.main &
+PORT=9003 python -m evaluate.main &
+PORT=9004 python -m synthesize.main &
+
+# Start Worker
+cd workflow && source .venv/bin/activate
+export TEMPORAL_ADDRESS="<namespace>.tmprl.cloud:7233"
+export TEMPORAL_NAMESPACE="<namespace>"
+export TEMPORAL_API_KEY="<your-api-key>"
+export AGENT_ENDPOINTS='{"gather":"http://localhost:9001","analyze":"http://localhost:9002","evaluate":"http://localhost:9003","synthesize":"http://localhost:9004"}'
+python main.py
+
+# Run demo
+python demo.py "Investigate multi-agent design patterns for generative AI"
+```
+
+## Repository Structure
+
+```
+workflow/                       — Temporal Worker (Orchestrator)
+  main.py                      — Worker entrypoint
+  demo.py                      — Demo CLI with progress display
+  flows/                       — Workflow definitions (DAG flows)
+    research_pipeline.py       — Research pipeline DAG
+  activities.py                — Activity definitions (Agent invocation)
+  a2a_client.py                — A2A communication layer (local/AWS)
+
+agents/                        — Individual Agents (AgentCore Runtime)
+  gather/main.py
+  analyze/main.py
+  evaluate/main.py
+  synthesize/main.py
+
+cdk/                           — CDK infrastructure
+  stacks/
+
+docs/                          — Documentation
+  variant-a-temporal.md        — Temporal variant: architecture + code
+  variant-b-yaml.md            — YAML variant: architecture + code
+  specs-temporal.md            — Temporal variant: deploy, IAM, networking
+  specs-yaml.md                — YAML variant: deploy, IAM, networking
+  code-walkthrough.md          — Code walkthrough
+```
+
+## Documentation
+
+- [Temporal Variant](docs/variant-a-temporal.md) — Production-ready with Temporal Cloud
+- [YAML Variant](docs/variant-b-yaml.md) — Lightweight, no external dependencies
+- [Code Walkthrough](docs/code-walkthrough.md) — Detailed code explanation
+
+## License
+
+MIT

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/README.md
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/README.md
@@ -188,7 +188,8 @@ docs/                          — Documentation
 ## Documentation
 
 - [Temporal Variant](docs/variant-a-temporal.md) — Production-ready with Temporal Cloud
-- [YAML Variant](docs/variant-b-yaml.md) — Lightweight, no external dependencies
+- [YAML Variant (EN)](docs/variant-b-yaml.en.md) — Lightweight, no external dependencies
+- [YAML Variant (JA)](docs/variant-b-yaml.md) — 軽量版（日本語）
 - [Code Walkthrough](docs/code-walkthrough.md) — Detailed code explanation
 
 ## License

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/agents/Dockerfile
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/agents/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM public.ecr.aws/docker/library/python:3.11-slim
 
 WORKDIR /app
 

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/agents/Dockerfile
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/agents/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY pyproject.toml .
+RUN pip install --no-cache-dir .
+
+ARG AGENT_NAME
+COPY ${AGENT_NAME}/ ./agent/
+
+CMD ["python", "agent/main.py"]

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/agents/analyze/main.py
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/agents/analyze/main.py
@@ -1,0 +1,58 @@
+import json
+import os
+
+from strands import Agent, tool
+from strands.models import BedrockModel
+from strands.multiagent.a2a import A2AServer
+from fastapi import FastAPI
+import uvicorn
+
+
+@tool
+def classify_topic(text: str) -> str:
+    """Classify the topics in the given text."""
+    # Demo stub
+    return json.dumps({"topics": ["technology", "architecture"], "confidence": 0.92})
+
+
+@tool
+def extract_key_points(text: str) -> str:
+    """Extract key points from the given text."""
+    # Demo stub
+    return json.dumps({"key_points": [f"Point extracted from: {text[:50]}..."]})
+
+
+_model = BedrockModel(
+    model_id=os.environ.get("MODEL_ID", "us.anthropic.claude-sonnet-4-6"),
+    region_name=os.environ.get("AWS_REGION", "us-east-1"),
+)
+
+agent = Agent(
+    model=_model,
+    system_prompt=(
+        "You are an expert analyst. Analyze the given information, "
+        "performing topic classification, key point extraction, and pattern identification. "
+        "Output JSON with an 'analysis' key for results and a 'confidence' key for score (0-1)."
+    ),
+    tools=[classify_topic, extract_key_points],
+    name="Analyze Agent",
+    description="Agent that analyzes information and extracts patterns and key points",
+)
+
+_port = os.environ.get("PORT", "9000")
+runtime_url = os.environ.get("AGENTCORE_RUNTIME_URL", f"http://127.0.0.1:{_port}/")
+a2a_server = A2AServer(agent=agent, http_url=runtime_url, serve_at_root=True)
+
+app = FastAPI()
+
+
+@app.get("/ping")
+def ping():
+    return {"status": "healthy"}
+
+
+app.mount("/", a2a_server.to_fastapi_app())
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", "9000"))
+    uvicorn.run(app, host="0.0.0.0", port=port)

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/agents/evaluate/main.py
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/agents/evaluate/main.py
@@ -1,0 +1,58 @@
+import json
+import os
+
+from strands import Agent, tool
+from strands.models import BedrockModel
+from strands.multiagent.a2a import A2AServer
+from fastapi import FastAPI
+import uvicorn
+
+
+@tool
+def score_quality(text: str, criteria: str) -> str:
+    """Score the quality of the given text against the specified criteria."""
+    # Demo stub
+    return json.dumps({"score": 0.75, "criteria": criteria, "rationale": "Meets most criteria"})
+
+
+@tool
+def detect_gaps(analysis: str) -> str:
+    """Detect gaps and missing elements in the analysis result."""
+    # Demo stub
+    return json.dumps({"gaps": ["Missing recent data", "No competitor comparison"], "severity": "medium"})
+
+
+_model = BedrockModel(
+    model_id=os.environ.get("MODEL_ID", "us.anthropic.claude-sonnet-4-6"),
+    region_name=os.environ.get("AWS_REGION", "us-east-1"),
+)
+
+agent = Agent(
+    model=_model,
+    system_prompt=(
+        "You are an expert quality evaluator. Evaluate the given analysis result "
+        "and provide a quality score along with actionable feedback for improvement. "
+        "Output JSON with a 'score' key (0-1) and a 'feedback' key listing improvements."
+    ),
+    tools=[score_quality, detect_gaps],
+    name="Evaluate Agent",
+    description="Agent that evaluates analysis quality and provides feedback",
+)
+
+_port = os.environ.get("PORT", "9000")
+runtime_url = os.environ.get("AGENTCORE_RUNTIME_URL", f"http://127.0.0.1:{_port}/")
+a2a_server = A2AServer(agent=agent, http_url=runtime_url, serve_at_root=True)
+
+app = FastAPI()
+
+
+@app.get("/ping")
+def ping():
+    return {"status": "healthy"}
+
+
+app.mount("/", a2a_server.to_fastapi_app())
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", "9000"))
+    uvicorn.run(app, host="0.0.0.0", port=port)

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/agents/gather/main.py
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/agents/gather/main.py
@@ -1,0 +1,62 @@
+import json
+import os
+
+from strands import Agent, tool
+from strands.models import BedrockModel
+from strands.multiagent.a2a import A2AServer
+from fastapi import FastAPI
+import uvicorn
+
+
+@tool
+def web_search(query: str) -> str:
+    """Run a web search for the given query and return results."""
+    # Demo stub — replace with SerpAPI or similar in production
+    return json.dumps({
+        "results": [
+            {"title": f"Result for: {query}", "snippet": f"Sample search result about {query}"},
+        ]
+    })
+
+
+@tool
+def extract_content(url: str) -> str:
+    """Extract content from the given URL."""
+    # Demo stub
+    return json.dumps({"content": f"Extracted content from {url}", "length": 1500})
+
+
+_model = BedrockModel(
+    model_id=os.environ.get("MODEL_ID", "us.anthropic.claude-sonnet-4-6"),
+    region_name=os.environ.get("AWS_REGION", "us-east-1"),
+)
+
+agent = Agent(
+    model=_model,
+    system_prompt=(
+        "You are an expert information gatherer. For the given query, "
+        "perform web searches and content extraction, then return structured information. "
+        "Output JSON with a 'findings' key containing a list of results."
+    ),
+    tools=[web_search, extract_content],
+    name="Gather Agent",
+    description="Agent that collects and structures information",
+)
+
+_port = os.environ.get("PORT", "9000")
+runtime_url = os.environ.get("AGENTCORE_RUNTIME_URL", f"http://127.0.0.1:{_port}/")
+a2a_server = A2AServer(agent=agent, http_url=runtime_url, serve_at_root=True)
+
+app = FastAPI()
+
+
+@app.get("/ping")
+def ping():
+    return {"status": "healthy"}
+
+
+app.mount("/", a2a_server.to_fastapi_app())
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", "9000"))
+    uvicorn.run(app, host="0.0.0.0", port=port)

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/agents/pyproject.toml
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/agents/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "daf-agents"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "strands-agents[a2a]>=0.3.0",
+    "bedrock-agentcore>=1.2.0",
+    "fastapi>=0.115.0",
+    "uvicorn>=0.32.0",
+    "langfuse>=2.0.0",
+    "boto3>=1.35.0",
+]
+
+[tool.setuptools.packages.find]
+include = ["gather*", "analyze*", "evaluate*", "synthesize*"]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+]

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/agents/synthesize/main.py
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/agents/synthesize/main.py
@@ -1,0 +1,58 @@
+import json
+import os
+
+from strands import Agent, tool
+from strands.models import BedrockModel
+from strands.multiagent.a2a import A2AServer
+from fastapi import FastAPI
+import uvicorn
+
+
+@tool
+def merge_findings(sources: str) -> str:
+    """Merge results from multiple sources into a consolidated output."""
+    # Demo stub
+    return json.dumps({"merged": "Consolidated findings from all sources", "source_count": 3})
+
+
+@tool
+def generate_summary(content: str, max_length: int) -> str:
+    """Summarize the content within the specified character limit."""
+    # Demo stub
+    return json.dumps({"summary": content[:max_length], "original_length": len(content)})
+
+
+_model = BedrockModel(
+    model_id=os.environ.get("MODEL_ID", "us.anthropic.claude-sonnet-4-6"),
+    region_name=os.environ.get("AWS_REGION", "us-east-1"),
+)
+
+agent = Agent(
+    model=_model,
+    system_prompt=(
+        "You are an expert synthesizer. Merge multiple analysis results and evaluations "
+        "into a final report. "
+        "Output JSON with a 'summary' key for the consolidated result and a 'recommendations' key for action items."
+    ),
+    tools=[merge_findings, generate_summary],
+    name="Synthesize Agent",
+    description="Agent that merges multiple analysis results into a final report",
+)
+
+_port = os.environ.get("PORT", "9000")
+runtime_url = os.environ.get("AGENTCORE_RUNTIME_URL", f"http://127.0.0.1:{_port}/")
+a2a_server = A2AServer(agent=agent, http_url=runtime_url, serve_at_root=True)
+
+app = FastAPI()
+
+
+@app.get("/ping")
+def ping():
+    return {"status": "healthy"}
+
+
+app.mount("/", a2a_server.to_fastapi_app())
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", "9000"))
+    uvicorn.run(app, host="0.0.0.0", port=port)

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/cdk/app.py
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/cdk/app.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+import aws_cdk as cdk
+
+from stacks.network_stack import NetworkStack
+from stacks.agents_stack import AgentsStack
+from stacks.orchestrator_stack import OrchestratorStack
+
+app = cdk.App()
+
+env = cdk.Environment(
+    account=app.node.try_get_context("account"),
+    region=app.node.try_get_context("region") or "us-east-1",
+)
+
+network = NetworkStack(app, "DafNetwork", env=env)
+
+agents = AgentsStack(app, "DafAgents", env=env)
+
+orchestrator = OrchestratorStack(
+    app, "DafOrchestrator",
+    vpc=network.vpc,
+    env=env,
+)
+orchestrator.add_dependency(network)
+orchestrator.add_dependency(agents)
+
+app.synth()

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/cdk/cdk.json
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/cdk/cdk.json
@@ -1,0 +1,8 @@
+{
+  "app": ".venv/bin/python3 app.py",
+  "context": {
+    "region": "<YOUR_REGION>",
+    "temporal_address": "<YOUR_NAMESPACE>.tmprl.cloud:7233",
+    "temporal_namespace": "<YOUR_NAMESPACE>"
+  }
+}

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/cdk/requirements.txt
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/cdk/requirements.txt
@@ -1,0 +1,2 @@
+aws-cdk-lib>=2.170.0
+constructs>=10.0.0

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/cdk/stacks/agents_stack.py
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/cdk/stacks/agents_stack.py
@@ -1,0 +1,74 @@
+from aws_cdk import (
+    Stack,
+    RemovalPolicy,
+    aws_ecr as ecr,
+    aws_ssm as ssm,
+    aws_iam as iam,
+    CfnOutput,
+)
+from constructs import Construct
+
+
+AGENT_NAMES = ["gather", "analyze", "evaluate", "synthesize"]
+
+
+class AgentsStack(Stack):
+    """Creates ECR repositories and SSM parameters for AgentCore Runtimes.
+
+    AgentCore Runtime itself has no CDK L2 support, so it must be deployed
+    separately via CfnRuntime (L1) or the bedrock-agentcore-starter-toolkit.
+    This stack provisions the prerequisite resources for that deployment.
+    """
+
+    def __init__(self, scope: Construct, construct_id: str, **kwargs):
+        super().__init__(scope, construct_id, **kwargs)
+
+        self.repositories: dict[str, ecr.Repository] = {}
+
+        for name in AGENT_NAMES:
+            repo = ecr.Repository(
+                self, f"Repo-{name}",
+                repository_name=f"daf-agent-{name}",
+                removal_policy=RemovalPolicy.DESTROY,
+                empty_on_delete=True,
+            )
+            self.repositories[name] = repo
+
+            # Placeholder — update with the actual ARN after AgentCore deployment
+            ssm.StringParameter(
+                self, f"Param-{name}",
+                parameter_name=f"/agents/{name}/arn",
+                string_value=f"arn:aws:bedrock-agentcore:{self.region}:{self.account}:runtime/PLACEHOLDER-{name}",
+                description=f"AgentCore Runtime ARN for {name} agent",
+            )
+
+        # IAM role for Worker Agents (AgentCore Execution Role)
+        self.agent_role = iam.Role(
+            self, "AgentExecutionRole",
+            assumed_by=iam.ServicePrincipal("bedrock-agentcore.amazonaws.com"),
+            description="Execution role for DAF Worker Agents",
+        )
+        self.agent_role.add_to_policy(iam.PolicyStatement(
+            actions=["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"],
+            resources=[
+                "arn:aws:bedrock:*::foundation-model/*",
+                f"arn:aws:bedrock:{self.region}:{self.account}:inference-profile/*",
+                "arn:aws:bedrock:*:*:inference-profile/*",
+            ],
+        ))
+        self.agent_role.add_to_policy(iam.PolicyStatement(
+            actions=[
+                "ecr:GetAuthorizationToken",
+            ],
+            resources=["*"],
+        ))
+        self.agent_role.add_to_policy(iam.PolicyStatement(
+            actions=[
+                "ecr:BatchGetImage",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchCheckLayerAvailability",
+            ],
+            resources=[f"arn:aws:ecr:{self.region}:{self.account}:repository/daf-agent-*"],
+        ))
+
+        CfnOutput(self, "AgentRoleArn", value=self.agent_role.role_arn)

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/cdk/stacks/network_stack.py
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/cdk/stacks/network_stack.py
@@ -1,0 +1,25 @@
+from aws_cdk import Stack, aws_ec2 as ec2
+from constructs import Construct
+
+
+class NetworkStack(Stack):
+    def __init__(self, scope: Construct, construct_id: str, **kwargs):
+        super().__init__(scope, construct_id, **kwargs)
+
+        self.vpc = ec2.Vpc(
+            self, "DafVpc",
+            max_azs=2,
+            nat_gateways=1,
+            subnet_configuration=[
+                ec2.SubnetConfiguration(
+                    name="Public",
+                    subnet_type=ec2.SubnetType.PUBLIC,
+                    cidr_mask=24,
+                ),
+                ec2.SubnetConfiguration(
+                    name="Private",
+                    subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS,
+                    cidr_mask=24,
+                ),
+            ],
+        )

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/cdk/stacks/orchestrator_stack.py
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/cdk/stacks/orchestrator_stack.py
@@ -1,0 +1,116 @@
+from aws_cdk import (
+    Stack,
+    Duration,
+    RemovalPolicy,
+    aws_ec2 as ec2,
+    aws_ecs as ecs,
+    aws_ecr as ecr,
+    aws_iam as iam,
+    aws_secretsmanager as secretsmanager,
+    aws_logs as logs,
+    CfnOutput,
+)
+from constructs import Construct
+
+
+class OrchestratorStack(Stack):
+    def __init__(self, scope: Construct, construct_id: str, vpc: ec2.Vpc, **kwargs):
+        super().__init__(scope, construct_id, **kwargs)
+
+        temporal_address = self.node.try_get_context("temporal_address")
+        temporal_namespace = self.node.try_get_context("temporal_namespace")
+
+        # ECR repository
+        repo = ecr.Repository(
+            self, "OrchestratorRepo",
+            repository_name="daf-orchestrator",
+            removal_policy=RemovalPolicy.DESTROY,
+            empty_on_delete=True,
+        )
+
+        # Temporal API Key (store manually in Secrets Manager before deployment)
+        temporal_secret = secretsmanager.Secret.from_secret_name_v2(
+            self, "TemporalApiKey",
+            secret_name="daf/temporal-api-key",
+        )
+
+        # ECS Cluster
+        cluster = ecs.Cluster(
+            self, "Cluster",
+            vpc=vpc,
+            cluster_name="daf-orchestrator",
+        )
+
+        # Task Definition
+        task_def = ecs.FargateTaskDefinition(
+            self, "TaskDef",
+            cpu=256,
+            memory_limit_mib=512,
+            runtime_platform=ecs.RuntimePlatform(
+                cpu_architecture=ecs.CpuArchitecture.ARM64,
+                operating_system_family=ecs.OperatingSystemFamily.LINUX,
+            ),
+        )
+
+        # IAM: SSM + AgentCore + SecretsManager
+        task_def.task_role.add_to_policy(iam.PolicyStatement(
+            actions=["ssm:GetParameter"],
+            resources=[f"arn:aws:ssm:{self.region}:{self.account}:parameter/agents/*"],
+        ))
+        task_def.task_role.add_to_policy(iam.PolicyStatement(
+            actions=["bedrock-agentcore:InvokeAgentRuntime"],
+            resources=[f"arn:aws:bedrock-agentcore:{self.region}:{self.account}:runtime/*"],
+        ))
+        temporal_secret.grant_read(task_def.task_role)
+
+        # Container
+        container = task_def.add_container(
+            "Worker",
+            image=ecs.ContainerImage.from_ecr_repository(repo, tag="latest"),
+            logging=ecs.LogDrivers.aws_logs(
+                stream_prefix="daf-orchestrator",
+                log_retention=logs.RetentionDays.TWO_WEEKS,
+            ),
+            environment={
+                "TEMPORAL_ADDRESS": temporal_address,
+                "TEMPORAL_NAMESPACE": temporal_namespace,
+                "AWS_REGION": self.region,
+            },
+            secrets={
+                "TEMPORAL_API_KEY": ecs.Secret.from_secrets_manager(temporal_secret),
+            },
+            stop_timeout=Duration.seconds(120),
+        )
+
+        # Security Group: outbound only (Worker is poll-based, no inbound needed)
+        sg = ec2.SecurityGroup(
+            self, "WorkerSG",
+            vpc=vpc,
+            description="DAF Orchestrator - outbound only",
+            allow_all_outbound=True,
+        )
+
+        # ECS Service
+        service = ecs.FargateService(
+            self, "Service",
+            cluster=cluster,
+            task_definition=task_def,
+            desired_count=1,
+            security_groups=[sg],
+            vpc_subnets=ec2.SubnetSelection(subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS),
+            capacity_provider_strategies=[
+                ecs.CapacityProviderStrategy(
+                    capacity_provider="FARGATE_SPOT",
+                    weight=1,
+                ),
+                ecs.CapacityProviderStrategy(
+                    capacity_provider="FARGATE",
+                    weight=0,
+                    base=1,
+                ),
+            ],
+        )
+
+        CfnOutput(self, "ClusterArn", value=cluster.cluster_arn)
+        CfnOutput(self, "ServiceArn", value=service.service_arn)
+        CfnOutput(self, "RepositoryUri", value=repo.repository_uri)

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/docs/README_ja.md
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/docs/README_ja.md
@@ -1,0 +1,196 @@
+# Declarative Agent Flow (DAF)
+
+> **English version is [here](../README.md)**
+
+独立デプロイされた AgentCore Runtime を Temporal Cloud でオーケストレーションする、マルチエージェント DAG ワークフローのサンプルアーキテクチャです。
+
+## 概要
+
+複数の AI Agent を非巡回グラフ（DAG）として構成し、依存関係に従って順次・並列に実行します。各 Agent は AgentCore Runtime 上で独立稼働し、A2A プロトコルで通信します。Orchestrator は LLM を使用しない決定的な DAG ランナーです。
+
+## アーキテクチャ
+
+<p align="center">
+
+```mermaid
+graph TB
+    Client["Client (demo.py)"]
+
+    subgraph TC["Temporal Cloud"]
+        direction TB
+        TS[Workflow State / Retry / Timeout]
+        TQ[Query API / Visibility API]
+    end
+
+    subgraph AWS["AWS Account"]
+        direction TB
+
+        subgraph ECS["ECS Fargate (ARM64)"]
+            Worker["Temporal Worker<br/>(Orchestrator)"]
+        end
+
+        subgraph Support["Support Services"]
+            direction TB
+            SSM["SSM Parameter Store"]
+            SM["Secrets Manager"]
+        end
+
+        subgraph AC["AgentCore Runtimes"]
+            direction TB
+            Gather["Gather Agent"]
+            Analyze["Analyze Agent"]
+            Evaluate["Evaluate Agent"]
+            Synthesize["Synthesize Agent"]
+        end
+
+        Bedrock["Amazon Bedrock<br/>(Claude Sonnet)"]
+    end
+
+    Client -->|SDK gRPC| TC
+    TC <-->|gRPC mTLS| Worker
+    Worker -->|GetParameter| SSM
+    Worker -->|GetSecretValue| SM
+    Worker -->|A2A SigV4| Gather
+    Worker -->|A2A SigV4| Analyze
+    Worker -->|A2A SigV4| Evaluate
+    Worker -->|A2A SigV4| Synthesize
+    Gather --> Bedrock
+    Analyze --> Bedrock
+    Evaluate --> Bedrock
+    Synthesize --> Bedrock
+```
+
+</p>
+
+## DAG フロー
+
+<p align="center">
+
+```mermaid
+graph TB
+    START((Start))
+    gather[Gather]
+    analyze[Analyze]
+    evaluate[Evaluate]
+    check{score < 0.7?}
+    re_analyze[Re-Analyze]
+    synthesize[Synthesize]
+    END((End))
+
+    START --> gather
+    gather --> analyze
+    gather --> evaluate
+    analyze --> check
+    evaluate --> check
+    check -->|Yes| re_analyze
+    check -->|No| synthesize
+    re_analyze --> synthesize
+    synthesize --> END
+```
+
+</p>
+
+- **Gather**: 情報収集（Web検索、コンテンツ抽出）
+- **Analyze / Evaluate**: fan-out で並列実行。分析と品質評価を同時に行う
+- **条件分岐**: evaluate のスコアが 0.7 未満の場合のみ Re-Analyze を実行
+- **Synthesize**: fan-in。分析結果と評価結果を統合して最終出力を生成
+
+## 設計方針
+
+- **決定的オーケストレーション**: Orchestrator は LLM を使わない。分岐・リトライ・fan-out/fan-in は全て決定的に処理
+- **独立スケール**: 各 Agent は個別の AgentCore Runtime としてデプロイされ、独立にスケール
+- **A2A プロトコル**: JSON-RPC 2.0 + SigV4 認証で Agent 間通信
+- **Temporal による信頼性**: リトライ・冪等性・タイムアウトは Temporal Cloud に委譲。自前実装不要
+
+## 既存サンプルとの差別化
+
+既存の公開サンプルは全て「LLM が動的にルーティング」か「全 Agent が1コンテナに同居」する構成です。DAF は **決定的 DAG 実行 × 独立スケール Agent** のパターンを埋めます。
+
+| 既存サンプル | アプローチ | DAF との違い |
+|---|---|---|
+| agentcore-samples (multi-runtimes-with-boto3) | LLM がルーティング判断 (Supervisor型) | 決定的 DAG 実行、LLM 不使用 |
+| temporal-community/amazon-bedrock-temporal-samples | Agent が1コンテナに同居 | 各 Agent が独立スケール |
+| sample-strands-agent-with-agentcore | A2A 使用だが LLM 依存の動的ルーティング | 宣言的フロー定義 |
+
+## ユースケース
+
+- リサーチパイプライン（情報収集 → 分析 → 評価 → 統合）
+- ドキュメント処理（抽出 → 分類 → 要約 → レビュー）
+- コード生成ワークフロー（要件分析 → 実装 → テスト → レビュー）
+- データ品質チェック（バリデーション → 異常検知 → 修正提案）
+
+## コスト
+
+- Temporal版: 約 $150/月 + Bedrock 従量課金
+- YAML版（PoC向け軽量版）: 約 $30/月 + Bedrock 従量課金
+
+## デプロイ前の設定
+
+デプロイ時は以下のファイルを自身の環境に合わせて更新してください:
+
+| ファイル | フィールド | 説明 |
+|---|---|---|
+| `cdk/cdk.json` | `context.region` | AWS リージョン（例: `us-west-2`） |
+| `cdk/cdk.json` | `context.temporal_address` | Temporal Cloud の gRPC エンドポイント |
+| `cdk/cdk.json` | `context.temporal_namespace` | Temporal Cloud の namespace |
+| 環境変数 | `TEMPORAL_API_KEY` | Temporal Cloud API キー（本番では Secrets Manager に格納） |
+
+## クイックスタート
+
+```bash
+# Agent 起動
+cd agents && source .venv/bin/activate
+PORT=9001 python -m gather.main &
+PORT=9002 python -m analyze.main &
+PORT=9003 python -m evaluate.main &
+PORT=9004 python -m synthesize.main &
+
+# Worker 起動
+cd workflow && source .venv/bin/activate
+export TEMPORAL_ADDRESS="<namespace>.tmprl.cloud:7233"
+export TEMPORAL_NAMESPACE="<namespace>"
+export TEMPORAL_API_KEY="<your-api-key>"
+export AGENT_ENDPOINTS='{"gather":"http://localhost:9001","analyze":"http://localhost:9002","evaluate":"http://localhost:9003","synthesize":"http://localhost:9004"}'
+python main.py
+
+# デモ実行
+python demo.py "生成AIエージェントのマルチエージェント設計パターンを調査してください"
+```
+
+## リポジトリ構成
+
+```
+workflow/                       — Temporal Worker (Orchestrator)
+  main.py                      — Worker 起動
+  demo.py                      — デモ CLI（進捗表示付き）
+  flows/                       — Workflow 定義（DAG フロー）
+    research_pipeline.py       — リサーチパイプライン DAG
+  activities.py                — Activity 定義（Agent 呼び出し）
+  a2a_client.py                — A2A 通信層（ローカル/AWS 両対応）
+
+agents/                        — 各 Agent（AgentCore Runtime 上で独立稼働）
+  gather/main.py
+  analyze/main.py
+  evaluate/main.py
+  synthesize/main.py
+
+cdk/                           — CDK インフラ定義
+  stacks/
+
+docs/                          — ドキュメント
+  variant-a-temporal.md        — Temporal版: アーキテクチャ + 実装コード
+  variant-b-yaml.md            — YAML版: アーキテクチャ + 実装コード
+  specs-temporal.md            — Temporal版: デプロイ、IAM、NW
+  specs-yaml.md                — YAML版: デプロイ、IAM、NW
+  code-walkthrough.md          — コード解説
+```
+
+## ドキュメント
+
+- [Temporal版](variant-a-temporal.md) — 本番向け構成
+- [YAML版](variant-b-yaml.md) — 検証・PoC向け構成
+- [コード解説](code-walkthrough.md) — 実装の詳細
+
+## License
+
+MIT

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/docs/code-walkthrough.md
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/docs/code-walkthrough.md
@@ -1,0 +1,160 @@
+# Code Walkthrough
+
+## Repository Structure
+
+```
+workflow/              Temporal Worker (DAG execution engine)
+  main.py             Worker entrypoint
+  demo.py             Demo CLI with live progress display
+  flows/              Workflow definitions (DAG flows)
+  activities.py       Activity definitions (Agent invocation units)
+  a2a_client.py       A2A protocol communication layer
+
+agents/               Individual Agents (each runs on AgentCore Runtime)
+  gather/main.py      Information gathering Agent
+  analyze/main.py     Analysis Agent
+  evaluate/main.py    Evaluation Agent
+  synthesize/main.py  Synthesis Agent
+
+cdk/                  CDK infrastructure definitions
+```
+
+## Orchestrator
+
+### main.py — Worker entrypoint
+
+```python
+worker = Worker(
+    client,
+    task_queue="daf-orchestrator",
+    workflows=[ResearchPipelineWorkflow],
+    activities=[invoke_agent],
+)
+await worker.run()
+```
+
+The Temporal Worker uses a poll-based model. It connects to Temporal Cloud and pulls tasks from the `daf-orchestrator` queue. No inbound ports are required — only outbound traffic is needed, making it a natural fit for ECS Fargate.
+
+### flows/research_pipeline.py — DAG flow definition
+
+This file is the core of the system. The DAG is expressed directly as Python code.
+
+```
+gather → [analyze, evaluate] → (conditional: re_analyze if score < 0.7) → synthesize
+```
+
+**Design highlights:**
+
+- `@workflow.defn` + `@workflow.run`: Registers the class as a Temporal Workflow. Temporal persists the execution state of this code.
+- `workflow.execute_activity("invoke_agent", args=[...])`: Invokes an Agent as an Activity. On failure, Temporal schedules retries automatically.
+- `asyncio.gather(...)`: Expresses fan-out. Runs analyze and evaluate in parallel.
+- `if score < 0.7`: Conditional branch. Re-analysis runs only when the evaluation score is below threshold.
+- `@workflow.query def get_status()`: Provides a query API to inspect workflow status while it is running.
+
+**RetryPolicy:**
+
+Each Activity has an explicit retry policy. `maximum_attempts=3, backoff_coefficient=2.0` means up to 3 retries with exponential backoff: 2s → 4s → 8s.
+
+### activities.py — Activity definitions
+
+```python
+@activity.defn
+async def invoke_agent(agent_name: str, input_data: dict) -> dict:
+    return await _invoke_agent(agent_name, input_data)
+```
+
+A thin wrapper. The `@activity.defn` decorator registers the function as a Temporal Activity. Actual communication is delegated to `a2a_client.py`.
+
+### a2a_client.py — A2A communication layer
+
+Handles all communication with Agents. Two execution paths exist: local mode and AWS mode.
+
+**Local mode** (when `AGENT_ENDPOINTS` env var is set):
+
+1. Reads Agent URLs from the environment variable (e.g. `{"gather":"http://localhost:9001",...}`)
+2. Resolves the Agent Card via a2a-sdk's `A2ACardResolver` → `ClientFactory`
+3. Sends an A2A protocol message via `SendMessageRequest`
+4. Extracts text from the task artifacts in the response
+
+**AWS mode** (default):
+
+1. **Service discovery**: Fetches the Agent ARN from SSM Parameter Store
+2. **URL construction**: Builds the AgentCore Runtime invoke URL from the ARN
+   - `https://bedrock-agentcore.{region}.amazonaws.com/runtimes/{URL_ENCODED_ARN}/invocations`
+3. **SigV4 signing**: Signs the request with AWS credentials (service: `bedrock-agentcore`)
+4. **JSON-RPC POST**: Sends the A2A protocol payload (JSON-RPC 2.0) directly
+5. **Response parsing**: Extracts text from artifacts or status message and returns it as JSON
+
+In AWS mode, the a2a-sdk's `A2ACardResolver` / `ClientFactory` are not used. AgentCore Runtime exposes only a single invoke endpoint and does not support `GET /.well-known/agent-card.json`.
+
+**SigV4HTTPXAuth class:**
+
+A custom httpx Auth implementation. Automatically attaches AWS SigV4 signatures to each request, signing as the `bedrock-agentcore` service and including the session ID header.
+
+**Caching:**
+
+`_arn_cache` caches SSM call results in process memory. Since the Worker is long-lived and calls the same Agents repeatedly, this reduces per-invocation latency.
+
+### demo.py — Demo CLI
+
+Submits a workflow to Temporal Cloud and polls the Query API to display live status in the terminal.
+
+```bash
+python demo.py "Investigate multi-agent design patterns for generative AI"
+```
+
+- Generates a Workflow ID and calls `start_workflow`
+- Calls `handle.query("get_status")` every 2 seconds and redraws the terminal progress
+- Displays the final result via `handle.result()` after completion
+
+## Agents
+
+### Agent structure (example: gather/main.py)
+
+```python
+_model = BedrockModel(
+    model_id=os.environ.get("MODEL_ID", "us.anthropic.claude-sonnet-4-6"),
+    region_name=os.environ.get("AWS_REGION", "us-east-1"),
+)
+
+agent = Agent(
+    model=_model,
+    system_prompt="...",
+    tools=[web_search, extract_content],
+)
+
+a2a_server = A2AServer(agent=agent, http_url=runtime_url, serve_at_root=True)
+app = FastAPI()
+app.get("/ping")(ping)
+app.mount("/", a2a_server.to_fastapi_app())
+```
+
+**Design highlights:**
+
+- `@tool` decorator: Defines tools for the LLM via the Strands SDK. Currently stub implementations — replace with SerpAPI or similar for production.
+- `A2AServer`: Strands SDK's A2A server. Exposes the Agent as an A2A-protocol-compatible endpoint.
+- `/ping`: Health check endpoint required by the AgentCore Runtime contract.
+- `PORT` env var: Allows each Agent to run on a different port for local development (default: 9000).
+- `MODEL_ID` env var: Makes the model configurable per deployment target.
+- `Dockerfile` `ARG AGENT_NAME`: A single Dockerfile builds all four Agent images using this build argument.
+
+## CDK Infrastructure
+
+### network_stack.py
+
+Creates a VPC: 2 AZs, 1 NAT Gateway, public and private subnets. The Orchestrator (ECS) runs in the private subnet and communicates externally via the NAT Gateway.
+
+### agents_stack.py
+
+- ECR Repository x4: Container image storage for each Agent
+- SSM Parameter x4: Service discovery for AgentCore Runtime ARNs (initial values are placeholders)
+- IAM Role (AgentCore Execution Role):
+  - Bedrock model invocation (`foundation-model` + `inference-profile`)
+  - ECR image pull (`GetAuthorizationToken`, `BatchGetImage`, `GetDownloadUrlForLayer`)
+
+### orchestrator_stack.py
+
+- ECS Cluster + Fargate Service: Execution environment for the Temporal Worker
+- Task Definition: 256 CPU / 512 MB RAM, ARM64. Temporal connection details injected via environment variables; API key retrieved from Secrets Manager.
+- Security Group: Outbound-only (no inbound ports needed — Worker is poll-based)
+- Capacity Provider: Fargate Spot preferred (`weight=1`), minimum 1 On-Demand task (`base=1`). Spot interruptions are safe because Temporal automatically reschedules in-progress tasks.

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/docs/deploy-guide.md
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/docs/deploy-guide.md
@@ -1,0 +1,184 @@
+# Deployment Guide (Temporal variant)
+
+## Prerequisites
+
+- AWS CLI v2 configured for the target account and region
+- Docker installed (ARM64 build support required)
+- Node.js 18+ & npm (for the CDK CLI)
+- Python 3.11+ & uv
+- Temporal Cloud account with a Namespace created
+- AWS CLI `bedrock-agentcore` extension (verify with `aws bedrock-agentcore help`)
+
+## 1. Temporal Cloud setup
+
+Create a Namespace in Temporal Cloud and issue an API Key.
+
+```bash
+# Store the Temporal API Key in Secrets Manager
+aws secretsmanager create-secret \
+  --name daf/temporal-api-key \
+  --secret-string "<your-temporal-api-key>" \
+  --region us-west-2
+```
+
+## 2. Deploy CDK infrastructure
+
+```bash
+cd cdk
+pip install -r requirements.txt
+
+# Install CDK CLI if not already installed
+npm install -g aws-cdk
+
+# Review and update cdk.json context values:
+# - region: target AWS region (e.g. us-west-2)
+# - temporal_address: Temporal Cloud gRPC endpoint
+# - temporal_namespace: Temporal Cloud Namespace name
+
+# Bootstrap (first time only)
+cdk bootstrap aws://<ACCOUNT_ID>/<REGION>
+
+# Deploy all 3 stacks
+cdk deploy --all -c account=<ACCOUNT_ID>
+```
+
+Deployed resources:
+- **DafNetwork**: VPC (2 AZs, 1 NAT Gateway, public/private subnets)
+- **DafAgents**: ECR Repository x4, SSM Parameter x4, Agent IAM Role
+- **DafOrchestrator**: ECS Cluster, Fargate Service (ARM64), Security Group
+
+## 3. Build and push Agent container images
+
+```bash
+cd agents
+
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+REGION=us-west-2
+
+# Log in to ECR
+aws ecr get-login-password --region ${REGION} | \
+  docker login --username AWS --password-stdin ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com
+
+# Build and push each Agent image (ARM64)
+for AGENT in gather analyze evaluate synthesize; do
+  docker build --platform linux/arm64 --build-arg AGENT_NAME=${AGENT} \
+    -t ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/daf-agent-${AGENT}:latest .
+  docker push ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/daf-agent-${AGENT}:latest
+done
+```
+
+## 4. Deploy AgentCore Runtimes
+
+AgentCore Runtime has no CDK L2 support, so it is created via the AWS CLI.
+
+```bash
+AGENT_ROLE_ARN=$(aws cloudformation describe-stacks \
+  --stack-name DafAgents --region ${REGION} \
+  --query "Stacks[0].Outputs[?OutputKey=='AgentRoleArn'].OutputValue" --output text)
+
+for AGENT in gather analyze evaluate synthesize; do
+  RUNTIME_ID=$(aws bedrock-agentcore create-agent-runtime \
+    --agent-runtime-name "daf_${AGENT}" \
+    --description "DAF ${AGENT} agent" \
+    --agent-runtime-artifact "{\"containerConfiguration\":{\"containerUri\":\"${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/daf-agent-${AGENT}:latest\"}}" \
+    --network-configuration '{"networkMode":"PUBLIC"}' \
+    --role-arn "${AGENT_ROLE_ARN}" \
+    --environment-variables '{"AWS_REGION":"'${REGION}'"}' \
+    --region ${REGION} \
+    --query 'agentRuntimeId' --output text)
+
+  echo "${AGENT}: ${RUNTIME_ID}"
+
+  # Store the ARN in SSM Parameter Store
+  aws ssm put-parameter \
+    --name "/agents/${AGENT}/arn" \
+    --value "arn:aws:bedrock-agentcore:${REGION}:${ACCOUNT_ID}:runtime/${RUNTIME_ID}" \
+    --type String \
+    --overwrite \
+    --region ${REGION}
+done
+```
+
+Wait for all Runtimes to reach ACTIVE status (takes a few minutes):
+
+```bash
+aws bedrock-agentcore get-agent-runtime \
+  --agent-runtime-id <RUNTIME_ID> \
+  --region ${REGION} \
+  --query 'status'
+```
+
+## 5. Build and push the Orchestrator container image
+
+```bash
+cd workflow
+
+docker build --platform linux/arm64 -t daf-orchestrator:latest .
+
+aws ecr get-login-password --region ${REGION} | \
+  docker login --username AWS --password-stdin ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com
+
+docker tag daf-orchestrator:latest \
+  ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/daf-orchestrator:latest
+docker push ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/daf-orchestrator:latest
+```
+
+## 6. Start the ECS Service
+
+```bash
+SERVICE_NAME=$(aws ecs list-services --cluster daf-orchestrator --region ${REGION} \
+  --query 'serviceArns[0]' --output text | xargs basename)
+
+aws ecs update-service \
+  --cluster daf-orchestrator \
+  --service ${SERVICE_NAME} \
+  --desired-count 1 \
+  --region ${REGION}
+```
+
+## 7. Run the demo
+
+```bash
+cd workflow
+uv run python demo.py "Investigate the latest trends in quantum computing"
+```
+
+Set the required environment variables beforehand:
+
+```bash
+export TEMPORAL_ADDRESS="<namespace>.tmprl.cloud:7233"
+export TEMPORAL_NAMESPACE="<namespace>"
+export TEMPORAL_API_KEY="<your-api-key>"
+```
+
+The demo CLI submits a workflow to Temporal Cloud and displays live progress:
+
+```
+============================================================
+  Research Pipeline
+  Query: Investigate the latest trends in quantum computing
+  Workflow ID: demo-a1b2c3d4
+============================================================
+
+DAG: gather → [analyze | evaluate] → (re_analyze?) → synthesize
+
+Progress:
+  ✅ gather: completed
+  ⏳ analyze: running
+  ⏳ evaluate: running
+  ⬜ re_analyze: pending
+  ⬜ synthesize: pending
+```
+
+You can also monitor execution in the Temporal UI at https://cloud.temporal.io.
+
+## Deployment order summary
+
+```
+1. Store Temporal API Key in Secrets Manager (manual)
+2. cdk deploy --all  (VPC → ECR/SSM → ECS)
+3. Build Agent images → push to ECR → create AgentCore Runtimes → update SSM
+4. Build Orchestrator image → push to ECR
+5. Start ECS Service (desired-count 1)
+6. Verify with demo.py
+```

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/docs/deploy-guide.md
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/docs/deploy-guide.md
@@ -71,6 +71,16 @@ done
 
 AgentCore Runtime has no CDK L2 support, so it is created via the AWS CLI.
 
+> **Note on network mode**: This sample uses `PUBLIC` mode for AgentCore Runtimes. Although
+> the CDK stack provisions private subnets, AgentCore Runtimes in `VPC` mode are only
+> reachable from within the attached VPC — the Orchestrator (ECS Fargate) invokes Agents
+> via the AgentCore control-plane endpoint (`bedrock-agentcore.<region>.amazonaws.com`),
+> which routes traffic externally. `PUBLIC` mode is therefore required for this
+> architecture. All agent endpoints remain IAM-authenticated (SigV4); there is no
+> unauthenticated network path. If your security requirements mandate VPC-only traffic,
+> consider co-locating the Orchestrator and Agents in the same VPC and switching to
+> direct HTTP invocation instead of the AgentCore control-plane route.
+
 ```bash
 AGENT_ROLE_ARN=$(aws cloudformation describe-stacks \
   --stack-name DafAgents --region ${REGION} \

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/docs/specs-temporal.md
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/docs/specs-temporal.md
@@ -1,0 +1,156 @@
+# Variant A: Temporal版 — インフラ仕様
+
+## リポジトリ構成
+
+```
+workflow/
+├── Dockerfile
+├── main.py                 # Temporal Worker起動
+├── demo.py                 # デモCLI（進捗表示付き）
+├── activities.py           # invoke_agent Activity
+├── a2a_client.py           # A2Aクライアント（ローカル/AWS両対応）
+└── flows/
+    └── research_pipeline.py
+
+agents/
+├── Dockerfile              # 共通Dockerfile (ARG AGENT_NAME)
+├── gather/
+│   └── main.py
+├── analyze/
+│   └── main.py
+├── evaluate/
+│   └── main.py
+└── synthesize/
+    └── main.py
+
+cdk/
+├── cdk.json
+├── app.py
+└── stacks/
+    ├── network_stack.py        # VPC
+    ├── agents_stack.py         # ECR + SSM + Agent IAM Role
+    └── orchestrator_stack.py   # ECS Fargate (ARM64) + IAM
+```
+
+## デプロイフロー
+
+```mermaid
+graph TD
+    CDK["cdk deploy --all"] --> ECR["1. ECR + イメージビルド (ARM64)"]
+    CDK --> TC["2. Temporal Cloud 設定"]
+    CDK --> ECS["3. ECS Fargate Service"]
+    CDK --> AC["4. AgentCore Runtimes"]
+
+    TC --> NS["Namespace作成"]
+    TC --> KEY["API Key → Secrets Manager"]
+
+    ECS --> TD["Task Definition (ARM64, 256CPU/512MB)"]
+    ECS --> ENV["Env: TEMPORAL_ADDRESS, NAMESPACE, AWS_REGION"]
+    ECS --> SEC["Secret: TEMPORAL_API_KEY"]
+    ECS --> STOP["stopTimeout: 120s"]
+    ECS --> IAM["IAM: SSM + AgentCore + SecretsManager"]
+
+    AC --> G["gather → SSM ARN"]
+    AC --> A["analyze → SSM ARN"]
+    AC --> E["evaluate → SSM ARN"]
+    AC --> S["synthesize → SSM ARN"]
+```
+
+## IAMポリシー
+
+### Orchestrator (ECS Task Role)
+
+```json
+{
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "ssm:GetParameter",
+      "Resource": "arn:aws:ssm:<REGION>:<ACCOUNT>:parameter/agents/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "bedrock-agentcore:InvokeAgentRuntime",
+      "Resource": "arn:aws:bedrock-agentcore:<REGION>:<ACCOUNT>:runtime/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "secretsmanager:GetSecretValue",
+      "Resource": "arn:aws:secretsmanager:<REGION>:<ACCOUNT>:secret:daf/temporal-*"
+    }
+  ]
+}
+```
+
+### Worker Agent (AgentCore Execution Role)
+
+```json
+{
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"],
+      "Resource": [
+        "arn:aws:bedrock:*::foundation-model/*",
+        "arn:aws:bedrock:<REGION>:<ACCOUNT>:inference-profile/*",
+        "arn:aws:bedrock:*:*:inference-profile/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "ecr:GetAuthorizationToken",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["ecr:BatchGetImage", "ecr:GetDownloadUrlForLayer", "ecr:BatchCheckLayerAvailability"],
+      "Resource": "arn:aws:ecr:<REGION>:<ACCOUNT>:repository/daf-agent-*"
+    }
+  ]
+}
+```
+
+## ネットワーク
+
+| 通信 | 経路 | プロトコル |
+|---|---|---|
+| ECS → Temporal Cloud | アウトバウンド | gRPC (port 7233) mTLS |
+| ECS → AgentCore | アウトバウンド | HTTPS (bedrock-agentcore endpoint) |
+| ECS → SSM / SecretsManager | アウトバウンド | HTTPS (AWS API) |
+| AgentCore → Bedrock | AWSマネージド | 内部 |
+| Client → Temporal Cloud | 直接 | SDK (gRPC) or UI (HTTPS) |
+
+- ECS Fargateはインバウンドポート不要（Temporal Workerはpoll型）
+- Security Groupはアウトバウンドのみ開放
+- VPCリソース（RDS等）へのアクセスが必要な場合のみVPC設定を追加
+
+## スケーリング
+
+| コンポーネント | 方式 | 上限 |
+|---|---|---|
+| Orchestrator (ECS) | ECS Auto Scaling (Temporal backlogメトリクス) | ECS Service上限 |
+| Worker Agent | AgentCore自動スケール | 1000 VM/アカウント (us-east-1, us-west-2) |
+| Temporal Cloud | マネージド | プランに応じた Actions/月 |
+| Bedrock | マネージド | モデル別クォータ |
+
+## ECS固有設定
+
+| 項目 | 値 | 理由 |
+|---|---|---|
+| CPU Architecture | ARM64 | コスト最適化 |
+| stopTimeout | 120s | グレースフルシャットダウン確保 |
+| WorkerStopTimeout (SDK) | 90s | stopTimeoutより短く |
+| Fargate Spot | 利用可 (weight=1, base=1) | 失敗ActivityはTemporalが再スケジュール |
+| CPU / Memory | 0.25 vCPU / 0.5 GB | デモ構成。ワークロードに応じて調整 |
+
+## コスト目安
+
+| コンポーネント | 月額 |
+|---|---|
+| Temporal Cloud (Essentials) | ~$100 |
+| ECS Fargate (0.25 vCPU, 常時1台) | ~$10 |
+| AgentCore Runtime | 従量課金 |
+| Bedrock | トークン従量 |
+| Langfuse (Self-hosted) | 無料 |
+| SSM Parameter Store | 無料 (Standard tier) |
+| Secrets Manager | ~$0.40/secret/月 |

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/docs/specs-yaml.md
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/docs/specs-yaml.md
@@ -1,0 +1,172 @@
+# Variant B: YAML版 — インフラ仕様
+
+## リポジトリ構成
+
+```
+orchestrator/
+├── Dockerfile
+├── main.py                 # BedrockAgentCoreApp entrypoint
+├── engine.py               # FlowEngine (DAG実行)
+├── dag.py                  # トポロジカルソート
+├── resolver.py             # JSONPath解決、condition評価
+├── retry.py                # リトライロジック
+├── a2a_client.py           # A2Aクライアント
+├── status_store.py         # DynamoDB書き込み
+└── flows/
+    └── research-pipeline.yaml
+
+agents/
+├── gather/
+│   ├── Dockerfile
+│   └── main.py
+├── analyze/
+│   ├── Dockerfile
+│   └── main.py
+├── evaluate/
+│   ├── Dockerfile
+│   └── main.py
+└── synthesize/
+    ├── Dockerfile
+    └── main.py
+
+infrastructure/
+└── cdk/
+    ├── app.py
+    └── stacks/
+        ├── orchestrator_stack.py   # AgentCore Runtime + DynamoDB
+        └── agents_stack.py         # AgentCore Runtimes + SSM
+```
+
+## デプロイフロー
+
+```mermaid
+graph TD
+    CDK["cdk deploy --all"] --> ECR["1. ECR + ARM64 イメージビルド"]
+    CDK --> DDB["2. DynamoDB テーブル作成"]
+    CDK --> AC["3. AgentCore Runtimes (Worker Agents)"]
+    CDK --> Orch["4. AgentCore Runtime (Orchestrator)"]
+
+    DDB --> TABLE["daf-flow-executions<br/>(on-demand, TTL有効)"]
+
+    AC --> G["gather → SSM ARN"]
+    AC --> A["analyze → SSM ARN"]
+    AC --> S["synthesize → SSM ARN"]
+
+    Orch --> IAM["IAM: SSM + AgentCore + DynamoDB"]
+```
+
+## IAMポリシー
+
+### Orchestrator (AgentCore Execution Role)
+
+```json
+{
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "ssm:GetParameter",
+      "Resource": "arn:aws:ssm:*:*:parameter/agents/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "bedrock-agentcore:InvokeAgentRuntime",
+      "Resource": "arn:aws:bedrock-agentcore:*:*:runtime/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["dynamodb:PutItem", "dynamodb:UpdateItem", "dynamodb:GetItem", "dynamodb:Query"],
+      "Resource": "arn:aws:dynamodb:*:*:table/daf-flow-executions"
+    }
+  ]
+}
+```
+
+### Worker Agent (AgentCore Execution Role)
+
+```json
+{
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "bedrock:InvokeModel",
+      "Resource": "arn:aws:bedrock:*::foundation-model/*"
+    }
+  ]
+}
+```
+
+## ネットワーク
+
+| 通信 | 経路 | プロトコル |
+|---|---|---|
+| Orchestrator → AgentCore (Worker) | AWSマネージドエンドポイント | HTTPS |
+| AgentCore → Bedrock | AWSマネージド | 内部 |
+| Orchestrator → DynamoDB | AWSマネージドエンドポイント | HTTPS |
+| Client → Orchestrator | AgentCoreエンドポイント | HTTPS / WebSocket |
+
+- VPC設定は不要（全てパブリックエンドポイント経由）
+- Worker AgentがVPCリソース（RDS等）にアクセスする場合のみVPC接続設定を追加
+
+```
+Client → https://bedrock-agentcore.{region}.amazonaws.com/runtimes/{arn}/invocations/
+       → AgentCoreサービスがリクエストをOrchestratorコンテナにルーティング
+```
+
+## スケーリング
+
+| コンポーネント | 方式 | 上限 |
+|---|---|---|
+| Orchestrator | AgentCore自動スケール | 1000 VM/アカウント (us-east-1, us-west-2) |
+| Worker Agent | AgentCore自動スケール（独立） | 同上（Runtimeごとに独立） |
+| DynamoDB | on-demand (自動) | アカウント上限に準拠 |
+| Bedrock | マネージド | モデル別クォータ |
+
+## DynamoDBテーブル設計
+
+```
+Table: daf-flow-executions
+Billing: PAY_PER_REQUEST (on-demand)
+TTL: ttl attribute (30日で自動削除)
+
+PK: flow#{flow_execution_id}  (String)
+SK: META | step#{step_id}     (String)
+```
+
+### レコード例
+
+| PK | SK | status | その他 |
+|---|---|---|---|
+| flow#abc123 | META | running | flow_name, started_at, ttl |
+| flow#abc123 | step#gather | completed | output, started_at, completed_at |
+| flow#abc123 | step#analyze | running | started_at, attempt |
+| flow#abc123 | step#evaluate | completed | output, completed_at |
+| flow#abc123 | step#synthesize | pending | — |
+
+### アクセスパターン
+
+| 操作 | キー条件 |
+|---|---|
+| フロー全体のステータス取得 | `Query PK=flow#abc123` |
+| 特定ステップの取得 | `GetItem PK=flow#abc123, SK=step#gather` |
+| フロー一覧（直近） | GSI (status-index) or Scan with filter |
+
+## AgentCore固有設定
+
+| 項目 | 値 | 理由 |
+|---|---|---|
+| /ping応答 | `add_async_task` で HealthyBusy を維持 | アイドル15分タイムアウト回避 |
+| セッション最大時間 | 8時間 | フローのtimeout_sec上限 |
+| ポート | 9000 | AgentCore標準 (非公式にはport 8080も可) |
+| プラットフォーム | AL2023 ARM64 | AgentCore要件 |
+
+## コスト目安
+
+| コンポーネント | 月額 |
+|---|---|
+| AgentCore Runtime (Orchestrator) | 従量課金 |
+| AgentCore Runtime (Worker Agents) | 従量課金 |
+| DynamoDB (on-demand) | ~$0 (低トラフィック時) |
+| Bedrock | トークン従量 |
+| Langfuse (Self-hosted) | 無料 |
+| SSM Parameter Store | 無料 (Standard tier) |
+| ECR | ~$0.10/GB/月 |

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/docs/variant-a-temporal.md
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/docs/variant-a-temporal.md
@@ -1,0 +1,245 @@
+# Variant A: Temporal版
+
+Temporal CloudでDAGフローを実行する本番向け構成。フロー定義はPythonのTemporal Workflowとして記述する。
+
+## アーキテクチャ
+
+```mermaid
+graph TB
+    Client["Client (demo.py)"]
+
+    subgraph TC["Temporal Cloud"]
+        direction TB
+        TS[Workflow State / Retry / Timeout]
+        TQ[Query API / Visibility API]
+    end
+
+    subgraph AWS["AWS Account"]
+        direction TB
+
+        subgraph ECS["ECS Fargate (ARM64)"]
+            Worker["Temporal Worker<br/>(Orchestrator)"]
+        end
+
+        subgraph Support["Support Services"]
+            direction TB
+            SSM["SSM Parameter Store"]
+            SM["Secrets Manager"]
+        end
+
+        subgraph AC["AgentCore Runtimes"]
+            direction TB
+            Gather["Gather Agent"]
+            Analyze["Analyze Agent"]
+            Evaluate["Evaluate Agent"]
+            Synthesize["Synthesize Agent"]
+        end
+
+        Bedrock["Amazon Bedrock<br/>(Claude Sonnet)"]
+    end
+
+    Client -->|SDK gRPC| TC
+    TC <-->|gRPC mTLS| Worker
+    Worker -->|GetParameter| SSM
+    Worker -->|GetSecretValue| SM
+    Worker -->|A2A SigV4| Gather
+    Worker -->|A2A SigV4| Analyze
+    Worker -->|A2A SigV4| Evaluate
+    Worker -->|A2A SigV4| Synthesize
+    Gather --> Bedrock
+    Analyze --> Bedrock
+    Evaluate --> Bedrock
+    Synthesize --> Bedrock
+```
+
+## DAGフロー図
+
+```mermaid
+graph TD
+    START((Start)) --> gather[Gather]
+    gather --> analyze[Analyze]
+    gather --> evaluate[Evaluate]
+    analyze --> check{score < 0.7?}
+    evaluate --> check
+    check -->|Yes| re_analyze[Re-Analyze]
+    check -->|No| synthesize[Synthesize]
+    re_analyze --> synthesize
+    synthesize --> END((End))
+```
+
+- **gather**: 情報収集（Web検索、コンテンツ抽出）
+- **analyze / evaluate**: fan-out で並列実行。分析と品質評価を同時に行う
+- **条件分岐**: evaluate のスコアが 0.7 未満の場合のみ re_analyze を実行
+- **synthesize**: fan-in。分析結果と評価結果を統合して最終出力を生成
+
+## フロー定義 (Python)
+
+```python
+# workflow/flows/research_pipeline.py
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+from datetime import timedelta
+import asyncio
+
+@workflow.defn
+class ResearchPipelineWorkflow:
+    def __init__(self):
+        self._status = {}
+
+    @workflow.run
+    async def run(self, input_data: dict) -> dict:
+        # Step 1: gather
+        self._status["gather"] = "running"
+        gathered = await workflow.execute_activity(
+            "invoke_agent",
+            args=["gather", input_data],
+            start_to_close_timeout=timedelta(minutes=10),
+            retry_policy=RetryPolicy(maximum_attempts=2),
+        )
+        self._status["gather"] = "completed"
+
+        # Step 2: fan-out (analyze + evaluate 並列)
+        self._status["analyze"] = "running"
+        self._status["evaluate"] = "running"
+        analyzed, evaluated = await asyncio.gather(
+            workflow.execute_activity(
+                "invoke_agent",
+                args=["analyze", gathered],
+                start_to_close_timeout=timedelta(minutes=10),
+                retry_policy=RetryPolicy(
+                    maximum_attempts=3,
+                    backoff_coefficient=2.0,
+                    initial_interval=timedelta(seconds=2),
+                ),
+            ),
+            workflow.execute_activity(
+                "invoke_agent",
+                args=["evaluate", gathered],
+                start_to_close_timeout=timedelta(minutes=10),
+                retry_policy=RetryPolicy(maximum_attempts=2),
+            ),
+        )
+        self._status["analyze"] = "completed"
+        self._status["evaluate"] = "completed"
+
+        # Step 3: 条件分岐
+        score = evaluated.get("score", 1.0)
+        if score < 0.7:
+            self._status["re_analyze"] = "running"
+            analyzed = await workflow.execute_activity(
+                "invoke_agent",
+                args=["analyze", {"original": analyzed, "feedback": evaluated.get("feedback", "")}],
+                start_to_close_timeout=timedelta(minutes=10),
+                retry_policy=RetryPolicy(maximum_attempts=2),
+            )
+            self._status["re_analyze"] = "completed"
+        else:
+            self._status["re_analyze"] = "skipped"
+
+        # Step 4: fan-in (synthesize)
+        self._status["synthesize"] = "running"
+        result = await workflow.execute_activity(
+            "invoke_agent",
+            args=["synthesize", {"analysis": analyzed, "evaluation": evaluated}],
+            start_to_close_timeout=timedelta(minutes=10),
+            retry_policy=RetryPolicy(maximum_attempts=2),
+        )
+        self._status["synthesize"] = "completed"
+        return result
+
+    @workflow.query
+    def get_status(self) -> dict:
+        return self._status
+```
+
+```python
+# workflow/activities.py
+from temporalio import activity
+from a2a_client import invoke_agent as _invoke
+
+@activity.defn
+async def invoke_agent(agent_name: str, input_data: dict) -> dict:
+    return await _invoke(agent_name, input_data)
+```
+
+```python
+# workflow/main.py
+import asyncio, os
+from temporalio.client import Client
+from temporalio.worker import Worker
+from flows.research_pipeline import ResearchPipelineWorkflow
+from activities import invoke_agent
+
+async def main():
+    client = await Client.connect(
+        os.environ["TEMPORAL_ADDRESS"],
+        namespace=os.environ["TEMPORAL_NAMESPACE"],
+        api_key=os.environ.get("TEMPORAL_API_KEY"),
+    )
+    worker = Worker(
+        client,
+        task_queue="daf-orchestrator",
+        workflows=[ResearchPipelineWorkflow],
+        activities=[invoke_agent],
+    )
+    await worker.run()
+
+asyncio.run(main())
+```
+
+## デモ実行
+
+```bash
+cd workflow
+source .venv/bin/activate
+
+export TEMPORAL_ADDRESS="<namespace>.tmprl.cloud:7233"
+export TEMPORAL_NAMESPACE="<namespace>"
+export TEMPORAL_API_KEY="<your-api-key>"
+
+python demo.py "AWS Bedrock AgentCoreの概要を調査してください"
+```
+
+出力例:
+
+```
+============================================================
+  Research Pipeline
+  Query: AWS Bedrock AgentCoreの概要を調査してください
+  Workflow ID: demo-52b524a2
+============================================================
+
+DAG: gather → [analyze | evaluate] → (re_analyze?) → synthesize
+
+Progress:
+  ✅ gather: completed
+  ✅ analyze: completed
+  ✅ evaluate: completed
+  ⏭️ re_analyze: skipped
+  ✅ synthesize: completed
+
+============================================================
+  Result:
+============================================================
+
+(調査結果がここに表示されます)
+```
+
+Temporal UI (https://cloud.temporal.io) でもフロー実行状況を確認できます。
+
+## ステータス管理
+
+Temporalが自動提供。追加インフラ不要。
+
+| 機能 | 詳細 |
+|---|---|
+| 実行状態 | Running / Completed / Failed / Timed Out / Cancelled |
+| Activity状態 | Scheduled → Started → Completed / Failed / Retried |
+| Query | `handle.query("get_status")` でWorkflow内部状態をリアルタイム取得 |
+| 実行履歴 | Event History（全イベント永続化） |
+| 検索 | Visibility API で workflow_id, status, 時刻でフィルタ |
+| UI | Temporal UI でフロー可視化 |
+
+## インフラ仕様
+
+リポジトリ構成、デプロイ、IAM、ネットワーク、スケーリング、コストについては [specs-temporal.md](specs-temporal.md) を参照。

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/docs/variant-b-yaml.en.md
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/docs/variant-b-yaml.en.md
@@ -1,8 +1,8 @@
-# Variant B: YAML版
+# Variant B: YAML-Based DAG Engine
 
-外部依存なしで動作する軽量版。フロー定義はYAML（GitHub Actions風）で記述し、自前DAGエンジンで実行する。
+A lightweight variant with no external dependencies. Flow definitions are written in YAML (GitHub Actions-style) and executed by a built-in DAG engine.
 
-## アーキテクチャ
+## Architecture
 
 ```mermaid
 graph TD
@@ -14,7 +14,7 @@ graph TD
             YAML --> DAG --> A2AClient
         end
 
-        DDB["DynamoDB<br/>(ステータス管理)"]
+        DDB["DynamoDB<br/>(Status Management)"]
 
         subgraph AC["AgentCore Runtimes"]
             Gather["Gather Agent"]
@@ -43,7 +43,7 @@ graph TD
     A2AClient -->|GetParameter| SSM
 ```
 
-## フロー定義 (YAML)
+## Flow Definition (YAML)
 
 ```yaml
 # orchestrator/flows/research-pipeline.yaml
@@ -98,35 +98,35 @@ output: $.steps.synthesize.output
 timeout_sec: 3600
 ```
 
-### YAML仕様
+### YAML Specification
 
 #### steps
 
-| フィールド | 必須 | 説明 |
+| Field | Required | Description |
 |---|---|---|
-| `id` | yes | ステップの一意識別子 |
-| `agent` | yes | `agents` セクションで定義したエージェント名 |
-| `input` | yes | JSONPathによる入力マッピング |
-| `depends_on` | no | 依存するステップID。全完了後に実行 |
-| `condition` | no | 条件式。falseならスキップ（output = null） |
-| `retry` | no | リトライ設定 |
+| `id` | yes | Unique identifier for the step |
+| `agent` | yes | Agent name defined in the `agents` section |
+| `input` | yes | Input mapping via JSONPath |
+| `depends_on` | no | Step IDs this step depends on. Executes after all complete |
+| `condition` | no | Condition expression. Step is skipped (output = null) if false |
+| `retry` | no | Retry configuration |
 
-#### input マッピング
+#### Input Mapping
 
 ```yaml
-# スカラー参照
+# Scalar reference
 input: $.input.query
 
-# オブジェクト構築
+# Object construction
 input:
   analysis: $.steps.analyze.output
   evaluation: $.steps.evaluate.output
 
-# フォールバック（左がnullなら右）
+# Fallback (use right side if left is null)
 input: $.steps.re_analyze.output ?? $.steps.analyze.output
 ```
 
-state構造:
+State structure:
 ```json
 {
   "input": { ... },
@@ -140,10 +140,10 @@ state構造:
 #### condition
 
 ```yaml
-# 比較演算子: <, >, <=, >=, ==, !=
+# Comparison operators: <, >, <=, >=, ==, !=
 condition: $.steps.evaluate.output.score < 0.7
 
-# 論理演算子: AND, OR, NOT
+# Logical operators: AND, OR, NOT
 condition: $.steps.a.output.ready AND $.steps.b.output.count > 0
 ```
 
@@ -151,12 +151,12 @@ condition: $.steps.a.output.ready AND $.steps.b.output.count > 0
 
 ```yaml
 retry:
-  max_attempts: 3           # 最大試行回数（デフォルト: 1 = リトライなし）
+  max_attempts: 3           # Maximum attempts (default: 1 = no retry)
   backoff: exponential      # exponential | fixed
-  initial_delay_sec: 2      # 初回待機秒数
+  initial_delay_sec: 2      # Initial wait in seconds
 ```
 
-#### GitHub Actions との対比
+#### Comparison with GitHub Actions
 
 | GitHub Actions | DAF YAML |
 |---|---|
@@ -166,7 +166,7 @@ retry:
 | `with:` | `input:` |
 | `${{ steps.x.outputs.y }}` | `$.steps.x.output.y` |
 
-## 実行モデル
+## Execution Model
 
 ```python
 # orchestrator/main.py
@@ -319,14 +319,14 @@ class StatusStore:
         table.put_item(Item={"pk": self.pk, "sk": sk, **data})
 ```
 
-## クライアント操作
+## Client Operations
 
 ```bash
-# 方法1: SSEストリーム（リアルタイム）
+# Option 1: SSE stream (real-time)
 POST /invocations
 {"flow": "research-pipeline", "input": {"query": "..."}}
 
-# レスポンス
+# Response
 data: {"event": "flow_started", "flow_execution_id": "abc123"}
 data: {"event": "step_completed", "step": "gather"}
 data: {"event": "step_completed", "step": "analyze"}
@@ -335,9 +335,9 @@ data: {"event": "step_skipped", "step": "re_analyze"}
 data: {"event": "step_completed", "step": "synthesize"}
 data: {"event": "flow_completed", "output": {...}}
 
-# 方法2: ステータスAPI（SSE切断後）
+# Option 2: Status API (after SSE disconnection)
 GET /flows/abc123/status
-→ {
+-> {
     "flow_execution_id": "abc123",
     "status": "running",
     "steps": {
@@ -348,23 +348,23 @@ GET /flows/abc123/status
     }
   }
 
-# 方法3: 結果取得
+# Option 3: Retrieve result
 GET /flows/abc123/output
-→ {"output": {...}}
+-> {"output": {...}}
 ```
 
-## ステータス管理 (DynamoDB)
+## Status Management (DynamoDB)
 
 ```
 Table: daf-flow-executions
 Billing: PAY_PER_REQUEST
-TTL: 30日で自動削除
+TTL: Auto-delete after 30 days
 
 PK: flow#{flow_execution_id}
 SK: META | step#{step_id}
 ```
 
-ステータス遷移:
+State transitions:
 
 ```mermaid
 stateDiagram-v2
@@ -385,12 +385,12 @@ stateDiagram-v2
     }
 ```
 
-## インフラ仕様
+## Infrastructure Specifications
 
-リポジトリ構成、デプロイ、IAM、ネットワーク、スケーリング、コストについては [specs-yaml.md](specs-yaml.md) を参照。
+For repository structure, deployment, IAM, networking, scaling, and cost details, see [specs-yaml.md](specs-yaml.md).
 
-## 制約
+## Constraints
 
-- AgentCore Runtimeのセッションタイムアウト: アイドル15分（`add_async_task`で延命）
-- フロー全体のタイムアウト: 最大8時間
-- VM障害時のフロー再開: 不可（再実行で対応）
+- AgentCore Runtime session timeout: 15 minutes idle (extend with `add_async_task`)
+- Flow-level timeout: 8 hours maximum
+- Flow resumption on VM failure: Not supported (re-execute the flow)

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/docs/variant-b-yaml.md
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/docs/variant-b-yaml.md
@@ -1,0 +1,379 @@
+# Variant B: YAML版
+
+外部依存なしで動作する軽量版。フロー定義はYAML（GitHub Actions風）で記述し、自前DAGエンジンで実行する。
+
+## アーキテクチャ
+
+```mermaid
+graph TD
+    subgraph AWS["AWS Account"]
+        subgraph Orch["AgentCore Runtime: Orchestrator"]
+            YAML["YAML Parser"]
+            DAG["DAG Engine"]
+            A2AClient["A2A Client"]
+            YAML --> DAG --> A2AClient
+        end
+
+        DDB["DynamoDB<br/>(ステータス管理)"]
+
+        subgraph AC["AgentCore Runtimes"]
+            Gather["Gather Agent"]
+            Analyze["Analyze Agent"]
+            Evaluate["Evaluate Agent"]
+            Synthesize["Synthesize Agent"]
+        end
+
+        Bedrock["Amazon Bedrock<br/>(Claude / Nova)"]
+        SSM["SSM Parameter Store"]
+        ECR["ECR"]
+    end
+
+    Client["Client<br/>(POST /invocations<br/>GET /flows/*)"]
+
+    Client -->|HTTPS / SSE| Orch
+    DAG --> DDB
+    A2AClient -->|A2A SigV4| Gather
+    A2AClient -->|A2A SigV4| Analyze
+    A2AClient -->|A2A SigV4| Evaluate
+    A2AClient -->|A2A SigV4| Synthesize
+    Gather --> Bedrock
+    Analyze --> Bedrock
+    Evaluate --> Bedrock
+    Synthesize --> Bedrock
+    A2AClient -->|GetParameter| SSM
+```
+
+## フロー定義 (YAML)
+
+```yaml
+# orchestrator/flows/research-pipeline.yaml
+name: research-pipeline
+version: "1.0"
+
+agents:
+  gather:
+    arn_param: /agents/gather/arn
+  analyze:
+    arn_param: /agents/analyze/arn
+  evaluate:
+    arn_param: /agents/evaluate/arn
+  synthesize:
+    arn_param: /agents/synthesize/arn
+
+steps:
+  - id: gather
+    agent: gather
+    input: $.input
+
+  - id: analyze
+    agent: analyze
+    input: $.steps.gather.output
+    depends_on: [gather]
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      initial_delay_sec: 2
+
+  - id: evaluate
+    agent: evaluate
+    input: $.steps.gather.output
+    depends_on: [gather]
+
+  - id: re_analyze
+    agent: analyze
+    input:
+      original: $.steps.analyze.output
+      feedback: $.steps.evaluate.output.feedback
+    depends_on: [analyze, evaluate]
+    condition: $.steps.evaluate.output.score < 0.7
+
+  - id: synthesize
+    agent: synthesize
+    input:
+      analysis: $.steps.re_analyze.output ?? $.steps.analyze.output
+      evaluation: $.steps.evaluate.output
+    depends_on: [analyze, evaluate, re_analyze]
+
+output: $.steps.synthesize.output
+timeout_sec: 3600
+```
+
+### YAML仕様
+
+#### steps
+
+| フィールド | 必須 | 説明 |
+|---|---|---|
+| `id` | yes | ステップの一意識別子 |
+| `agent` | yes | `agents` セクションで定義したエージェント名 |
+| `input` | yes | JSONPathによる入力マッピング |
+| `depends_on` | no | 依存するステップID。全完了後に実行 |
+| `condition` | no | 条件式。falseならスキップ（output = null） |
+| `retry` | no | リトライ設定 |
+
+#### input マッピング
+
+```yaml
+# スカラー参照
+input: $.input.query
+
+# オブジェクト構築
+input:
+  analysis: $.steps.analyze.output
+  evaluation: $.steps.evaluate.output
+
+# フォールバック（左がnullなら右）
+input: $.steps.re_analyze.output ?? $.steps.analyze.output
+```
+
+state構造:
+```json
+{
+  "input": { ... },
+  "steps": {
+    "gather": { "output": { ... } },
+    "analyze": { "output": { ... } }
+  }
+}
+```
+
+#### condition
+
+```yaml
+# 比較演算子: <, >, <=, >=, ==, !=
+condition: $.steps.evaluate.output.score < 0.7
+
+# 論理演算子: AND, OR, NOT
+condition: $.steps.a.output.ready AND $.steps.b.output.count > 0
+```
+
+#### retry
+
+```yaml
+retry:
+  max_attempts: 3           # 最大試行回数（デフォルト: 1 = リトライなし）
+  backoff: exponential      # exponential | fixed
+  initial_delay_sec: 2      # 初回待機秒数
+```
+
+#### GitHub Actions との対比
+
+| GitHub Actions | DAF YAML |
+|---|---|
+| `needs: [a, b]` | `depends_on: [a, b]` |
+| `if: steps.x.outputs.y` | `condition: $.steps.x.output.y` |
+| `uses: actions/xxx` | `agent: xxx` |
+| `with:` | `input:` |
+| `${{ steps.x.outputs.y }}` | `$.steps.x.output.y` |
+
+## 実行モデル
+
+```python
+# orchestrator/main.py
+from bedrock_agentcore import BedrockAgentCoreApp
+from engine import FlowEngine
+import json, uuid
+
+app = BedrockAgentCoreApp()
+
+@app.entrypoint
+async def handler(event):
+    flow_id = str(uuid.uuid4())
+    flow_name = event["flow"]
+
+    engine = FlowEngine(flow_name, flow_id)
+    yield json.dumps({"event": "flow_started", "flow_execution_id": flow_id})
+
+    async for progress in engine.run(event.get("input", {})):
+        yield json.dumps(progress)
+
+app.run()
+```
+
+```python
+# orchestrator/engine.py
+import asyncio, yaml, time
+from dag import topological_batches, Step
+from resolver import resolve_input, evaluate_condition
+from retry import with_retry
+from a2a_client import invoke_agent
+from status_store import StatusStore
+
+class FlowEngine:
+    def __init__(self, flow_name: str, flow_id: str):
+        with open(f"flows/{flow_name}.yaml") as f:
+            self.flow = yaml.safe_load(f)
+        self.store = StatusStore(flow_id, flow_name)
+        self.state = {}
+
+    async def run(self, input_data: dict):
+        self.state = {"input": input_data, "steps": {}}
+        timeout = self.flow.get("timeout_sec", 3600)
+        start = time.time()
+
+        steps = [Step(
+            id=s["id"], agent=s["agent"], input=s.get("input"),
+            depends_on=s.get("depends_on", []),
+            condition=s.get("condition"), retry=s.get("retry"),
+        ) for s in self.flow["steps"]]
+
+        for batch in topological_batches(steps):
+            if time.time() - start > timeout:
+                self.store.flow_timed_out()
+                yield {"event": "error", "message": "Flow timeout exceeded"}
+                return
+
+            tasks = []
+            batch_steps = []
+            for step in batch:
+                if not evaluate_condition(step.condition, self.state):
+                    self.state["steps"][step.id] = {"output": None}
+                    self.store.step_skipped(step.id)
+                    yield {"event": "step_skipped", "step": step.id}
+                    continue
+                resolved = resolve_input(step.input, self.state)
+                tasks.append(self._execute_step(step, resolved))
+                batch_steps.append(step)
+
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+
+            for step, result in zip(batch_steps, results):
+                if isinstance(result, Exception):
+                    self.store.step_failed(step.id, str(result))
+                    self.store.flow_failed(str(result))
+                    yield {"event": "step_failed", "step": step.id, "error": str(result)}
+                    return
+                self.state["steps"][step.id] = {"output": result}
+                self.store.step_completed(step.id, result)
+                yield {"event": "step_completed", "step": step.id}
+
+        final_output = resolve_input(self.flow["output"], self.state)
+        self.store.flow_completed(final_output)
+        yield {"event": "flow_completed", "output": final_output}
+
+    async def _execute_step(self, step: Step, input_data):
+        agent_config = self.flow["agents"][step.agent]
+        self.store.step_started(step.id)
+
+        async def _invoke():
+            return await invoke_agent(agent_config["arn_param"], input_data)
+
+        return await with_retry(_invoke, step.retry)
+```
+
+```python
+# orchestrator/status_store.py
+import boto3, time
+
+dynamodb = boto3.resource("dynamodb")
+table = dynamodb.Table("daf-flow-executions")
+
+class StatusStore:
+    def __init__(self, flow_id: str, flow_name: str):
+        self.pk = f"flow#{flow_id}"
+        self._write("META", {
+            "status": "running", "flow_name": flow_name,
+            "started_at": int(time.time()),
+            "ttl": int(time.time()) + 86400 * 30,
+        })
+
+    def step_started(self, step_id: str):
+        self._write(f"step#{step_id}", {"status": "running", "started_at": int(time.time())})
+
+    def step_completed(self, step_id: str, output: dict):
+        self._write(f"step#{step_id}", {"status": "completed", "output": output, "completed_at": int(time.time())})
+
+    def step_failed(self, step_id: str, error: str):
+        self._write(f"step#{step_id}", {"status": "failed", "error": error})
+
+    def step_skipped(self, step_id: str):
+        self._write(f"step#{step_id}", {"status": "skipped"})
+
+    def flow_completed(self, output: dict):
+        self._write("META", {"status": "completed", "output": output, "completed_at": int(time.time())})
+
+    def flow_failed(self, error: str):
+        self._write("META", {"status": "failed", "error": error})
+
+    def flow_timed_out(self):
+        self._write("META", {"status": "timed_out"})
+
+    def _write(self, sk: str, data: dict):
+        table.put_item(Item={"pk": self.pk, "sk": sk, **data})
+```
+
+## クライアント操作
+
+```bash
+# 方法1: SSEストリーム（リアルタイム）
+POST /invocations
+{"flow": "research-pipeline", "input": {"query": "..."}}
+
+# レスポンス
+data: {"event": "flow_started", "flow_execution_id": "abc123"}
+data: {"event": "step_completed", "step": "gather"}
+data: {"event": "step_completed", "step": "analyze"}
+data: {"event": "step_completed", "step": "evaluate"}
+data: {"event": "step_skipped", "step": "re_analyze"}
+data: {"event": "step_completed", "step": "synthesize"}
+data: {"event": "flow_completed", "output": {...}}
+
+# 方法2: ステータスAPI（SSE切断後）
+GET /flows/abc123/status
+→ {
+    "flow_execution_id": "abc123",
+    "status": "running",
+    "steps": {
+      "gather": {"status": "completed"},
+      "analyze": {"status": "running"},
+      "evaluate": {"status": "completed"},
+      "synthesize": {"status": "pending"}
+    }
+  }
+
+# 方法3: 結果取得
+GET /flows/abc123/output
+→ {"output": {...}}
+```
+
+## ステータス管理 (DynamoDB)
+
+```
+Table: daf-flow-executions
+Billing: PAY_PER_REQUEST
+TTL: 30日で自動削除
+
+PK: flow#{flow_execution_id}
+SK: META | step#{step_id}
+```
+
+ステータス遷移:
+
+```mermaid
+stateDiagram-v2
+    state "Step" as step {
+        [*] --> pending
+        pending --> running
+        running --> completed
+        running --> failed
+        pending --> skipped
+    }
+
+    state "Flow" as flow {
+        [*] --> pending2: pending
+        pending2 --> running2: running
+        running2 --> completed2: completed
+        running2 --> failed2: failed
+        running2 --> timed_out
+    }
+```
+
+## インフラ仕様
+
+リポジトリ構成、デプロイ、IAM、ネットワーク、スケーリング、コストについては [specs-yaml.md](specs-yaml.md) を参照。
+
+## 制約
+
+- AgentCore Runtimeのセッションタイムアウト: アイドル15分（`add_async_task`で延命）
+- フロー全体のタイムアウト: 最大8時間
+- VM障害時のフロー再開: 不可（再実行で対応）

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/workflow/Dockerfile
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/workflow/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM public.ecr.aws/docker/library/python:3.11-slim
 
 WORKDIR /app
 

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/workflow/Dockerfile
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/workflow/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY pyproject.toml .
+RUN pip install --no-cache-dir .
+
+COPY . .
+
+CMD ["python", "main.py"]

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/workflow/a2a_client.py
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/workflow/a2a_client.py
@@ -1,0 +1,226 @@
+import json
+import os
+from urllib.parse import quote
+from uuid import uuid4
+
+import httpx
+from a2a.client import A2ACardResolver, ClientConfig, ClientFactory
+from a2a.types import Message, Part, Role, SendMessageRequest, TaskState
+
+_region = os.environ.get("AWS_REGION", "us-east-1")
+
+# Local mode: set AGENT_ENDPOINTS env var to specify Agent URLs directly
+# e.g. {"gather":"http://localhost:9001","analyze":"http://localhost:9002",...}
+_local_endpoints: dict[str, str] = {}
+if os.environ.get("AGENT_ENDPOINTS"):
+    _local_endpoints = json.loads(os.environ["AGENT_ENDPOINTS"])
+
+_is_local = bool(_local_endpoints)
+
+
+class SigV4HTTPXAuth(httpx.Auth):
+    """SigV4 auth for AgentCore. Re-fetches credentials per request to handle rotation."""
+
+    def __init__(self, credentials, service: str, region: str):
+        self._credentials = credentials
+        self._service = service
+        self._region = region
+
+    def auth_flow(self, request: httpx.Request):
+        from botocore.auth import SigV4Auth
+        from botocore.awsrequest import AWSRequest
+
+        headers = dict(request.headers)
+        headers.pop("connection", None)
+
+        aws_request = AWSRequest(
+            method=request.method,
+            url=str(request.url),
+            data=request.content,
+            headers=headers,
+        )
+        frozen_creds = self._credentials.get_frozen_credentials()
+        SigV4Auth(frozen_creds, self._service, self._region).add_auth(aws_request)
+        request.headers.update(dict(aws_request.headers))
+        yield request
+
+
+# --- Service Discovery ---
+
+_arn_cache: dict[str, str] = {}
+
+
+def _get_agent_arn(agent_name: str) -> str:
+    import boto3
+
+    if not hasattr(_get_agent_arn, "_ssm"):
+        _get_agent_arn._ssm = boto3.client("ssm", region_name=_region)
+
+    if agent_name not in _arn_cache:
+        param = _get_agent_arn._ssm.get_parameter(Name=f"/agents/{agent_name}/arn")
+        _arn_cache[agent_name] = param["Parameter"]["Value"]
+
+    return _arn_cache[agent_name]
+
+
+def _get_invoke_url(arn: str) -> str:
+    return f"https://bedrock-agentcore.{_region}.amazonaws.com/runtimes/{quote(arn, safe='')}/invocations"
+
+
+# --- HTTP Client ---
+
+_card_cache: dict[str, object] = {}
+
+
+def _create_httpx_client(signed: bool = False) -> httpx.AsyncClient:
+    if not signed:
+        return httpx.AsyncClient(timeout=600)
+
+    import boto3
+
+    session = boto3.Session(region_name=_region)
+    credentials = session.get_credentials()
+    auth = SigV4HTTPXAuth(
+        credentials=credentials,
+        service="bedrock-agentcore",
+        region=_region,
+    )
+    session_id = str(uuid4())
+    headers = {"X-Amzn-Bedrock-AgentCore-Runtime-Session-Id": session_id}
+    return httpx.AsyncClient(timeout=600, auth=auth, headers=headers)
+
+
+# --- Public API ---
+
+
+async def invoke_agent(agent_name: str, input_data: dict) -> dict:
+    """Invoke an Agent via the A2A protocol.
+
+    Local mode (when AGENT_ENDPOINTS is set):
+      - No SigV4 signing; uses a2a-sdk ClientFactory
+
+    AWS mode (default):
+      - Resolves ARN from SSM, builds the invoke URL
+      - Sends a SigV4-signed JSON-RPC POST directly
+    """
+    if _is_local:
+        return await _invoke_local(agent_name, input_data)
+    else:
+        return await _invoke_aws(agent_name, input_data)
+
+
+async def _invoke_local(agent_name: str, input_data: dict) -> dict:
+    url = _local_endpoints.get(agent_name)
+    if not url:
+        raise ValueError(f"Agent '{agent_name}' not found in AGENT_ENDPOINTS")
+
+    httpx_client = httpx.AsyncClient(timeout=600)
+    try:
+        if agent_name not in _card_cache:
+            resolver = A2ACardResolver(httpx_client=httpx_client, base_url=url)
+            _card_cache[agent_name] = await resolver.get_agent_card()
+
+        card = _card_cache[agent_name]
+        config = ClientConfig(httpx_client=httpx_client, streaming=False)
+        a2a_client = ClientFactory(config).create(card)
+
+        message = Message(
+            role=Role.ROLE_USER,
+            parts=[Part(text=json.dumps(input_data))],
+            message_id=uuid4().hex,
+        )
+        request = SendMessageRequest(message=message)
+
+        async for event in a2a_client.send_message(request):
+            if hasattr(event, "task"):
+                task = event.task
+                if task.status.state == TaskState.TASK_STATE_FAILED:
+                    error_msg = task.status.message.parts[0].text if task.status.message.parts else "Unknown error"
+                    raise RuntimeError(f"Agent '{agent_name}' failed: {error_msg}")
+                if task.artifacts:
+                    text = task.artifacts[0].parts[0].text
+                    try:
+                        return json.loads(text)
+                    except json.JSONDecodeError:
+                        return {"result": text}
+                if task.status.message and task.status.message.parts:
+                    text = task.status.message.parts[0].text
+                    try:
+                        return json.loads(text)
+                    except json.JSONDecodeError:
+                        return {"result": text}
+            elif isinstance(event, Message):
+                text = event.parts[0].text
+                try:
+                    return json.loads(text)
+                except json.JSONDecodeError:
+                    return {"result": text}
+    finally:
+        await httpx_client.aclose()
+
+    raise RuntimeError(f"No response from agent: {agent_name}")
+
+
+async def _invoke_aws(agent_name: str, input_data: dict) -> dict:
+    arn = _get_agent_arn(agent_name)
+    url = _get_invoke_url(arn)
+
+    httpx_client = _create_httpx_client(signed=True)
+    try:
+        payload = {
+            "jsonrpc": "2.0",
+            "method": "message/send",
+            "id": uuid4().hex,
+            "params": {
+                "message": {
+                    "role": "user",
+                    "parts": [{"kind": "text", "text": json.dumps(input_data)}],
+                    "messageId": uuid4().hex,
+                }
+            },
+        }
+
+        response = await httpx_client.post(
+            url,
+            json=payload,
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+        )
+        response.raise_for_status()
+        result = response.json()
+
+        if "error" in result:
+            raise RuntimeError(f"Agent '{agent_name}' JSON-RPC error: {result['error']}")
+
+        task = result.get("result", {})
+
+        # Check for failed state
+        status = task.get("status", {})
+        if status.get("state") == "failed":
+            error_parts = status.get("message", {}).get("parts", [])
+            error_msg = error_parts[0].get("text", "Unknown error") if error_parts else "Unknown error"
+            raise RuntimeError(f"Agent '{agent_name}' failed: {error_msg}")
+
+        # Extract text from artifacts
+        artifacts = task.get("artifacts", [])
+        if artifacts:
+            parts = artifacts[0].get("parts", [])
+            if parts:
+                text = parts[0].get("text", "")
+                try:
+                    return json.loads(text)
+                except json.JSONDecodeError:
+                    return {"result": text}
+
+        # Fallback: extract from status message
+        msg_parts = status.get("message", {}).get("parts", [])
+        if msg_parts:
+            text = msg_parts[0].get("text", "")
+            try:
+                return json.loads(text)
+            except json.JSONDecodeError:
+                return {"result": text}
+
+    finally:
+        await httpx_client.aclose()
+
+    raise RuntimeError(f"No response from agent: {agent_name}")

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/workflow/activities.py
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/workflow/activities.py
@@ -1,0 +1,9 @@
+from temporalio import activity
+
+from a2a_client import invoke_agent as _invoke_agent
+
+
+@activity.defn
+async def invoke_agent(agent_name: str, input_data: dict) -> dict:
+    """Invoke an AgentCore Runtime via the A2A protocol."""
+    return await _invoke_agent(agent_name, input_data)

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/workflow/demo.py
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/workflow/demo.py
@@ -1,0 +1,116 @@
+"""DAF demo CLI — starts a Temporal Workflow and displays live progress."""
+
+import asyncio
+import os
+import sys
+import time
+from uuid import uuid4
+
+from temporalio.client import Client
+
+
+TEMPORAL_ADDRESS = os.environ.get("TEMPORAL_ADDRESS", "")
+TEMPORAL_NAMESPACE = os.environ.get("TEMPORAL_NAMESPACE", "")
+TEMPORAL_API_KEY = os.environ.get("TEMPORAL_API_KEY", "")
+
+STEPS = ["gather", "analyze", "evaluate", "re_analyze", "synthesize"]
+
+STATUS_ICONS = {
+    "running": "⏳",
+    "completed": "✅",
+    "skipped": "⏭️",
+}
+
+
+def _render_status(status: dict) -> str:
+    lines = []
+    for step in STEPS:
+        state = status.get(step, "pending")
+        icon = STATUS_ICONS.get(state, "⬜")
+        lines.append(f"  {icon} {step}: {state}")
+    return "\n".join(lines)
+
+
+async def run(query: str):
+    if not TEMPORAL_ADDRESS or not TEMPORAL_NAMESPACE:
+        print("ERROR: set TEMPORAL_ADDRESS / TEMPORAL_NAMESPACE environment variables")
+        sys.exit(1)
+    if not TEMPORAL_API_KEY:
+        print("ERROR: set TEMPORAL_API_KEY environment variable")
+        sys.exit(1)
+
+    print(f"Connecting to Temporal Cloud ({TEMPORAL_NAMESPACE})...")
+    client = await Client.connect(
+        TEMPORAL_ADDRESS,
+        namespace=TEMPORAL_NAMESPACE,
+        api_key=TEMPORAL_API_KEY,
+        tls=True,
+    )
+
+    workflow_id = f"demo-{uuid4().hex[:8]}"
+    print(f"\n{'='*60}")
+    print(f"  Research Pipeline")
+    print(f"  Query: {query}")
+    print(f"  Workflow ID: {workflow_id}")
+    print(f"{'='*60}\n")
+
+    handle = await client.start_workflow(
+        "ResearchPipelineWorkflow",
+        args=[{"query": query}],
+        id=workflow_id,
+        task_queue="daf-orchestrator",
+    )
+
+    print("DAG: gather → [analyze | evaluate] → (re_analyze?) → synthesize\n")
+    print("Progress:")
+
+    prev_status = {}
+    while True:
+        try:
+            status = await handle.query("get_status")
+        except Exception:
+            status = prev_status
+
+        if status != prev_status:
+            sys.stdout.write(f"\033[{len(STEPS)+1}A\033[J" if prev_status else "")
+            print(_render_status(status))
+            prev_status = status
+
+        desc = await handle.describe()
+        if desc.status != 1:  # not RUNNING
+            break
+
+        await asyncio.sleep(2)
+
+    print(f"\n{'='*60}")
+
+    if desc.status == 2:  # COMPLETED
+        result = await handle.result()
+        print("  Result:")
+        print(f"{'='*60}\n")
+
+        if isinstance(result, dict) and "result" in result:
+            print(result["result"])
+        else:
+            import json
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+    elif desc.status == 3:  # FAILED
+        print("  FAILED")
+        print(f"{'='*60}")
+    else:
+        print(f"  Status: {desc.status}")
+        print(f"{'='*60}")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python demo.py <query>")
+        print("Example: python demo.py 'Investigate multi-agent design patterns for generative AI'")
+        sys.exit(1)
+
+    query = " ".join(sys.argv[1:])
+    asyncio.run(run(query))
+
+
+if __name__ == "__main__":
+    main()

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/workflow/flows/research_pipeline.py
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/workflow/flows/research_pipeline.py
@@ -1,0 +1,84 @@
+from datetime import timedelta
+import asyncio
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+
+@workflow.defn
+class ResearchPipelineWorkflow:
+    def __init__(self):
+        self._status: dict[str, str] = {}
+
+    @workflow.run
+    async def run(self, input_data: dict) -> dict:
+        # Step 1: gather
+        self._status["gather"] = "running"
+        gathered = await workflow.execute_activity(
+            "invoke_agent",
+            args=["gather", input_data],
+            start_to_close_timeout=timedelta(minutes=10),
+            retry_policy=RetryPolicy(maximum_attempts=2),
+        )
+        self._status["gather"] = "completed"
+
+        # Step 2: fan-out (analyze + evaluate in parallel)
+        self._status["analyze"] = "running"
+        self._status["evaluate"] = "running"
+
+        analyzed, evaluated = await asyncio.gather(
+            workflow.execute_activity(
+                "invoke_agent",
+                args=["analyze", gathered],
+                start_to_close_timeout=timedelta(minutes=10),
+                retry_policy=RetryPolicy(
+                    maximum_attempts=3,
+                    backoff_coefficient=2.0,
+                    initial_interval=timedelta(seconds=2),
+                ),
+            ),
+            workflow.execute_activity(
+                "invoke_agent",
+                args=["evaluate", gathered],
+                start_to_close_timeout=timedelta(minutes=10),
+                retry_policy=RetryPolicy(maximum_attempts=2),
+            ),
+        )
+        self._status["analyze"] = "completed"
+        self._status["evaluate"] = "completed"
+
+        # Step 3: conditional branch — re-analyze only if score is below threshold
+        score = evaluated.get("score", 1.0)
+        if score < 0.7:
+            self._status["re_analyze"] = "running"
+            analyzed = await workflow.execute_activity(
+                "invoke_agent",
+                args=["analyze", {
+                    "original": analyzed,
+                    "feedback": evaluated.get("feedback", ""),
+                }],
+                start_to_close_timeout=timedelta(minutes=10),
+                retry_policy=RetryPolicy(maximum_attempts=2),
+            )
+            self._status["re_analyze"] = "completed"
+        else:
+            self._status["re_analyze"] = "skipped"
+
+        # Step 4: fan-in (synthesize)
+        self._status["synthesize"] = "running"
+        result = await workflow.execute_activity(
+            "invoke_agent",
+            args=["synthesize", {
+                "analysis": analyzed,
+                "evaluation": evaluated,
+            }],
+            start_to_close_timeout=timedelta(minutes=10),
+            retry_policy=RetryPolicy(maximum_attempts=2),
+        )
+        self._status["synthesize"] = "completed"
+
+        return result
+
+    @workflow.query
+    def get_status(self) -> dict:
+        return self._status

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/workflow/main.py
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/workflow/main.py
@@ -1,0 +1,33 @@
+import asyncio
+import os
+
+from temporalio.client import Client
+from temporalio.worker import Worker
+
+from flows.research_pipeline import ResearchPipelineWorkflow
+from activities import invoke_agent
+
+
+async def main():
+    print("Connecting to Temporal Cloud...", flush=True)
+    client = await Client.connect(
+        os.environ["TEMPORAL_ADDRESS"],
+        namespace=os.environ["TEMPORAL_NAMESPACE"],
+        api_key=os.environ.get("TEMPORAL_API_KEY"),
+        tls=True,
+    )
+    print(f"Connected. Namespace: {os.environ['TEMPORAL_NAMESPACE']}", flush=True)
+
+    worker = Worker(
+        client,
+        task_queue="daf-orchestrator",
+        workflows=[ResearchPipelineWorkflow],
+        activities=[invoke_agent],
+    )
+
+    print("Worker started. Listening on task queue: daf-orchestrator", flush=True)
+    await worker.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/agentic-workloads/bedrock-agentcore-temporal-dag/workflow/pyproject.toml
+++ b/agentic-workloads/bedrock-agentcore-temporal-dag/workflow/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "daf-orchestrator"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "temporalio>=1.9.0",
+    "httpx>=0.27.0",
+    "boto3>=1.35.0",
+    "a2a-sdk>=1.0.0",
+    "langfuse>=2.0.0",
+    "pyyaml>=6.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+]


### PR DESCRIPTION
Multi-agent DAG workflow using independently deployed AgentCore Runtimes, orchestrated by Temporal Cloud via the A2A protocol.

## What's included

- `agents/` — 4 independent Agents (gather, analyze, evaluate, synthesize), each deployed as a separate AgentCore Runtime
- `workflow/` — Temporal Worker (Orchestrator): deterministic DAG execution, no LLM routing
- `cdk/` — CDK stacks (VPC, AgentCore Runtimes x4, ECS Fargate Worker)
- `docs/` — Architecture docs, specs, code walkthrough (English + Japanese)

## Architecture

```
Client (demo.py)
  → Temporal Cloud (gRPC)
    → ECS Fargate Worker (Orchestrator)
      → AgentCore Runtime x4 (A2A / SigV4)
        → Amazon Bedrock (Claude)
```

## DAG Flow

```
gather → [analyze | evaluate] → (re_analyze?) → synthesize
```

- Fan-out: analyze and evaluate run in parallel
- Conditional: re_analyze only if evaluation score < 0.7
- Fan-in: synthesize merges all results

## Key design decisions

- **Deterministic orchestration**: no LLM routing — branching, fan-out/fan-in, retries are handled by Temporal
- **Independent scaling**: each Agent is a separate AgentCore Runtime
- **A2A protocol**: JSON-RPC 2.0 + SigV4 between Orchestrator and Agents

## Testing

Deployed and verified on AWS (us-west-2) with ECS Fargate ARM64 + Temporal Cloud. E2E test confirmed (gather → analyze/evaluate → synthesize pipeline completes successfully).