### PR TITLE
Fix READ-ONLY DB access: use ROLE + SET ROLE instead of separate secret

### DIFF
--- a/agentic-workloads/internal-business-agent-tools/cdk/bin/app.ts
+++ b/agentic-workloads/internal-business-agent-tools/cdk/bin/app.ts
@@ -30,7 +30,7 @@ new AgentCoreStack(app, 'InternalAgent-AgentCore', {
   userPoolClientId: dataStack.auth.client.userPoolClientId,
   bucketArn: dataStack.storage.bucket.bucketArn,
   clusterArn: dataStack.database.cluster.clusterArn,
-  secretArn: dataStack.database.readOnlySecret.secretArn,
+  secretArn: dataStack.database.cluster.secret!.secretArn,
   description: 'AgentCore Runtime (PUBLIC) + Gateway',
 });
 

--- a/agentic-workloads/internal-business-agent-tools/cdk/lib/constructs/database.ts
+++ b/agentic-workloads/internal-business-agent-tools/cdk/lib/constructs/database.ts
@@ -1,7 +1,6 @@
 import { Construct } from 'constructs';
 import * as rds from 'aws-cdk-lib/aws-rds';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
-import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import { RemovalPolicy } from 'aws-cdk-lib';
 
 export interface DatabaseProps {
@@ -10,7 +9,6 @@ export interface DatabaseProps {
 
 export class Database extends Construct {
   public readonly cluster: rds.DatabaseCluster;
-  public readonly readOnlySecret: secretsmanager.ISecret;
 
   constructor(scope: Construct, id: string, props: DatabaseProps) {
     super(scope, id);
@@ -29,19 +27,6 @@ export class Database extends Construct {
       removalPolicy: RemovalPolicy.DESTROY,
       serverlessV2MinCapacity: 0.5,
       serverlessV2MaxCapacity: 2,
-    });
-
-    this.readOnlySecret = new secretsmanager.Secret(this, 'ReadOnlySecret', {
-      secretName: 'internalagent/readonly-user',
-      generateSecretString: {
-        secretStringTemplate: JSON.stringify({
-          username: 'readonly_user',
-          dbname: 'internal_db',
-        }),
-        generateStringKey: 'password',
-        excludePunctuation: true,
-        passwordLength: 32,
-      },
     });
   }
 }

--- a/agentic-workloads/internal-business-agent-tools/cdk/lib/constructs/mcp-runtime.ts
+++ b/agentic-workloads/internal-business-agent-tools/cdk/lib/constructs/mcp-runtime.ts
@@ -1,12 +1,10 @@
 import { Construct } from 'constructs';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import * as rds from 'aws-cdk-lib/aws-rds';
-import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 
 export interface McpRuntimeProps {
   cluster: rds.DatabaseCluster;
-  readOnlySecret: secretsmanager.ISecret;
   bucket: s3.IBucket;
   ssmPrefix: string;
 }
@@ -21,7 +19,7 @@ export class McpRuntime extends Construct {
   constructor(scope: Construct, id: string, props: McpRuntimeProps) {
     super(scope, id);
 
-    const { cluster, readOnlySecret, bucket, ssmPrefix } = props;
+    const { cluster, bucket, ssmPrefix } = props;
 
     new ssm.StringParameter(this, 'ClusterArn', {
       parameterName: `${ssmPrefix}CLUSTER_ARN`,
@@ -30,7 +28,7 @@ export class McpRuntime extends Construct {
 
     new ssm.StringParameter(this, 'SecretArn', {
       parameterName: `${ssmPrefix}SECRET_ARN`,
-      stringValue: readOnlySecret.secretArn,
+      stringValue: cluster.secret!.secretArn,
     });
 
     new ssm.StringParameter(this, 'Database', {

--- a/agentic-workloads/internal-business-agent-tools/cdk/lib/constructs/seed-database.ts
+++ b/agentic-workloads/internal-business-agent-tools/cdk/lib/constructs/seed-database.ts
@@ -2,22 +2,19 @@ import { Construct } from 'constructs';
 import * as cr from 'aws-cdk-lib/custom-resources';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as rds from 'aws-cdk-lib/aws-rds';
-import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { CustomResource, Duration, Stack } from 'aws-cdk-lib';
 import * as path from 'path';
 
 export interface SeedDatabaseProps {
   cluster: rds.DatabaseCluster;
-  readOnlySecret: secretsmanager.ISecret;
 }
 
 export class SeedDatabase extends Construct {
   constructor(scope: Construct, id: string, props: SeedDatabaseProps) {
     super(scope, id);
 
-    const { cluster, readOnlySecret } = props;
-    const readOnlyPassword = readOnlySecret.secretValueFromJson('password').unsafeUnwrap();
+    const { cluster } = props;
 
     const statements = [
       `CREATE TABLE IF NOT EXISTS customers (
@@ -49,9 +46,9 @@ export class SeedDatabase extends Construct {
       `INSERT INTO internal_projects (project_name, owner, department, status, budget, start_date, end_date, description) SELECT '顧客管理システム刷新', '木村美穂', 'IT部門', 'planning', 30000000, '2024-10-01', '2025-09-30', 'レガシーCRMから新システムへの移行' WHERE NOT EXISTS (SELECT 1 FROM internal_projects WHERE project_name = '顧客管理システム刷新')`,
       `INSERT INTO internal_projects (project_name, owner, department, status, budget, start_date, end_date, description) SELECT 'データ分析基盤', '中村拓也', 'データサイエンス', 'in_progress', 20000000, '2024-01-01', '2024-12-31', 'S3 + Athena によるデータレイク構築' WHERE NOT EXISTS (SELECT 1 FROM internal_projects WHERE project_name = 'データ分析基盤')`,
       `INSERT INTO internal_projects (project_name, owner, department, status, budget, start_date, end_date, description) SELECT 'セキュリティ強化施策', '渡辺由美', '情報セキュリティ', 'completed', 8000000, '2023-07-01', '2024-06-30', 'ゼロトラスト導入と監査体制整備' WHERE NOT EXISTS (SELECT 1 FROM internal_projects WHERE project_name = 'セキュリティ強化施策')`,
-      // Create a READ-ONLY database user for the MCP server (least privilege)
-      `DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'readonly_user') THEN CREATE USER readonly_user WITH PASSWORD '${readOnlyPassword}'; END IF; END $$`,
-      `GRANT CONNECT ON DATABASE internal_db TO readonly_user`,
+      // Create a READ-ONLY role for the MCP server (least privilege).
+      // The MCP server uses SET ROLE readonly_user before executing queries.
+      `DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'readonly_user') THEN CREATE ROLE readonly_user NOLOGIN; END IF; END $$`,
       `GRANT USAGE ON SCHEMA public TO readonly_user`,
       `GRANT SELECT ON customers, internal_projects TO readonly_user`,
     ];

--- a/agentic-workloads/internal-business-agent-tools/cdk/lib/data-stack.ts
+++ b/agentic-workloads/internal-business-agent-tools/cdk/lib/data-stack.ts
@@ -23,14 +23,12 @@ export class DataStack extends Stack {
 
     new McpRuntime(this, 'McpRuntime', {
       cluster: this.database.cluster,
-      readOnlySecret: this.database.readOnlySecret,
       bucket: this.storage.bucket,
       ssmPrefix: '/internalagent/',
     });
 
     new SeedDatabase(this, 'SeedDatabase', {
       cluster: this.database.cluster,
-      readOnlySecret: this.database.readOnlySecret,
     });
 
     new CfnOutput(this, 'VpcId', { value: this.network.vpc.vpcId });

--- a/agentic-workloads/internal-business-agent-tools/mcp-server/main.py
+++ b/agentic-workloads/internal-business-agent-tools/mcp-server/main.py
@@ -61,6 +61,17 @@ def query_database(sql: str) -> str:
 
     try:
         rds_data = boto3.client("rds-data", region_name=REGION)
+
+        # Switch to the read-only role before executing the user query.
+        # This ensures DB-level enforcement of SELECT-only access on
+        # application tables, regardless of the generated SQL.
+        rds_data.execute_statement(
+            resourceArn=CLUSTER_ARN,
+            secretArn=SECRET_ARN,
+            database=DATABASE,
+            sql="SET ROLE readonly_user",
+        )
+
         response = rds_data.execute_statement(
             resourceArn=CLUSTER_ARN,
             secretArn=SECRET_ARN,


### PR DESCRIPTION
Replace the separate Secrets Manager secret approach with PostgreSQL's ROLE mechanism. readonly_user is created as NOLOGIN role (no password), admin secret is used for Data API connection, and MCP server calls SET ROLE readonly_user before executing each user query to enforce DB-level SELECT-only access on application tables.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
