### PR TITLE
feat: harden Claude Apps Gateway ALB, health checks, VPC endpoints, and model allowlist

### DIFF
--- a/ai-coding-assistants/claude-apps-gateway-on-aws/README.md
+++ b/ai-coding-assistants/claude-apps-gateway-on-aws/README.md
@@ -126,7 +126,8 @@ Create it from the template and edit the key values:
 
 ```bash
 cp cdk.context.json.example cdk.context.json
-# edit at least: gatewayHost, hostedZoneName, awsAccount, allowedEmailDomains, cognitoDomainPrefix
+# edit at least: gatewayHost, hostedZoneName, awsAccount, allowedEmailDomains,
+#                cognitoDomainPrefix, availableModels
 ```
 
 | Context key | Meaning |
@@ -136,6 +137,7 @@ cp cdk.context.json.example cdk.context.json
 | `awsAccount` / `awsRegion` | Deployment target (needed for the hosted-zone lookup) |
 | `allowedClientCidrs` | CIDRs allowed to reach the internal ALB on 443 (VPN/corporate/devbox) |
 | `allowedEmailDomains` | Cognito ID-token email domains the gateway accepts |
+| `availableModels` | Model allowlist shown in the Claude Code model picker and enforced server-side (`managed.policies` + `enforceAvailableModels`). **List only the Claude models you have enabled access for in Bedrock** — models outside the allowlist can't be selected, and without one the picker offers every built-in model, including ones that fail with `AccessDenied` mid-conversation |
 | `cognitoDomainPrefix` | Cognito hosted-domain prefix (globally unique per region) |
 | `bedrockRegion` | Region for Bedrock inference |
 | `claudeVersion` | Pinned Claude Code version baked into the image |

--- a/ai-coding-assistants/claude-apps-gateway-on-aws/README.md
+++ b/ai-coding-assistants/claude-apps-gateway-on-aws/README.md
@@ -75,7 +75,7 @@ Full diagram, request path, network isolation, and the security-group matrix:
 | Resource | Purpose |
 |---|---|
 | VPC (2 AZs, 1 NAT) | Public / application / isolated-database subnet tiers |
-| Internal ALB (HTTPS 443) | TLS termination (ACM); 443 only from `allowedClientCidrs` |
+| Internal ALB (HTTPS 443) | TLS termination (ACM); 443 only from `allowedClientCidrs`; 3600s idle timeout for streaming; target group health check on `/healthz` |
 | ECS Fargate service | Runs `claude gateway`; task role limited to Bedrock `InvokeModel*` |
 | Aurora PostgreSQL Serverless v2 | Device flow, sessions, rate-limit state (isolated) |
 | Cognito User Pool + client | OIDC identity provider (email sign-in, confidential client) |

--- a/ai-coding-assistants/claude-apps-gateway-on-aws/README.md
+++ b/ai-coding-assistants/claude-apps-gateway-on-aws/README.md
@@ -75,6 +75,7 @@ Full diagram, request path, network isolation, and the security-group matrix:
 | Resource | Purpose |
 |---|---|
 | VPC (2 AZs, 1 NAT) | Public / application / isolated-database subnet tiers |
+| VPC endpoints (6 interface + S3 gateway) | Bedrock Runtime, Secrets Manager, ECR (api + dkr), CloudWatch Logs/Monitoring, S3 — AWS-service traffic stays on the AWS backbone instead of the NAT path (`createVpcEndpoints: false` to opt out) |
 | Internal ALB (HTTPS 443) | TLS termination (ACM); 443 only from `allowedClientCidrs`; 3600s idle timeout for streaming; target group health check on `/healthz` |
 | ECS Fargate service | Runs `claude gateway`; task role limited to Bedrock `InvokeModel*` |
 | Aurora PostgreSQL Serverless v2 | Device flow, sessions, rate-limit state (isolated) |
@@ -142,6 +143,7 @@ cp cdk.context.json.example cdk.context.json
 | `bedrockRegion` | Region for Bedrock inference |
 | `claudeVersion` | Pinned Claude Code version baked into the image |
 | `desiredCount` / `natGateways` | Fargate task count / NAT Gateway count |
+| `createVpcEndpoints` | Create the interface + S3 gateway VPC endpoints (default `true`). Interface endpoints cost ~$0.01/AZ/hour each; set `false` to route AWS-service traffic through NAT instead |
 
 Defaults in [`lib/config.ts`](lib/config.ts) are placeholders; context always
 overrides them, and any value can also be passed per-command with `cdk -c key=value`.

--- a/ai-coding-assistants/claude-apps-gateway-on-aws/cdk.context.json.example
+++ b/ai-coding-assistants/claude-apps-gateway-on-aws/cdk.context.json.example
@@ -7,6 +7,12 @@
   "allowedEmailDomains": [
     "corp.example.com"
   ],
+  "availableModels": [
+    "claude-opus-4-8",
+    "claude-sonnet-5",
+    "claude-haiku-4-5",
+    "claude-fable-5"
+  ],
   "claudeVersion": "2.1.195",
   "cognitoDomainPrefix": "claude-gateway-example",
   "bedrockRegion": "us-east-1",

--- a/ai-coding-assistants/claude-apps-gateway-on-aws/cdk.context.json.example
+++ b/ai-coding-assistants/claude-apps-gateway-on-aws/cdk.context.json.example
@@ -21,5 +21,6 @@
   "databaseName": "claude_gateway",
   "desiredCount": 2,
   "maxAzs": 2,
-  "natGateways": 1
+  "natGateways": 1,
+  "createVpcEndpoints": true
 }

--- a/ai-coding-assistants/claude-apps-gateway-on-aws/docker/render-gateway-config.sh
+++ b/ai-coding-assistants/claude-apps-gateway-on-aws/docker/render-gateway-config.sh
@@ -52,6 +52,23 @@ upstreams:
 auto_include_builtin_models: true
 YAML
 
+if [ -n "${GATEWAY_AVAILABLE_MODELS:-}" ]; then
+  # Constrain the model picker to the models actually enabled in Bedrock, so
+  # developers can't select one that fails with AccessDenied mid-conversation.
+  # enforceAvailableModels is also applied server-side at /v1/messages, so a
+  # patched client can't bypass the allowlist. Comma-joined list -> YAML flow
+  # sequence; YAML trims whitespace around items.
+  cat >> "$GATEWAY_CONFIG_PATH" <<POLICY
+
+managed:
+  policies:
+    - match: {}
+      cli:
+        availableModels: [${GATEWAY_AVAILABLE_MODELS}]
+        enforceAvailableModels: true
+POLICY
+fi
+
 if [ "${1:-}" = "--render-only" ]; then
   cat "$GATEWAY_CONFIG_PATH"
   exit 0

--- a/ai-coding-assistants/claude-apps-gateway-on-aws/docs/architecture.md
+++ b/ai-coding-assistants/claude-apps-gateway-on-aws/docs/architecture.md
@@ -53,11 +53,14 @@ starting the gateway login flow.
    private IPs.
 2. The **internal ALB** terminates TLS on port 443 (ACM certificate, `RECOMMENDED_TLS`
    policy) and forwards to the gateway tasks on port 8080. The ALB security group
-   only allows 443 from `allowedClientCidrs`.
+   only allows 443 from `allowedClientCidrs`. Idle timeout is 3600s so long-running
+   streaming responses aren't cut off mid-stream.
 3. The **ECS Fargate** gateway container runs the `claude gateway` server. The target
    group and container health checks both hit `/healthz` (liveness) — `/readyz`
    checks Postgres, and using it at the ALB would drain every replica during a
-   transient DB blip.
+   transient DB blip. A 120s health-check grace period covers the boot-time
+   Postgres migration so a slow cold start during a rolling deploy doesn't trip
+   the deployment circuit breaker.
 4. Sign-in runs the **OIDC** authorization-code flow against the **Cognito User Pool**
    (hosted domain + confidential client). Only email domains in `allowedEmailDomains`
    are accepted.

--- a/ai-coding-assistants/claude-apps-gateway-on-aws/docs/architecture.md
+++ b/ai-coding-assistants/claude-apps-gateway-on-aws/docs/architecture.md
@@ -22,6 +22,7 @@ flowchart TB
       subgraph App["Application subnets (private + egress)"]
         ALB["Internal ALB<br/>HTTPS :443"]
         ECS["ECS Fargate<br/>claude gateway :8080"]
+        VPCE["VPC endpoints<br/>Bedrock · SM · ECR · Logs · S3"]
       end
       subgraph Db["Database subnets (isolated)"]
         DB["Aurora PostgreSQL<br/>Serverless v2 :5432"]
@@ -38,8 +39,9 @@ flowchart TB
   ECS -->|"OIDC sign-in"| Cognito
   ECS -->|"env secrets"| Secrets
   ECS --> Logs
-  ECS -->|"egress"| NAT
-  ECS -->|"InvokeModel"| Bedrock
+  ECS -->|"OIDC egress"| NAT
+  ECS -->|"AWS services"| VPCE
+  VPCE -->|"InvokeModel"| Bedrock
 ```
 
 CloudFront and public DNS are intentionally **not** on the login path: the Claude
@@ -77,13 +79,21 @@ hop:
 | Tier | Subnet type | Holds | Ingress allowed from |
 |---|---|---|---|
 | Public | `PUBLIC` | NAT Gateway | — |
-| Application | `PRIVATE_WITH_EGRESS` | Internal ALB, Fargate tasks | ALB: 443 from `allowedClientCidrs`; Tasks: 8080 from ALB SG only |
+| Application | `PRIVATE_WITH_EGRESS` | Internal ALB, Fargate tasks, VPC endpoint ENIs | ALB: 443 from `allowedClientCidrs`; Tasks: 8080 from ALB SG only; Endpoints: 443 from task SG only |
 | Database | `PRIVATE_ISOLATED` | Aurora PostgreSQL Serverless v2 | 5432 from task SG only |
 
 ## Key resources
 
-- **VPC** — `maxAzs: 2`, `natGateways: 1` (egress for pulling the image, OIDC
-  discovery, and Bedrock calls).
+- **VPC** — `maxAzs: 2`, `natGateways: 1`. NAT carries only the Cognito OIDC
+  leg (no VPC endpoint exists for it); everything else uses the endpoints below.
+- **VPC endpoints** (`createVpcEndpoints: true`, default) — six interface
+  endpoints (Bedrock Runtime, Secrets Manager, ECR api + dkr, CloudWatch
+  Logs, CloudWatch Monitoring) with private DNS, plus an S3 gateway endpoint,
+  so Bedrock inference, secret reads, image pulls, and log delivery stay on
+  the AWS backbone. The S3 gateway is what actually serves ECR image layer
+  blobs — the ECR interface endpoints only handle auth and manifests. The
+  bedrock-runtime endpoint is regional: cross-region inference
+  (`bedrockRegion` ≠ stack region) still egresses via NAT.
 - **Aurora PostgreSQL Serverless v2 (16.13)** — single writer scaling 0.5–2 ACU,
   storage-encrypted, 7-day backups, deleted with the stack (`RemovalPolicy.DESTROY`).
 - **Cognito User Pool** — self sign-up disabled, email sign-in, deleted with the

--- a/ai-coding-assistants/claude-apps-gateway-on-aws/docs/architecture.md
+++ b/ai-coding-assistants/claude-apps-gateway-on-aws/docs/architecture.md
@@ -55,7 +55,9 @@ starting the gateway login flow.
    policy) and forwards to the gateway tasks on port 8080. The ALB security group
    only allows 443 from `allowedClientCidrs`.
 3. The **ECS Fargate** gateway container runs the `claude gateway` server. The target
-   group health check hits `/readyz`; the container health check hits `/healthz`.
+   group and container health checks both hit `/healthz` (liveness) — `/readyz`
+   checks Postgres, and using it at the ALB would drain every replica during a
+   transient DB blip.
 4. Sign-in runs the **OIDC** authorization-code flow against the **Cognito User Pool**
    (hosted domain + confidential client). Only email domains in `allowedEmailDomains`
    are accepted.

--- a/ai-coding-assistants/claude-apps-gateway-on-aws/docs/operations.md
+++ b/ai-coding-assistants/claude-apps-gateway-on-aws/docs/operations.md
@@ -87,7 +87,9 @@ gateway URL, open the Cognito login flow, and complete the gateway session.
 
 **`/readyz` fails but `/healthz` works**
 - The gateway process is alive, but a dependency such as PostgreSQL, OIDC discovery,
-  or migrations is not ready.
+  or migrations is not ready. The ALB target group checks `/healthz` (liveness), so
+  the task stays in rotation and keeps serving requests that don't need the
+  unready dependency — this alone won't trigger the `UnhealthyHostAlarm`.
 - Check ECS task logs in the `LogGroupName` stack output.
 
 **Bedrock calls fail with authorization errors**

--- a/ai-coding-assistants/claude-apps-gateway-on-aws/lib/config.ts
+++ b/ai-coding-assistants/claude-apps-gateway-on-aws/lib/config.ts
@@ -17,6 +17,7 @@ export interface GatewayConfig {
   readonly desiredCount: number;
   readonly maxAzs: number;
   readonly natGateways: number;
+  readonly createVpcEndpoints: boolean;
 }
 
 // Placeholder defaults — set your real deployment values in cdk.context.json
@@ -38,7 +39,10 @@ export const defaultGatewayConfig: GatewayConfig = {
   databaseName: "claude_gateway",
   desiredCount: 2,
   maxAzs: 2,
-  natGateways: 1
+  natGateways: 1,
+  // Interface endpoints cost ~$0.01/AZ/hour each; set false to opt out and
+  // send AWS-service traffic through the NAT gateway instead.
+  createVpcEndpoints: true
 };
 
 type ConfigKeys<V> = {
@@ -58,6 +62,17 @@ export function loadGatewayConfig(app: cdk.App): GatewayConfig {
     }
     if (typeof value === "string" && value.trim() !== "") {
       return Number(value);
+    }
+    return defaultGatewayConfig[key];
+  };
+
+  const readBoolean = (key: ConfigKeys<boolean>): boolean => {
+    const value = app.node.tryGetContext(key);
+    if (typeof value === "boolean") {
+      return value;
+    }
+    if (typeof value === "string") {
+      return value.trim().toLowerCase() === "true";
     }
     return defaultGatewayConfig[key];
   };
@@ -90,6 +105,7 @@ export function loadGatewayConfig(app: cdk.App): GatewayConfig {
     databaseName: readString("databaseName"),
     desiredCount: readNumber("desiredCount"),
     maxAzs: readNumber("maxAzs"),
-    natGateways: readNumber("natGateways")
+    natGateways: readNumber("natGateways"),
+    createVpcEndpoints: readBoolean("createVpcEndpoints")
   };
 }

--- a/ai-coding-assistants/claude-apps-gateway-on-aws/lib/config.ts
+++ b/ai-coding-assistants/claude-apps-gateway-on-aws/lib/config.ts
@@ -7,6 +7,7 @@ export interface GatewayConfig {
   readonly hostedZoneName: string;
   readonly allowedClientCidrs: string[];
   readonly allowedEmailDomains: string[];
+  readonly availableModels: string[];
   readonly claudeVersion: string;
   readonly cognitoDomainPrefix: string;
   readonly bedrockRegion: string;
@@ -25,6 +26,10 @@ export const defaultGatewayConfig: GatewayConfig = {
   hostedZoneName: "corp.example.com",
   allowedClientCidrs: ["10.0.0.0/8"],
   allowedEmailDomains: ["corp.example.com"],
+  // Model allowlist rendered into managed.policies — keep in sync with the
+  // models you have actually enabled access for in Bedrock, or the picker
+  // offers models that fail with AccessDenied mid-conversation.
+  availableModels: ["claude-opus-4-8", "claude-sonnet-5", "claude-haiku-4-5", "claude-fable-5"],
   claudeVersion: "2.1.195",
   cognitoDomainPrefix: "claude-gateway-example",
   bedrockRegion: "us-east-1",
@@ -76,6 +81,7 @@ export function loadGatewayConfig(app: cdk.App): GatewayConfig {
     hostedZoneName: readString("hostedZoneName"),
     allowedClientCidrs: readStringArray("allowedClientCidrs"),
     allowedEmailDomains: readStringArray("allowedEmailDomains"),
+    availableModels: readStringArray("availableModels"),
     claudeVersion: readString("claudeVersion"),
     cognitoDomainPrefix: readString("cognitoDomainPrefix"),
     bedrockRegion: readString("bedrockRegion"),

--- a/ai-coding-assistants/claude-apps-gateway-on-aws/lib/gateway-stack.ts
+++ b/ai-coding-assistants/claude-apps-gateway-on-aws/lib/gateway-stack.ts
@@ -76,6 +76,49 @@ export class GatewayStack extends Stack {
       "ALB to gateway HTTP"
     );
 
+    // Interface + S3 gateway endpoints keep AWS-service traffic (Bedrock
+    // inference, secrets reads, image pulls, log delivery) on the AWS backbone
+    // instead of the NAT-to-internet path. The S3 gateway is required for ECR:
+    // the ecr.api/ecr.dkr endpoints serve auth and manifests, but layer blobs
+    // are fetched from S3. NAT stays for the Cognito OIDC leg, which has no
+    // VPC endpoint. Endpoints are regional: the bedrock-runtime endpoint only
+    // covers inference when bedrockRegion matches the stack region; cross-
+    // region Bedrock calls still egress via NAT. Opt out with
+    // createVpcEndpoints=false to trade the per-AZ-hour endpoint cost for NAT
+    // data charges.
+    if (config.createVpcEndpoints) {
+      const endpointSecurityGroup = new ec2.SecurityGroup(this, "VpcEndpointSecurityGroup", {
+        vpc,
+        description: "Allow only gateway tasks to reach VPC interface endpoints",
+        allowAllOutbound: true
+      });
+      endpointSecurityGroup.addIngressRule(
+        taskSecurityGroup,
+        ec2.Port.tcp(443),
+        "Gateway tasks to VPC endpoints"
+      );
+
+      const interfaceEndpoints: Array<[string, ec2.InterfaceVpcEndpointAwsService]> = [
+        ["BedrockRuntimeEndpoint", ec2.InterfaceVpcEndpointAwsService.BEDROCK_RUNTIME],
+        ["SecretsManagerEndpoint", ec2.InterfaceVpcEndpointAwsService.SECRETS_MANAGER],
+        ["EcrApiEndpoint", ec2.InterfaceVpcEndpointAwsService.ECR],
+        ["EcrDockerEndpoint", ec2.InterfaceVpcEndpointAwsService.ECR_DOCKER],
+        ["CloudWatchLogsEndpoint", ec2.InterfaceVpcEndpointAwsService.CLOUDWATCH_LOGS],
+        ["CloudWatchMonitoringEndpoint", ec2.InterfaceVpcEndpointAwsService.CLOUDWATCH_MONITORING]
+      ];
+      for (const [id, service] of interfaceEndpoints) {
+        vpc.addInterfaceEndpoint(id, {
+          service,
+          securityGroups: [endpointSecurityGroup],
+          privateDnsEnabled: true
+        });
+      }
+
+      vpc.addGatewayEndpoint("S3Endpoint", {
+        service: ec2.GatewayVpcEndpointAwsService.S3
+      });
+    }
+
     const databaseSecurityGroup = new ec2.SecurityGroup(this, "DatabaseSecurityGroup", {
       vpc,
       description: "Allow only gateway tasks to reach PostgreSQL",

--- a/ai-coding-assistants/claude-apps-gateway-on-aws/lib/gateway-stack.ts
+++ b/ai-coding-assistants/claude-apps-gateway-on-aws/lib/gateway-stack.ts
@@ -248,7 +248,11 @@ export class GatewayStack extends Stack {
       },
       circuitBreaker: {
         rollback: true
-      }
+      },
+      // Boot runs Postgres migrations before /healthz answers; without a grace
+      // period a slow cold start fails ALB health checks mid-rolling-deploy and
+      // trips the circuit breaker into a spurious rollback.
+      healthCheckGracePeriod: Duration.seconds(120)
     });
     // The gateway runs Postgres migrations at boot, so tasks crash-loop (and trip
     // the circuit breaker) if they start before the Aurora writer is available.
@@ -293,7 +297,11 @@ export class GatewayStack extends Stack {
       targets: [service],
       healthCheck: {
         enabled: true,
-        path: "/readyz",
+        // Liveness, not readiness: /readyz checks Postgres, so a transient DB
+        // blip would drain every replica from rotation at once even though
+        // bearer tokens still validate locally. /healthz only asserts the
+        // process is alive; the container health check covers the same path.
+        path: "/healthz",
         healthyHttpCodes: "200",
         interval: Duration.seconds(30),
         timeout: Duration.seconds(5),

--- a/ai-coding-assistants/claude-apps-gateway-on-aws/lib/gateway-stack.ts
+++ b/ai-coding-assistants/claude-apps-gateway-on-aws/lib/gateway-stack.ts
@@ -3,6 +3,7 @@ import * as cdk from "aws-cdk-lib";
 import { Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
 import { Construct } from "constructs";
 import * as certificatemanager from "aws-cdk-lib/aws-certificatemanager";
+import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
 import * as cognito from "aws-cdk-lib/aws-cognito";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as ecrAssets from "aws-cdk-lib/aws-ecr-assets";
@@ -309,6 +310,18 @@ export class GatewayStack extends Stack {
         unhealthyThresholdCount: 3
       },
       deregistrationDelay: Duration.seconds(30)
+    });
+
+    new cloudwatch.Alarm(this, "UnhealthyHostAlarm", {
+      alarmDescription: "One or more gateway tasks are failing the ALB /healthz check",
+      metric: targetGroup.metrics.unhealthyHostCount({
+        period: Duration.minutes(1),
+        statistic: "max"
+      }),
+      threshold: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      evaluationPeriods: 3,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING
     });
 
     // The private zone is scoped to the gateway FQDN itself (alias record at the

--- a/ai-coding-assistants/claude-apps-gateway-on-aws/lib/gateway-stack.ts
+++ b/ai-coding-assistants/claude-apps-gateway-on-aws/lib/gateway-stack.ts
@@ -274,7 +274,10 @@ export class GatewayStack extends Stack {
       vpcSubnets: {
         subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS
       },
-      idleTimeout: Duration.minutes(5)
+      // Long-running streaming responses go quiet between tokens; the 60s default
+      // (and anything short) drops them mid-stream. 3600s matches the upstream
+      // deployment guidance.
+      idleTimeout: Duration.seconds(3600)
     });
 
     const listener = loadBalancer.addListener("HttpsListener", {

--- a/ai-coding-assistants/claude-apps-gateway-on-aws/lib/gateway-stack.ts
+++ b/ai-coding-assistants/claude-apps-gateway-on-aws/lib/gateway-stack.ts
@@ -206,6 +206,7 @@ export class GatewayStack extends Stack {
         BEDROCK_REGION: config.bedrockRegion,
         CLAUDE_GATEWAY_LOG_LEVEL: "info",
         CLAUDE_VERSION: config.claudeVersion,
+        GATEWAY_AVAILABLE_MODELS: config.availableModels.join(","),
         GATEWAY_DB_HOST: database.clusterEndpoint.hostname,
         GATEWAY_DB_NAME: config.databaseName,
         GATEWAY_DB_PORT: cdk.Token.asString(database.clusterEndpoint.port),

--- a/ai-coding-assistants/claude-apps-gateway-on-aws/lib/gateway-stack.ts
+++ b/ai-coding-assistants/claude-apps-gateway-on-aws/lib/gateway-stack.ts
@@ -110,7 +110,10 @@ export class GatewayStack extends Stack {
         vpc.addInterfaceEndpoint(id, {
           service,
           securityGroups: [endpointSecurityGroup],
-          privateDnsEnabled: true
+          privateDnsEnabled: true,
+          // Suppress the default allow-from-VPC-CIDR ingress rule; only the
+          // task SG rule added above should reach the endpoints.
+          open: false
         });
       }
 

--- a/ai-coding-assistants/claude-apps-gateway-on-aws/scripts/validate-gateway-config.js
+++ b/ai-coding-assistants/claude-apps-gateway-on-aws/scripts/validate-gateway-config.js
@@ -19,6 +19,7 @@ const rendered = execFileSync(
       GATEWAY_DB_HOST: "gateway-db.example.internal",
       GATEWAY_DB_NAME: "claude_gateway",
       GATEWAY_DB_PORT: "5432",
+      GATEWAY_AVAILABLE_MODELS: "claude-opus-4-8,claude-sonnet-5",
       GATEWAY_PUBLIC_URL: "https://claude-gateway.corp.example.com",
       OIDC_ALLOWED_EMAIL_DOMAINS: "corp.example.com",
       OIDC_CLIENT_ID: "example-client-id",
@@ -35,7 +36,8 @@ const requiredPaths = [
   ["oidc", "client_secret"],
   ["session", "jwt_secret"],
   ["store", "postgres_url"],
-  ["upstreams", 0, "provider"]
+  ["upstreams", 0, "provider"],
+  ["managed", "policies", 0, "cli", "enforceAvailableModels"]
 ];
 
 for (const parts of requiredPaths) {
@@ -46,6 +48,11 @@ for (const parts of requiredPaths) {
   if (!cursor) {
     throw new Error(`Rendered gateway config is missing ${parts.join(".")}`);
   }
+}
+
+const availableModels = parsed.managed.policies[0].cli.availableModels;
+if (!Array.isArray(availableModels) || availableModels.length !== 2 || availableModels[0] !== "claude-opus-4-8") {
+  throw new Error(`managed.policies availableModels did not render as a list: ${JSON.stringify(availableModels)}`);
 }
 
 console.log("Rendered gateway.yaml is valid YAML.");

--- a/ai-coding-assistants/claude-apps-gateway-on-aws/test/gateway-stack.test.ts
+++ b/ai-coding-assistants/claude-apps-gateway-on-aws/test/gateway-stack.test.ts
@@ -115,6 +115,32 @@ describe("GatewayStack", () => {
     });
   });
 
+  test("creates interface endpoints and an S3 gateway endpoint for AWS-service traffic", () => {
+    // 6 interface endpoints (Bedrock Runtime, Secrets Manager, ECR api+dkr,
+    // Logs, Monitoring) + 1 S3 gateway endpoint.
+    template.resourceCountIs("AWS::EC2::VPCEndpoint", 7);
+    template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
+      ServiceName: "com.amazonaws.us-east-1.bedrock-runtime",
+      VpcEndpointType: "Interface",
+      PrivateDnsEnabled: true
+    });
+    template.hasResourceProperties("AWS::EC2::VPCEndpoint", {
+      VpcEndpointType: "Gateway"
+    });
+  });
+
+  test("omits VPC endpoints when createVpcEndpoints is false", () => {
+    const app = new cdk.App();
+    const stack = new GatewayStack(app, "TestGatewayStackNoEndpoints", {
+      env: {
+        account: "123456789012",
+        region: "us-east-1"
+      },
+      config: { ...testConfig, createVpcEndpoints: false }
+    });
+    Template.fromStack(stack).resourceCountIs("AWS::EC2::VPCEndpoint", 0);
+  });
+
   test("alarms on unhealthy target hosts", () => {
     template.hasResourceProperties("AWS::CloudWatch::Alarm", {
       MetricName: "UnHealthyHostCount",

--- a/ai-coding-assistants/claude-apps-gateway-on-aws/test/gateway-stack.test.ts
+++ b/ai-coding-assistants/claude-apps-gateway-on-aws/test/gateway-stack.test.ts
@@ -111,6 +111,16 @@ describe("GatewayStack", () => {
     });
   });
 
+  test("alarms on unhealthy target hosts", () => {
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "UnHealthyHostCount",
+      Namespace: "AWS/ApplicationELB",
+      ComparisonOperator: "GreaterThanOrEqualToThreshold",
+      Threshold: 1,
+      EvaluationPeriods: 3
+    });
+  });
+
   test("restricts ALB, ECS task, and database ingress ports", () => {
     template.hasResourceProperties("AWS::EC2::SecurityGroup", {
       GroupDescription: "Allow private-network HTTPS traffic to Claude Apps Gateway",

--- a/ai-coding-assistants/claude-apps-gateway-on-aws/test/gateway-stack.test.ts
+++ b/ai-coding-assistants/claude-apps-gateway-on-aws/test/gateway-stack.test.ts
@@ -57,6 +57,10 @@ describe("GatewayStack", () => {
               Value: "us-east-1"
             }),
             Match.objectLike({
+              Name: "GATEWAY_AVAILABLE_MODELS",
+              Value: testConfig.availableModels.join(",")
+            }),
+            Match.objectLike({
               Name: "GATEWAY_PUBLIC_URL",
               Value: `https://${testConfig.gatewayHost}`
             })


### PR DESCRIPTION
## What

A set of production-hardening improvements for the **Claude Apps Gateway on AWS** sample (`ai-coding-assistants/claude-apps-gateway-on-aws/`), covering ALB behavior for streaming workloads, health-check accuracy, observability, VPC network isolation, and configurable model access.

## Changes

Grouped by area (7 commits):

### ALB & health checks
- **Raise ALB idle timeout to 3600s** so long streaming responses aren't cut off mid-stream.
- **Use `/healthz` liveness for the ALB health check** and add a container **startup grace period**, so tasks aren't killed before they're ready.
- **Add the unhealthy-host CloudWatch alarm** that the docs already described but wasn't actually created in the stack.
- **Document** the ALB idle timeout, health-check grace period, and alarm behavior in the README, architecture, and operations docs.

### Model access
- **Render the `managed.policies` model allowlist from the `availableModels` context** instead of hardcoding it — the allowed-model list is now driven by CDK context and reflected in the gateway config rendering + validation.

### VPC network isolation
- **Add VPC interface endpoints and an S3 gateway endpoint** so AWS-service traffic stays on the VPC instead of egressing to the internet.
- **Restrict VPC endpoint ingress to the task security group only**, tightening endpoint access to least privilege.

## Testing

- Extends `test/gateway-stack.test.ts` with coverage for the new alarm, VPC endpoints, and model-allowlist rendering.
- Docs (README / architecture / operations) updated to match the implemented behavior.