### PR TITLE
fix(agentic-analytics): repair broken Strands docs links (/latest/ → /docs/)

### DIFF
--- a/agentic-workloads/agentic-analytics/README.md
+++ b/agentic-workloads/agentic-analytics/README.md
@@ -2,7 +2,7 @@
 
 A reference implementation and [AWS Workshop Studio](https://workshops.aws/) deployable for building AI-powered self-service analytics on multi-tenant SaaS. Business users ask questions in plain English — by **text or by voice** — the AI agent selects the right query, enforces security policies, and returns formatted insights, including **generated charts**.
 
-Built with [Amazon Bedrock AgentCore](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/what-is-bedrock-agentcore.html), [Strands Agents SDK](https://strandsagents.com/latest/), Aurora PostgreSQL, and Cedar policies.
+Built with [Amazon Bedrock AgentCore](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/what-is-bedrock-agentcore.html), [Strands Agents SDK](https://strandsagents.com/docs/), Aurora PostgreSQL, and Cedar policies.
 
 ## Architecture
 

--- a/agentic-workloads/agentic-analytics/workshop/content/01-agent-and-infrastructure/00-getting-started/index.en.md
+++ b/agentic-workloads/agentic-analytics/workshop/content/01-agent-and-infrastructure/00-getting-started/index.en.md
@@ -132,5 +132,5 @@ Next, you'll build your first AI agent → [Step 1: Build Your First Strands Age
 ## Reference Materials
 
 - [Amazon Bedrock AgentCore Documentation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/)
-- [Strands Agents SDK](https://strandsagents.com/latest/)
+- [Strands Agents SDK](https://strandsagents.com/docs/)
 - [Workshop Studio User Guide](https://catalog.workshops.aws/docs/en-US/)

--- a/agentic-workloads/agentic-analytics/workshop/content/01-agent-and-infrastructure/01-test-basic-agent/index.en.md
+++ b/agentic-workloads/agentic-analytics/workshop/content/01-agent-and-infrastructure/01-test-basic-agent/index.en.md
@@ -16,7 +16,7 @@ By the end of this step, you will:
 
 Your tenants need answers. Lyra Starwhisper at Mythical Unicorns wants to know her top customers by revenue — but she'd have to email the data team and wait half a day. As the Timely-Unicorn SaaS platform team, let's build something better for her and all of the future tenants with the same need.
 
-Before deploying to the cloud, it's important to understand how an AI agent works at its core. :link[Strands Agents]{href="https://strandsagents.com/latest/" external=true} is an open-source SDK from AWS that takes a :link[model-driven approach]{href="https://aws.amazon.com/blogs/opensource/strands-agents-and-the-model-driven-approach/" external=true} — instead of writing complex routing logic, you define tools and a prompt, and the LLM decides which tools to call and in what order.
+Before deploying to the cloud, it's important to understand how an AI agent works at its core. :link[Strands Agents]{href="https://strandsagents.com/docs/" external=true} is an open-source SDK from AWS that takes a :link[model-driven approach]{href="https://aws.amazon.com/blogs/opensource/strands-agents-and-the-model-driven-approach/" external=true} — instead of writing complex routing logic, you define tools and a prompt, and the LLM decides which tools to call and in what order.
 
 An agent has three components:
 
@@ -38,7 +38,7 @@ Open :code[exercises/basic_agent.py]{showCopyAction=true} in the Code Editor. Th
 
 ### Step 1.2: Configure the Bedrock Model (TODO 1.2)
 
-The agent needs a foundation model. Find `TODO 1.2` in `exercises/basic_agent.py` — replace `None` with a :link[BedrockModel]{href="https://strandsagents.com/latest/user-guide/concepts/model-providers/amazon-bedrock/" external=true} using the model ID and region already shown in the hint.
+The agent needs a foundation model. Find `TODO 1.2` in `exercises/basic_agent.py` — replace `None` with a :link[BedrockModel]{href="https://strandsagents.com/docs/user-guide/concepts/model-providers/amazon-bedrock/" external=true} using the model ID and region already shown in the hint.
 
 ::::expand{header="💡 Need help with TODO 1.2? Click to see the solution"}
 :::code{language=python showCopyAction=true}
@@ -65,7 +65,7 @@ One line. The docstring `"""Get the top customers by revenue..."""` already tell
 
 ### Step 1.4: Create the Agent (TODO 1.4)
 
-Wire the three components together. Find `TODO 1.4` — replace `None` with an :link[Agent]{href="https://strandsagents.com/latest/user-guide/concepts/agents/agent-loop/" external=true} using `bedrock_model`, a system prompt string, and `tools=[get_top_customers]`.
+Wire the three components together. Find `TODO 1.4` — replace `None` with an :link[Agent]{href="https://strandsagents.com/docs/user-guide/concepts/agents/agent-loop/" external=true} using `bedrock_model`, a system prompt string, and `tools=[get_top_customers]`.
 
 ::::expand{header="💡 Need help with TODO 1.4? Click to see the solution"}
 :::code{language=python showCopyAction=true}
@@ -151,7 +151,7 @@ Next, you'll move from a single machine deployment to a highly available deploym
 
 ## Reference Materials
 
-- [Strands Agents SDK Documentation](https://strandsagents.com/latest/)
-- [Strands Agents — Tools](https://strandsagents.com/latest/user-guide/concepts/tools/tools-overview/)
+- [Strands Agents SDK Documentation](https://strandsagents.com/docs/)
+- [Strands Agents — Tools](https://strandsagents.com/docs/user-guide/concepts/tools/)
 - [Amazon Bedrock Model Access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html)
-- [BedrockModel Configuration](https://strandsagents.com/latest/user-guide/concepts/model-providers/amazon-bedrock/)
+- [BedrockModel Configuration](https://strandsagents.com/docs/user-guide/concepts/model-providers/amazon-bedrock/)

--- a/agentic-workloads/agentic-analytics/workshop/content/01-agent-and-infrastructure/02-deploy-agent-infra/index.en.md
+++ b/agentic-workloads/agentic-analytics/workshop/content/01-agent-and-infrastructure/02-deploy-agent-infra/index.en.md
@@ -86,7 +86,7 @@ SYSTEM_PROMPT = load_system_prompt()
 
 #### TODO 2.3.2: Create the Agent
 
-Wire the components together. Find `TODO 2.3.2` — replace `None` with an :link[Agent]{href="https://strandsagents.com/latest/user-guide/concepts/agents/agent-loop/" external=true} constructor. Pass it `system_prompt` (the SOP you loaded in TODO 2.3.1) and `agent_tools` — both assembled for you just above. `agent_tools` includes the `mcp_client`, which is what connects the agent to the Gateway's MCP tools; the Gateway has no toolsets yet (you'll add them in later steps), but the wiring is in place. Leave `hooks=[]` for now — you'll switch it on in the next TODO.
+Wire the components together. Find `TODO 2.3.2` — replace `None` with an :link[Agent]{href="https://strandsagents.com/docs/user-guide/concepts/agents/agent-loop/" external=true} constructor. Pass it `system_prompt` (the SOP you loaded in TODO 2.3.1) and `agent_tools` — both assembled for you just above. `agent_tools` includes the `mcp_client`, which is what connects the agent to the Gateway's MCP tools; the Gateway has no toolsets yet (you'll add them in later steps), but the wiring is in place. Leave `hooks=[]` for now — you'll switch it on in the next TODO.
 
 ::::expand{header="💡 Need help with TODO 2.3.2? Click to see the solution"}
 :::code{language=python showCopyAction=true}
@@ -201,4 +201,4 @@ Next → [Step 3: Connect the Chat UI](../03-connect-ui/)
 - :link[AgentCore Gateway]{href="https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway.html"}
 - :link[AgentCore Runtime]{href="https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/agents-tools-runtime.html"}
 - :link[MCP Protocol]{href="https://modelcontextprotocol.io/docs/getting-started/intro" external=true}
-- :link[Strands Agents — MCP Client]{href="https://strandsagents.com/latest/user-guide/concepts/tools/mcp-tools/" external=true}
+- :link[Strands Agents — MCP Client]{href="https://strandsagents.com/docs/user-guide/concepts/tools/mcp-tools/" external=true}

--- a/agentic-workloads/agentic-analytics/workshop/content/02-toolsets/04-deploy-prebaked-sql/index.en.md
+++ b/agentic-workloads/agentic-analytics/workshop/content/02-toolsets/04-deploy-prebaked-sql/index.en.md
@@ -184,4 +184,4 @@ Next, you'll connect the agent to existing business APIs → [Step 5: Integrate 
 
 - :link[AgentCore Gateway — Adding Targets]{href="https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-building-adding-targets.html"}
 - :link[AgentCore Gateway — Tool Naming]{href="https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-tool-naming.html"}
-- :link[Strands Agents — Tools]{href="https://strandsagents.com/latest/user-guide/concepts/tools/tools-overview/" external=true}
+- :link[Strands Agents — Tools]{href="https://strandsagents.com/docs/user-guide/concepts/tools/" external=true}

--- a/agentic-workloads/agentic-analytics/workshop/content/02-toolsets/05-integrate-existing-apis/index.en.md
+++ b/agentic-workloads/agentic-analytics/workshop/content/02-toolsets/05-integrate-existing-apis/index.en.md
@@ -161,4 +161,4 @@ But right now, any user can create bookings. We'll fix this with AgentCore Polic
 ## Reference Materials
 
 - [AgentCore Gateway — Creating Targets](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-targets.html)
-- [Strands Agents — Tool Chaining](https://strandsagents.com/latest/user-guide/concepts/tools/tools-overview/)
+- [Strands Agents — Tool Chaining](https://strandsagents.com/docs/user-guide/concepts/tools/)

--- a/agentic-workloads/agentic-analytics/workshop/content/03-security-multitenancy-governance/08-guardrails/index.en.md
+++ b/agentic-workloads/agentic-analytics/workshop/content/03-security-multitenancy-governance/08-guardrails/index.en.md
@@ -149,4 +149,4 @@ Next, you'll learn to leverage observability to monitor your agent → [Step 9: 
 - [Amazon Bedrock Guardrails](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html)
 - [Bedrock Guardrails — Topic Filters](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-topic-filters.html)
 - [Bedrock Guardrails — Content Filters](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-content-filters.html)
-- [Strands Agents — Hooks](https://strandsagents.com/latest/user-guide/concepts/agents/hooks/)
+- [Strands Agents — Hooks](https://strandsagents.com/docs/user-guide/concepts/agents/hooks/)

--- a/agentic-workloads/agentic-analytics/workshop/content/03-security-multitenancy-governance/10-evaluation/index.en.md
+++ b/agentic-workloads/agentic-analytics/workshop/content/03-security-multitenancy-governance/10-evaluation/index.en.md
@@ -117,5 +117,5 @@ Next → [Summary & Next Steps](../../summary/)
 - :link[Built-in Evaluators]{href="https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/built-in-evaluators-overview.html"}
 - :link[On-Demand Evaluation Guide]{href="https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/getting-started-on-demand.html"}
 - :link[Online Evaluation Guide]{href="https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/create-online-evaluations.html"}
-- :link[Strands Agents Evals SDK]{href="https://strandsagents.com/latest/documentation/docs/user-guide/evals-sdk/quickstart/" external=true} (for test-dataset evaluation)
-- :link[Strands Evals — Output Evaluator]{href="https://strandsagents.com/latest/documentation/docs/user-guide/evals-sdk/evaluators/output_evaluator/" external=true}
+- :link[Strands Agents Evals SDK]{href="https://strandsagents.com/docs/user-guide/evals-sdk/quickstart/" external=true} (for test-dataset evaluation)
+- :link[Strands Evals — Output Evaluator]{href="https://strandsagents.com/docs/user-guide/evals-sdk/evaluators/output_evaluator/" external=true}

--- a/agentic-workloads/agentic-analytics/workshop/content/index.en.md
+++ b/agentic-workloads/agentic-analytics/workshop/content/index.en.md
@@ -9,7 +9,7 @@ Welcome! In this workshop, you'll build an AI assistant that lets business users
 
 This is **agentic data access** — an AI agent that understands your business context, selects the right database query, enforces security policies, and returns formatted insights. You'll build it step by step, starting with a simple local agent and progressively adding enterprise capabilities: centralized tool management, role-based access control, tenant data isolation for multi-tenant environment, content safety, and custom SQL with human approval.
 
-::alert[This workshop uses :link[Amazon Bedrock AgentCore]{href="https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/what-is-bedrock-agentcore.html"} and :link[Strands Agents SDK]{href="https://strandsagents.com/latest/"} — but the focus is on the **data access patterns**, not the tools The techniques you learn here apply to agentic analytics system in general.]{type="info"}
+::alert[This workshop uses :link[Amazon Bedrock AgentCore]{href="https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/what-is-bedrock-agentcore.html"} and :link[Strands Agents SDK]{href="https://strandsagents.com/docs/"} — but the focus is on the **data access patterns**, not the tools The techniques you learn here apply to agentic analytics system in general.]{type="info"}
 
 ## The Scenario: Timely-Unicorn
 

--- a/agentic-workloads/agentic-analytics/workshop/content/summary/index.en.md
+++ b/agentic-workloads/agentic-analytics/workshop/content/summary/index.en.md
@@ -76,7 +76,7 @@ The :link[SaaS Lens]{href="https://docs.aws.amazon.com/wellarchitected/latest/sa
 
 ### Learn More
 - :link[Amazon Bedrock AgentCore Documentation]{href="https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/"}
-- :link[Strands Agents SDK]{href="https://strandsagents.com/latest/" external=true}
+- :link[Strands Agents SDK]{href="https://strandsagents.com/docs/" external=true}
 - :link[AI Agents in Enterprises: Best Practices]{href="https://aws.amazon.com/blogs/machine-learning/ai-agents-in-enterprises-best-practices-with-amazon-bedrock-agentcore/" external=true}
 - :link[Dynamic Text-to-SQL for Enterprise Workloads]{href="https://aws.amazon.com/blogs/machine-learning/dynamic-text-to-sql-for-enterprise-workloads-with-amazon-bedrock-agents/" external=true}
 - :link[Cedar Policy Language]{href="https://www.cedarpolicy.com/" external=true}


### PR DESCRIPTION
## Problem
A customer running the **Agentic Analytics** workshop (feedback relayed via Aaron Su) reported a **broken link in Step 1.2 "Configure the Bedrock Model"**.

**Root cause:** the Strands Agents documentation site restructured its URLs — the `/latest/` path prefix has been retired (content now lives under `/docs/`), and the tools page leaf `tools/tools-overview/` is now just `tools/`. Every `strandsagents.com/latest/...` link in the workshop content returns 404. The customer only noticed the Step 1.2 one, but the same dead pattern appears across the workshop.

## Fix
Documentation-only change (10 markdown files; **no CFN or code changes**). Applied these transforms and **verified each resulting URL returns HTTP 200**:

| Rule | Example |
|---|---|
| `/latest/documentation/docs/` → `/docs/` | evals-sdk quickstart / output_evaluator |
| `/latest/` → `/docs/` | root, model-providers/amazon-bedrock, agents/agent-loop, agents/hooks, tools/mcp-tools |
| `.../tools/tools-overview/` → `.../tools/` | tools overview page |

## Files changed
README.md + 9 workshop content pages (getting-started, test-basic-agent, deploy-agent-infra, deploy-prebaked-sql, integrate-existing-apis, guardrails, evaluation, content index, summary).

## Testing
- Confirmed every old `/latest/` URL is 404 and every new `/docs/` URL is 200 (browser UA, redirects followed).
- Diff is pure URL substitution — surrounding prose unchanged (17 insertions / 17 deletions).