### PR TITLE
fix(gateway): harden Bedrock Converse request conversion

### DIFF
--- a/ai-coding-assistants/claude-code-proxy-on-aws/gateway/domains/runtime/converter/request_converter.py
+++ b/ai-coding-assistants/claude-code-proxy-on-aws/gateway/domains/runtime/converter/request_converter.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
+import re
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any
@@ -11,6 +13,16 @@ from typing import Any
 from gateway.domains.runtime.types import MessageRequest
 from shared.exceptions import ValidationError
 from shared.models import ModelCatalog
+
+# Bedrock Converse constrains toolSpec.name to ^[a-zA-Z0-9_-]{1,64}$, while the
+# Anthropic Messages API allows up to 128 chars. MCP tool names (mcp__server__tool)
+# routinely exceed 64 and may contain characters Bedrock rejects. Names are
+# sanitized for Bedrock and the original is restored on the response toolUse name
+# via `tool_name_map`.
+_TOOL_NAME_VALID_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+_TOOL_NAME_INVALID_CHAR_RE = re.compile(r"[^a-zA-Z0-9_-]")
+_MAX_TOOL_NAME_LEN = 64
+_TOOL_NAME_HASH_LEN = 8
 
 MIN_BEDROCK_THINKING_BUDGET_TOKENS = 1024
 MIN_REQUEST_MAX_TOKENS_FOR_FIXED_THINKING = MIN_BEDROCK_THINKING_BUDGET_TOKENS + 1
@@ -70,6 +82,14 @@ class AnthropicToBedrockConverter:
         max_tokens_override: int | None = None,
     ) -> dict[str, Any]:
         cache_counter = _CachePointCounter()
+        # Per-request tool-name sanitization state. Reset on every call because a
+        # converter instance is created per request but this keeps it correct even
+        # if reused. `tool_name_map` (sanitized -> original) is read by the response
+        # converter to restore the client-facing tool name.
+        self.tool_name_map: dict[str, str] = {}
+        self._tool_name_forward: dict[str, str] = {}
+        self._used_tool_names: set[str] = set()
+        self._used_document_names: set[str] = set()
         effective_max_tokens = (
             max_tokens_override if max_tokens_override is not None else anthropic_req.max_tokens
         )
@@ -195,7 +215,9 @@ class AnthropicToBedrockConverter:
             "tools": self._convert_tools_with_cache_points(tools, cache_policy, cache_counter),
         }
         if tool_choice is not None:
-            payload["toolChoice"] = self._convert_tool_choice(tool_choice)
+            converted_choice = self._convert_tool_choice(tool_choice)
+            if converted_choice is not None:
+                payload["toolChoice"] = converted_choice
         return payload
 
     def convert_thinking(
@@ -250,12 +272,13 @@ class AnthropicToBedrockConverter:
         return converted
 
     def _convert_tool(self, tool: dict[str, Any]) -> dict[str, Any]:
+        sanitized_name = self._register_tool_name(tool["name"])
         input_schema = self._normalize_tool_input_schema(
             tool.get("input_schema"),
             tool_name=tool["name"],
         )
         tool_spec: dict[str, Any] = {
-            "name": tool["name"],
+            "name": sanitized_name,
             "inputSchema": {"json": input_schema},
         }
         description = tool.get("description")
@@ -265,15 +288,69 @@ class AnthropicToBedrockConverter:
             tool_spec["strict"] = bool(tool["strict"])
         return {"toolSpec": tool_spec}
 
-    def _convert_tool_choice(self, tool_choice: dict[str, Any]) -> dict[str, Any]:
+    def _register_tool_name(self, original: str) -> str:
+        """Return the Bedrock-safe tool name, recording the reverse mapping.
+
+        Deterministic and collision-free within a request: valid names pass
+        through unchanged; invalid/oversized names are sanitized and, if they
+        collide with an already-used name, disambiguated with a hash suffix.
+        """
+        cached = self._tool_name_forward.get(original)
+        if cached is not None:
+            return cached
+        sanitized = self._sanitize_tool_name(original)
+        if sanitized in self._used_tool_names:
+            sanitized = self._dedupe_tool_name(sanitized, original)
+        self._used_tool_names.add(sanitized)
+        self._tool_name_forward[original] = sanitized
+        if sanitized != original:
+            self.tool_name_map[sanitized] = original
+        return sanitized
+
+    def _sanitize_tool_name(self, original: str) -> str:
+        if _TOOL_NAME_VALID_RE.match(original):
+            return original
+        cleaned = _TOOL_NAME_INVALID_CHAR_RE.sub("_", original)
+        if not cleaned:
+            cleaned = "tool"
+        if len(cleaned) > _MAX_TOOL_NAME_LEN:
+            digest = hashlib.sha256(original.encode("utf-8")).hexdigest()[:_TOOL_NAME_HASH_LEN]
+            keep = _MAX_TOOL_NAME_LEN - _TOOL_NAME_HASH_LEN - 1
+            cleaned = f"{cleaned[:keep]}_{digest}"
+        return cleaned
+
+    def _dedupe_tool_name(self, sanitized: str, original: str) -> str:
+        digest = hashlib.sha256(original.encode("utf-8")).hexdigest()[:_TOOL_NAME_HASH_LEN]
+        keep = _MAX_TOOL_NAME_LEN - _TOOL_NAME_HASH_LEN - 1
+        candidate = f"{sanitized[:keep]}_{digest}"
+        counter = 0
+        while candidate in self._used_tool_names:
+            counter += 1
+            suffix = f"{digest}{counter}"
+            candidate = f"{sanitized[: _MAX_TOOL_NAME_LEN - len(suffix) - 1]}_{suffix}"
+        return candidate
+
+    def _convert_tool_choice(self, tool_choice: dict[str, Any]) -> dict[str, Any] | None:
         choice_type = tool_choice.get("type")
         if choice_type == "auto":
             return {"auto": {}}
         if choice_type == "any":
             return {"any": {}}
         if choice_type == "tool":
-            return {"tool": {"name": tool_choice["name"]}}
-        return deepcopy(tool_choice)
+            name = tool_choice.get("name")
+            if name is None:
+                return None
+            return {"tool": {"name": self._sanitized_tool_name_for(name)}}
+        # Anthropic's "none" and any unsupported/unknown type have no Bedrock
+        # Converse toolChoice equivalent. Omit toolChoice rather than passing an
+        # invalid shape (Bedrock rejects unknown toolChoice members).
+        return None
+
+    def _sanitized_tool_name_for(self, name: str) -> str:
+        cached = self._tool_name_forward.get(name)
+        if cached is not None:
+            return cached
+        return self._sanitize_tool_name(name)
 
     def _normalize_thinking(
         self,
@@ -514,10 +591,26 @@ class AnthropicToBedrockConverter:
         return {
             "document": {
                 "format": document_format,
-                "name": self._sanitize_document_name(block.get("title")),
+                "name": self._register_document_name(block.get("title")),
                 "source": {"bytes": document_bytes},
             }
         }
+
+    def _register_document_name(self, title: Any) -> str:
+        """Return a document name unique within the request.
+
+        Bedrock Converse rejects requests with duplicate document names. The
+        sanitized base name is disambiguated with a ' (N)' suffix (parentheses
+        are allowed by Bedrock) when it collides with an earlier document.
+        """
+        base = self._sanitize_document_name(title)
+        candidate = base
+        counter = 1
+        while candidate in self._used_document_names:
+            counter += 1
+            candidate = f"{base} ({counter})"
+        self._used_document_names.add(candidate)
+        return candidate
 
     @staticmethod
     def _sanitize_document_name(title: Any) -> str:

--- a/ai-coding-assistants/claude-code-proxy-on-aws/gateway/domains/runtime/converter/response_converter.py
+++ b/ai-coding-assistants/claude-code-proxy-on-aws/gateway/domains/runtime/converter/response_converter.py
@@ -18,11 +18,14 @@ class BedrockToAnthropicConverter:
     """Convert Converse and ConverseStream responses to Anthropic-compatible payloads."""
 
     def convert_response(
-        self, bedrock_resp: dict[str, Any], response_model: str
+        self,
+        bedrock_resp: dict[str, Any],
+        response_model: str,
+        tool_name_map: dict[str, str] | None = None,
     ) -> MessageResponse:
         output = bedrock_resp.get("output", {}).get("message", {})
         usage_info = self.extract_usage(bedrock_resp)
-        content = self._convert_output_content(output.get("content", []))
+        content = self._convert_output_content(output.get("content", []), tool_name_map)
         return MessageResponse(
             id=bedrock_resp.get("id")
             or bedrock_resp.get("ResponseMetadata", {}).get("RequestId", "msg_unknown"),
@@ -112,7 +115,9 @@ class BedrockToAnthropicConverter:
     def _coerce_usage_int(value: Any) -> int:
         return int(value or 0)
 
-    def _convert_output_content(self, content: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def _convert_output_content(
+        self, content: list[dict[str, Any]], tool_name_map: dict[str, str] | None = None
+    ) -> list[dict[str, Any]]:
         converted: list[dict[str, Any]] = []
         for block in content:
             if "text" in block:
@@ -123,7 +128,7 @@ class BedrockToAnthropicConverter:
                     {
                         "type": "tool_use",
                         "id": tool_use.get("toolUseId"),
-                        "name": tool_use.get("name"),
+                        "name": self._restore_tool_name(tool_use.get("name"), tool_name_map),
                         "input": tool_use.get("input", {}),
                     }
                 )
@@ -268,6 +273,14 @@ class BedrockToAnthropicConverter:
     def _handle_metadata(self, metadata_event: dict[str, Any], state: StreamState) -> None:
         state.pending_usage = self.extract_usage(metadata_event)
 
+    @staticmethod
+    def _restore_tool_name(
+        name: str | None, tool_name_map: dict[str, str] | None
+    ) -> str | None:
+        if name is not None and tool_name_map:
+            return tool_name_map.get(name, name)
+        return name
+
     def _convert_stream_content_block_start(
         self, start: dict[str, Any], state: StreamState
     ) -> dict[str, Any]:
@@ -277,7 +290,7 @@ class BedrockToAnthropicConverter:
             return {
                 "type": "tool_use",
                 "id": tool_use.get("toolUseId"),
-                "name": tool_use.get("name"),
+                "name": self._restore_tool_name(tool_use.get("name"), state.tool_name_map),
                 "input": {},
             }
 
@@ -344,7 +357,7 @@ class BedrockToAnthropicConverter:
             return {
                 "type": "tool_use",
                 "id": tool_use.get("toolUseId"),
-                "name": tool_use.get("name"),
+                "name": self._restore_tool_name(tool_use.get("name"), state.tool_name_map),
                 "input": {},
             }
 

--- a/ai-coding-assistants/claude-code-proxy-on-aws/gateway/domains/runtime/services.py
+++ b/ai-coding-assistants/claude-code-proxy-on-aws/gateway/domains/runtime/services.py
@@ -299,6 +299,7 @@ class GatewayService:
             message = self._response_converter.convert_response(
                 response,
                 self._response_model_name(context, request.model),
+                tool_name_map=getattr(self._request_converter, "tool_name_map", None),
             )
             usage = self._response_converter.extract_usage(response)
             await self._usage_service.record_success(context, usage)
@@ -398,6 +399,7 @@ class GatewayService:
                     if self._metrics
                     else None
                 ),
+                tool_name_map=getattr(self._request_converter, "tool_name_map", None),
             )
         except AppError as error:
             if isinstance(error, BedrockThrottlingError):

--- a/ai-coding-assistants/claude-code-proxy-on-aws/gateway/domains/runtime/streaming.py
+++ b/ai-coding-assistants/claude-code-proxy-on-aws/gateway/domains/runtime/streaming.py
@@ -84,10 +84,12 @@ class StreamProcessor:
         bedrock_stream: dict[str, Any],
         context,  # type: ignore[no-untyped-def]
         on_done: Callable[[], None] | None = None,
+        tool_name_map: dict[str, str] | None = None,
     ) -> AsyncGenerator[str, None]:
         state = StreamState(
             message_id=f"msg_{getattr(context, 'request_id', 'unknown')}",
             model_name=self._response_model_name(context),
+            tool_name_map=tool_name_map or {},
         )
         stream = bedrock_stream["stream"]
         iterator = iter(stream)

--- a/ai-coding-assistants/claude-code-proxy-on-aws/gateway/domains/runtime/types.py
+++ b/ai-coding-assistants/claude-code-proxy-on-aws/gateway/domains/runtime/types.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 import json
+from dataclasses import dataclass, field
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -112,6 +112,7 @@ class StreamState:
     started_blocks: set[int] = field(default_factory=set)
     text_chunks: list[str] = field(default_factory=list)
     unhandled_event_types: dict[str, int] = field(default_factory=dict)
+    tool_name_map: dict[str, str] = field(default_factory=dict)
 
 
 END_OF_STREAM = object()

--- a/ai-coding-assistants/claude-code-proxy-on-aws/tests/unit/gateway/test_request_converter.py
+++ b/ai-coding-assistants/claude-code-proxy-on-aws/tests/unit/gateway/test_request_converter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from types import SimpleNamespace
 
 import pytest
@@ -9,6 +10,99 @@ import pytest
 from gateway.domains.runtime.converter.request_converter import AnthropicToBedrockConverter
 from gateway.domains.runtime.types import MessageRequest
 from shared.exceptions import ValidationError
+
+_BEDROCK_TOOL_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+
+
+def _tool(name: str) -> dict:
+    return {
+        "name": name,
+        "description": "x",
+        "input_schema": {"type": "object", "properties": {}},
+    }
+
+
+def _convert_with_tools(tools: list[dict], tool_choice: dict | None = None):
+    converter = AnthropicToBedrockConverter()
+    request = MessageRequest(
+        model="claude-sonnet-4-6",
+        max_tokens=64,
+        messages=[{"role": "user", "content": "hi"}],
+        tools=tools,
+        tool_choice=tool_choice,
+    )
+    converted = converter.convert_request(
+        request, SimpleNamespace(bedrock_model_id="bedrock-model"), "none"
+    )
+    return converter, converted
+
+
+def _tool_names(converted: dict) -> list[str]:
+    return [t["toolSpec"]["name"] for t in converted["toolConfig"]["tools"]]
+
+
+# --- #1/#2: tool name length + charset sanitization with reverse mapping ---
+
+def test_long_tool_name_is_truncated_to_64_and_reverse_mapped() -> None:
+    long_name = "mcp__aws-sentral-mcp__get_customer_influences_by_account_and_service"  # 68
+    assert len(long_name) > 64
+    converter, converted = _convert_with_tools([_tool(long_name)])
+    (sanitized,) = _tool_names(converted)
+    assert _BEDROCK_TOOL_NAME_RE.match(sanitized)
+    assert len(sanitized) <= 64
+    # reverse map lets the response side restore the original name
+    assert converter.tool_name_map[sanitized] == long_name
+
+
+def test_invalid_charset_tool_name_is_sanitized() -> None:
+    converter, converted = _convert_with_tools([_tool("aws.sentral.get.customer")])
+    (sanitized,) = _tool_names(converted)
+    assert _BEDROCK_TOOL_NAME_RE.match(sanitized)
+    assert "." not in sanitized
+    assert converter.tool_name_map[sanitized] == "aws.sentral.get.customer"
+
+
+def test_colliding_sanitized_tool_names_stay_unique_and_reversible() -> None:
+    # both sanitize to "a_b" before dedupe
+    converter, converted = _convert_with_tools([_tool("a.b"), _tool("a/b")])
+    names = _tool_names(converted)
+    assert len(set(names)) == 2, names
+    for n in names:
+        assert _BEDROCK_TOOL_NAME_RE.match(n)
+    # every sanitized name maps back to its distinct original
+    assert converter.tool_name_map[names[0]] == "a.b"
+    assert converter.tool_name_map[names[1]] == "a/b"
+
+
+def test_valid_tool_names_pass_through_without_map_entries() -> None:
+    converter, converted = _convert_with_tools([_tool("read_file"), _tool("get-weather")])
+    assert _tool_names(converted) == ["read_file", "get-weather"]
+    assert converter.tool_name_map == {}
+
+
+def test_tool_choice_tool_name_is_sanitized_to_match_spec() -> None:
+    long_name = "mcp__server__" + "x" * 60
+    converter, converted = _convert_with_tools(
+        [_tool(long_name)], tool_choice={"type": "tool", "name": long_name}
+    )
+    (spec_name,) = _tool_names(converted)
+    assert converted["toolConfig"]["toolChoice"] == {"tool": {"name": spec_name}}
+
+
+# --- #3: tool_choice none / unsupported type must not break Bedrock ---
+
+def test_tool_choice_none_omits_toolchoice() -> None:
+    _converter, converted = _convert_with_tools(
+        [_tool("read_file")], tool_choice={"type": "none"}
+    )
+    assert "toolChoice" not in converted["toolConfig"]
+
+
+def test_tool_choice_unknown_type_is_dropped() -> None:
+    _converter, converted = _convert_with_tools(
+        [_tool("read_file")], tool_choice={"type": "totally_unknown"}
+    )
+    assert "toolChoice" not in converted["toolConfig"]
 
 
 def _resolved_model(
@@ -1368,3 +1462,47 @@ def test_convert_request_marks_tool_result_with_is_error_as_error_status() -> No
     )
 
     assert converted["messages"][0]["content"][0]["toolResult"]["status"] == "error"
+
+
+# --- #4: document name uniqueness within a request ---
+
+def _doc(title: str | None) -> dict:
+    import base64 as _b64
+
+    data = _b64.b64encode(b"x").decode()
+    block: dict = {
+        "type": "document",
+        "source": {"type": "base64", "media_type": "text/plain", "data": data},
+    }
+    if title is not None:
+        block["title"] = title
+    return block
+
+
+def _doc_names(tools_msg_content: list[dict]) -> list[str]:
+    return [b["document"]["name"] for b in tools_msg_content if "document" in b]
+
+
+def _convert_docs(blocks: list[dict]) -> dict:
+    converter = AnthropicToBedrockConverter()
+    request = MessageRequest(
+        model="claude-sonnet-4-6",
+        max_tokens=64,
+        messages=[{"role": "user", "content": blocks}],
+    )
+    return converter.convert_request(
+        request, SimpleNamespace(bedrock_model_id="bedrock-model"), "none"
+    )
+
+
+def test_duplicate_document_titles_get_unique_names() -> None:
+    converted = _convert_docs([_doc("report"), _doc("report"), {"type": "text", "text": "sum"}])
+    names = _doc_names(converted["messages"][0]["content"])
+    assert names == ["report", "report (2)"]
+
+
+def test_untitled_documents_get_unique_names() -> None:
+    converted = _convert_docs([_doc(None), _doc(None)])
+    names = _doc_names(converted["messages"][0]["content"])
+    assert names == ["document", "document (2)"]
+    assert len(set(names)) == 2

--- a/ai-coding-assistants/claude-code-proxy-on-aws/tests/unit/gateway/test_response_converter.py
+++ b/ai-coding-assistants/claude-code-proxy-on-aws/tests/unit/gateway/test_response_converter.py
@@ -413,3 +413,76 @@ def test_finalize_stream_emits_zero_usage_message_delta_when_metadata_is_missing
         "cache_creation_input_tokens": 0,
         "cache_read_input_tokens": 0,
     }
+
+
+# --- #1: tool name reverse mapping (restore original client-facing name) ---
+
+def _tool_use_response(name: str) -> dict:
+    tool_use = {"toolUse": {"toolUseId": "t1", "name": name, "input": {"q": 1}}}
+    return {
+        "output": {"message": {"content": [tool_use]}},
+        "stopReason": "tool_use",
+        "usage": {"inputTokens": 1, "outputTokens": 1},
+    }
+
+
+def test_convert_response_restores_original_tool_name() -> None:
+    converter = BedrockToAnthropicConverter()
+    msg = converter.convert_response(
+        _tool_use_response("mcp__srv__short"),
+        "model",
+        tool_name_map={"mcp__srv__short": "mcp__aws-sentral-mcp__really_long_original_name"},
+    )
+    tool_use = msg.content[0]
+    assert tool_use["type"] == "tool_use"
+    assert tool_use["name"] == "mcp__aws-sentral-mcp__really_long_original_name"
+
+
+def test_convert_response_without_map_keeps_name() -> None:
+    converter = BedrockToAnthropicConverter()
+    msg = converter.convert_response(_tool_use_response("read_file"), "model")
+    assert msg.content[0]["name"] == "read_file"
+
+
+def test_convert_response_name_not_in_map_is_unchanged() -> None:
+    converter = BedrockToAnthropicConverter()
+    msg = converter.convert_response(
+        _tool_use_response("read_file"), "model", tool_name_map={"other": "x"}
+    )
+    assert msg.content[0]["name"] == "read_file"
+
+
+def test_stream_content_block_start_restores_original_tool_name() -> None:
+    converter = BedrockToAnthropicConverter()
+    state = StreamState(tool_name_map={"san_name": "orig.tool.name"})
+    converter.convert_stream_event({"messageStart": {"role": "assistant"}}, state)
+    events = converter.convert_stream_event(
+        {
+            "contentBlockStart": {
+                "contentBlockIndex": 0,
+                "start": {"toolUse": {"toolUseId": "t", "name": "san_name"}},
+            }
+        },
+        state,
+    )
+    starts = [e for e in events if e.event == "content_block_start"]
+    assert starts, events
+    assert starts[0].data["content_block"]["name"] == "orig.tool.name"
+
+
+def test_stream_tool_name_restored_from_delta_start() -> None:
+    converter = BedrockToAnthropicConverter()
+    state = StreamState(tool_name_map={"san_name": "orig.tool.name"})
+    converter.convert_stream_event({"messageStart": {"role": "assistant"}}, state)
+    events = converter.convert_stream_event(
+        {
+            "contentBlockDelta": {
+                "contentBlockIndex": 0,
+                "delta": {"toolUse": {"toolUseId": "t", "name": "san_name"}},
+            }
+        },
+        state,
+    )
+    starts = [e for e in events if e.event == "content_block_start"]
+    assert starts, events
+    assert starts[0].data["content_block"]["name"] == "orig.tool.name"

--- a/ai-coding-assistants/claude-code-proxy-on-aws/tests/unit/gateway/test_runtime_fallback.py
+++ b/ai-coding-assistants/claude-code-proxy-on-aws/tests/unit/gateway/test_runtime_fallback.py
@@ -536,3 +536,33 @@ async def test_stream_bedrock_success_does_not_call_anthropic() -> None:
     bedrock_client.converse_stream.assert_awaited_once()
     anthropic_client.messages_stream.assert_not_awaited()
     stream_processor.stream_response.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_stream_client_bug_error_propagates_for_http_400() -> None:
+    """A pre-stream BedrockClientBugError (e.g. ValidationException) must
+    propagate out of process_message_stream so the FastAPI exception handler
+    renders HTTP 400 invalid_request_error -- NOT be swallowed into a 200
+    text/event-stream with a generic api_error event.
+
+    Regression lock for issue #9 on the standard (non web-search) stream path.
+    """
+    bedrock_client = SimpleNamespace(
+        converse=AsyncMock(),
+        converse_stream=AsyncMock(
+            side_effect=BedrockClientBugError(
+                "ValidationException: toolSpec.name must be <= 64"
+            )
+        ),
+    )
+    service, _ = _make_service(
+        bedrock_side_effect=None,
+        anthropic_client=SimpleNamespace(
+            messages=AsyncMock(), messages_stream=AsyncMock()
+        ),
+        resolved_model=_build_resolved_model("claude-sonnet-4-5-20250929"),
+        bedrock_client=bedrock_client,
+    )
+
+    with pytest.raises(BedrockClientBugError):
+        await service.process_message_stream(_build_request(), "sk-test", "req-stream-bug")


### PR DESCRIPTION
## Summary

Hardens the Anthropic → Bedrock Converse request/response translation in the
Claude Code proxy gateway against edge cases that surface as `ValidationException`
/ `ParamValidationError` (and, for Claude Code's streaming path, an opaque
"API Error"). All issues were reproduced against a deployed gateway.

## Changes

**`fix(gateway): harden Bedrock Converse request conversion for tool and document edge cases`**
- **Tool name sanitization + reverse mapping**: Bedrock Converse constrains
  `toolSpec.name` to `^[a-zA-Z0-9_-]{1,64}$`, while Anthropic allows up to 128
  chars. MCP tool names (`mcp__server__tool`) routinely exceed 64 or contain
  rejected characters, which rejects the whole request even when the tool is
  only *declared* (not called). Names are now sanitized (truncate + charset
  substitution + collision-safe hash suffix) and the original name is restored
  on the response and streaming `toolUse` blocks via a reverse map.
- **`tool_choice`**: Anthropic `none`/unknown types are omitted rather than
  passed as an invalid `toolChoice` shape that Bedrock rejects.
- **Document names**: made unique within a request (Bedrock rejects duplicates).

**`test(gateway): lock streaming client-bug errors surface as HTTP 400`**
- Regression test asserting a pre-stream `BedrockClientBugError` on the standard
  streaming path propagates to the exception handler (HTTP 400
  `invalid_request_error`) instead of being swallowed into a `200`
  `text/event-stream` with a generic `api_error` event.

## Testing

- New/updated unit tests for all cases (request converter, response converter,
  streaming reverse mapping, streaming error propagation).
- Full unit suite green; `ruff` clean.

## Notes / out of scope

- `max_tokens` clamping was intentionally **not** added: clamping to a
  misconfigured ceiling would silently truncate valid responses, which is worse
  than Bedrock's clear error for a reference architecture. Over-limit requests
  keep surfacing Bedrock's explicit 400.
- Image `url` sources and `top_k` pass-through remain as follow-ups.
