### PR TITLE
fix(ambient-voice-qa): correct SPDX tag and add Pipecat/Daily attribution

### DIFF
--- a/agentic-workloads/ambient-voice-qa/THIRD-PARTY-LICENSES
+++ b/agentic-workloads/ambient-voice-qa/THIRD-PARTY-LICENSES
@@ -1,0 +1,33 @@
+Ambient Voice QA includes third-party software subject to the following licenses.
+
+-------------------------------------------------------------------------------
+Pipecat (pipecat-ai) — https://github.com/pipecat-ai/pipecat
+
+Portions of the server code (server/bot.py) were scaffolded by the Pipecat CLI
+and retain the following notice:
+
+Copyright (c) 2024-2025, Daily
+
+SPDX-License-Identifier: BSD-2-Clause
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-------------------------------------------------------------------------------

--- a/agentic-workloads/ambient-voice-qa/server/bot.py
+++ b/agentic-workloads/ambient-voice-qa/server/bot.py
@@ -1,7 +1,8 @@
 #
 # Copyright (c) 2024-2025, Daily
+# Copyright Amazon.com, Inc. or its affiliates.
 #
-# SPDX-License-Identifier: BSD 2-Clause License
+# SPDX-License-Identifier: BSD-2-Clause
 #
 
 """Ambient Voice QA for Manufacturing/Warehouse Workers - Pipecat Voice Agent.


### PR DESCRIPTION
## What

Fixes the license header on `agentic-workloads/ambient-voice-qa/server/bot.py`, which was inherited from the Pipecat CLI scaffold.

- **Correct the SPDX identifier.** `SPDX-License-Identifier: BSD 2-Clause License` is not a valid SPDX identifier (it breaks license scanners). Changed to the valid token `BSD-2-Clause`.
- **Add Amazon's copyright** alongside Daily's, for the substantial Amazon-authored additions. Daily's notice is **retained** (not relicensed) to satisfy BSD-2-Clause clause 1.
- **Add `THIRD-PARTY-LICENSES`** at the sample root recording the Pipecat/Daily BSD-2-Clause attribution (durable central record alongside the per-file header).

## Why

The file started from the Pipecat CLI scaffold (BSD-2-Clause, © Daily). BSD-2-Clause clause 1 requires retaining the copyright + license notice on redistributed source, so the correct handling is retain-and-attribute rather than relicensing to MIT-0. `BSD-2-Clause` is a pre-approved permissive license for distribution, so no policy exception is needed. The embedded license text is verified byte-for-byte against the canonical SPDX BSD-2-Clause text.

> Note: the same Pipecat-scaffold pattern is being addressed on the ClaimPilot PR (#117); this PR brings the already-merged `ambient-voice-qa` sample in line.

## Scope

`ambient-voice-qa` only — `server/bot.py` is the sole file carrying the header (verified across the sample). No functional/runtime changes.
