### PR TITLE
fix(claude-code-proxy): convert image/document blocks and is_error to Bedrock Converse format

### DIFF
--- a/ai-coding-assistants/claude-code-proxy-on-aws/gateway/domains/runtime/converter/request_converter.py
+++ b/ai-coding-assistants/claude-code-proxy-on-aws/gateway/domains/runtime/converter/request_converter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 from copy import deepcopy
 from dataclasses import dataclass
@@ -26,6 +27,24 @@ BEDROCK_TOOL_RESULT_CONTENT_KEYS = {
     "searchResult",
     "text",
     "video",
+}
+IMAGE_MEDIA_TYPE_TO_BEDROCK_FORMAT = {
+    "image/png": "png",
+    "image/jpeg": "jpeg",
+    "image/jpg": "jpeg",
+    "image/gif": "gif",
+    "image/webp": "webp",
+}
+DOCUMENT_MEDIA_TYPE_TO_BEDROCK_FORMAT = {
+    "application/pdf": "pdf",
+    "text/csv": "csv",
+    "application/msword": "doc",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+    "application/vnd.ms-excel": "xls",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
+    "text/html": "html",
+    "text/plain": "txt",
+    "text/markdown": "md",
 }
 
 
@@ -375,17 +394,19 @@ class AnthropicToBedrockConverter:
                 }
             }
         if block_type == "tool_result":
+            # Anthropic marks failed tool calls with is_error; Bedrock uses status.
+            status = "error" if block.get("is_error") else block.get("status", "success")
             return {
                 "toolResult": {
                     "toolUseId": block.get("tool_use_id"),
                     "content": self._convert_tool_result_content(block.get("content", [])),
-                    "status": block.get("status", "success"),
+                    "status": status,
                 }
             }
         if block_type == "image":
-            return {"image": block.get("source", block)}
+            return self._convert_image_block(block)
         if block_type == "document":
-            return {"document": block.get("source", block)}
+            return self._convert_document_block(block)
         if block_type == "thinking":
             reasoning_text: dict[str, Any] = {"text": block.get("thinking", "")}
             signature = block.get("signature")
@@ -428,9 +449,9 @@ class AnthropicToBedrockConverter:
             if block_type == "text":
                 return {"text": block.get("text", "")}
             if block_type == "image":
-                return {"image": deepcopy(block.get("source", block))}
+                return self._convert_image_block(block)
             if block_type == "document":
-                return {"document": deepcopy(block.get("source", block))}
+                return self._convert_document_block(block)
             if block_type == "json":
                 return {"json": deepcopy(block.get("json", block.get("data", {})))}
             if block_type == "search_result":
@@ -439,6 +460,76 @@ class AnthropicToBedrockConverter:
                     return {"searchResult": deepcopy(search_result)}
             return {"json": deepcopy(block)}
         return {"text": str(block)}
+
+    def _convert_image_block(self, block: dict[str, Any]) -> dict[str, Any]:
+        source = block.get("source")
+        if not isinstance(source, dict):
+            return {"image": source if source is not None else block}
+        source_type = source.get("type")
+        if source_type is None:
+            # Already-Bedrock shapes ({"bytes": ...}, {"s3Location": ...}).
+            return {"image": deepcopy(source)}
+        if source_type != "base64":
+            raise ValidationError(
+                f"Unsupported image source type for Bedrock Converse: {source_type!r}"
+            )
+        media_type = source.get("media_type", "")
+        image_format = IMAGE_MEDIA_TYPE_TO_BEDROCK_FORMAT.get(media_type)
+        if image_format is None:
+            raise ValidationError(
+                f"Unsupported image media type for Bedrock Converse: {media_type!r}"
+            )
+        try:
+            image_bytes = base64.b64decode(source.get("data", ""))
+        except (ValueError, TypeError) as exc:
+            raise ValidationError("Image data is not valid base64.") from exc
+        return {"image": {"format": image_format, "source": {"bytes": image_bytes}}}
+
+    def _convert_document_block(self, block: dict[str, Any]) -> dict[str, Any]:
+        source = block.get("source")
+        if not isinstance(source, dict):
+            return {"document": source if source is not None else block}
+        source_type = source.get("type")
+        if source_type is None:
+            # Already-Bedrock shapes ({"bytes": ...}, {"s3Location": ...}).
+            return {"document": deepcopy(source)}
+        media_type = source.get("media_type", "")
+        if source_type == "base64":
+            document_format = DOCUMENT_MEDIA_TYPE_TO_BEDROCK_FORMAT.get(media_type)
+            if document_format is None:
+                raise ValidationError(
+                    f"Unsupported document media type for Bedrock Converse: {media_type!r}"
+                )
+            try:
+                document_bytes = base64.b64decode(source.get("data", ""))
+            except (ValueError, TypeError) as exc:
+                raise ValidationError("Document data is not valid base64.") from exc
+        elif source_type == "text":
+            document_format = DOCUMENT_MEDIA_TYPE_TO_BEDROCK_FORMAT.get(media_type, "txt")
+            document_bytes = str(source.get("data", "")).encode("utf-8")
+        else:
+            raise ValidationError(
+                f"Unsupported document source type for Bedrock Converse: {source_type!r}"
+            )
+        return {
+            "document": {
+                "format": document_format,
+                "name": self._sanitize_document_name(block.get("title")),
+                "source": {"bytes": document_bytes},
+            }
+        }
+
+    @staticmethod
+    def _sanitize_document_name(title: Any) -> str:
+        # Bedrock document names only allow alphanumerics, single spaces,
+        # hyphens, parentheses, and square brackets.
+        if not isinstance(title, str) or not title.strip():
+            return "document"
+        sanitized_chars = [
+            ch if (ch.isalnum() or ch in " -()[]") else " " for ch in title
+        ]
+        sanitized = " ".join("".join(sanitized_chars).split())
+        return sanitized or "document"
 
     def _is_bedrock_tool_result_content_block(self, block: dict[str, Any]) -> bool:
         matching_keys = [key for key in BEDROCK_TOOL_RESULT_CONTENT_KEYS if key in block]

--- a/ai-coding-assistants/claude-code-proxy-on-aws/tests/unit/gateway/test_request_converter.py
+++ b/ai-coding-assistants/claude-code-proxy-on-aws/tests/unit/gateway/test_request_converter.py
@@ -1234,3 +1234,137 @@ def test_convert_request_merges_inline_system_with_top_level_system() -> None:
         {"text": "base system prompt"},
         {"text": "extra mid-conversation guidance"},
     ]
+
+
+def _image_block(media_type: str = "image/png", data: str = "aGVsbG8=") -> dict:
+    return {
+        "type": "image",
+        "source": {"type": "base64", "media_type": media_type, "data": data},
+    }
+
+
+def test_convert_request_converts_tool_result_image_to_bedrock_format() -> None:
+    converter = AnthropicToBedrockConverter()
+    request = MessageRequest(
+        model="claude-sonnet-4-6",
+        max_tokens=16,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_1",
+                        "content": [_image_block()],
+                    }
+                ],
+            }
+        ],
+    )
+
+    converted = converter.convert_request(
+        request, _resolved_model("bedrock-model"), "none"
+    )
+
+    image = converted["messages"][0]["content"][0]["toolResult"]["content"][0]["image"]
+    assert image == {"format": "png", "source": {"bytes": b"hello"}}
+
+
+def test_convert_request_converts_user_image_to_bedrock_format() -> None:
+    converter = AnthropicToBedrockConverter()
+    request = MessageRequest(
+        model="claude-sonnet-4-6",
+        max_tokens=16,
+        messages=[{"role": "user", "content": [_image_block("image/jpeg")]}],
+    )
+
+    converted = converter.convert_request(
+        request, _resolved_model("bedrock-model"), "none"
+    )
+
+    image = converted["messages"][0]["content"][0]["image"]
+    assert image == {"format": "jpeg", "source": {"bytes": b"hello"}}
+
+
+def test_convert_request_rejects_url_image_source() -> None:
+    converter = AnthropicToBedrockConverter()
+    request = MessageRequest(
+        model="claude-sonnet-4-6",
+        max_tokens=16,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {"type": "url", "url": "https://example.com/a.png"},
+                    }
+                ],
+            }
+        ],
+    )
+
+    with pytest.raises(ValidationError):
+        converter.convert_request(request, _resolved_model("bedrock-model"), "none")
+
+
+def test_convert_request_converts_document_to_bedrock_format() -> None:
+    converter = AnthropicToBedrockConverter()
+    request = MessageRequest(
+        model="claude-sonnet-4-6",
+        max_tokens=16,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "document",
+                        "title": "Q3 Report: final/v2*",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "application/pdf",
+                            "data": "aGVsbG8=",
+                        },
+                    }
+                ],
+            }
+        ],
+    )
+
+    converted = converter.convert_request(
+        request, _resolved_model("bedrock-model"), "none"
+    )
+
+    document = converted["messages"][0]["content"][0]["document"]
+    assert document == {
+        "format": "pdf",
+        "name": "Q3 Report final v2",
+        "source": {"bytes": b"hello"},
+    }
+
+
+def test_convert_request_marks_tool_result_with_is_error_as_error_status() -> None:
+    converter = AnthropicToBedrockConverter()
+    request = MessageRequest(
+        model="claude-sonnet-4-6",
+        max_tokens=16,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_1",
+                        "content": "command failed",
+                        "is_error": True,
+                    }
+                ],
+            }
+        ],
+    )
+
+    converted = converter.convert_request(
+        request, _resolved_model("bedrock-model"), "none"
+    )
+
+    assert converted["messages"][0]["content"][0]["toolResult"]["status"] == "error"


### PR DESCRIPTION
## Problem

Three Anthropic-to-Converse conversion gaps in `gateway/domains/runtime/converter/request_converter.py`:

1. **Image blocks crash every request containing them.** Both top-level and tool_result-nested image blocks were passed through with Anthropic keys (`type`/`media_type`/`data`), which boto3 rejects client-side:

   ```
   ParamValidationError: Parameter validation failed:
   Missing required parameter in messages[N].content[0].toolResult.content[0].image: "format"
   Missing required parameter in ...image: "source"
   Unknown parameter in ...image: "type", must be one of: format, source, error
   ```

   In practice this breaks Claude Code whenever the Read tool returns a screenshot, or the user pastes an image — the request 400s with no recovery.

2. **Document blocks have the identical passthrough bug** and would fail the same way (Converse additionally requires a `name` with a restricted character set).

3. **Failed tool calls are reported as successful.** Anthropic marks tool failures with `is_error: true`; the converter read a nonexistent `status` key and defaulted to `"success"`, so the model never learned a tool call had failed.

## Fix

- Convert image blocks to Converse `ImageBlock` (`format` + `source.bytes`), decoding base64 to raw bytes (boto3 re-encodes; passing the string through would double-encode and corrupt the payload).
- Convert document blocks likewise, mapping media types to Converse formats and sanitizing `title` into a valid `name`.
- Map `is_error` to `status: "error"` (explicit `status` still honored).
- Unsupported source types (e.g. `url`) now raise a clear `ValidationError` instead of surfacing a cryptic boto3 message.

## Testing

- 5 regression tests added; all 5 fail on the previous code and pass with the fix.
- Full unit suite passes.
- Verified end-to-end on a live deployment: the previously failing tool_result-image request now returns 200 and the model correctly reads the image bytes; a tool_result with `is_error: true` is now acknowledged as a failure by the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)