### PR TITLE
fix(agentic-analytics): Aurora PostgreSQL 15.8 → 15.14 (15.8 retired by AWS)

### DIFF
--- a/agentic-workloads/agentic-analytics/infrastructure/stacks/aurora-stack.yaml
+++ b/agentic-workloads/agentic-analytics/infrastructure/stacks/aurora-stack.yaml
@@ -426,7 +426,12 @@ Resources:
     Properties:
       DBClusterIdentifier: !Sub ${EnvironmentName}-cluster
       Engine: aurora-postgresql
-      EngineVersion: '15.8'
+      # NOTE: pin to a currently-available Aurora PostgreSQL 15.x minor. AWS
+      # periodically retires minor versions; when 15.8 was retired, fresh
+      # CreateDBCluster calls failed with "Cannot find version 15.8". If this
+      # recurs, bump to a current 15.x from: aws rds describe-db-engine-versions
+      # --engine aurora-postgresql --query "DBEngineVersions[?starts_with(EngineVersion,'15.')].EngineVersion"
+      EngineVersion: '15.14'
       EngineMode: provisioned
       DatabaseName: !Ref DatabaseName
       MasterUsername: !Sub '{{resolve:secretsmanager:${DatabaseSecret}:SecretString:username}}'


### PR DESCRIPTION
## Problem
Fresh deploys of the **Agentic Analytics for Multi-tenant SaaS with AgentCore** workshop fail during infrastructure deployment:

```
main-stack → AuroraStack → AuroraCluster (AWS::RDS::DBCluster) CREATE_FAILED:
  "Cannot find version 15.8 for aurora-postgresql"
```

AWS has **retired Aurora PostgreSQL 15.8** as a creatable minor version in us-east-1. `aurora-stack.yaml` pins `EngineVersion: '15.8'`, so every new `CreateDBCluster` fails immediately — participants can't get past the base infrastructure deploy.

**Reproduced** on the currently-published Workshop Studio build (`3e6d4dd0`) via a fresh test event: base stack failed at AuroraCluster with the message above. Confirmed 15.8 is no longer returned by `describe-db-engine-versions`; current 15.x minors are 15.10/15.12/15.13/15.14/15.15/15.17.

## Fix
Bump the pin to **15.14** — a current 15.x minor. Same major version, so **no schema / RLS / Cube compatibility impact** for the workshop. Added a comment documenting how to refresh the pin if a future minor is retired (this is a recurring AWS-side deprecation pattern).

## Testing
- Root cause reproduced live on the published build (CFN CREATE_FAILED at AuroraCluster).
- Verified 15.14 is currently available in us-east-1.
- YAML parse validated.
- One-line value change; no other resources touched.