### PR TITLE
bedrock-image-url-bridge: convert http(s) image URLs to inline data URIs for Mantle and Runtime APIs

### DIFF
--- a/agentic-workloads/bedrock-image-url-bridge/.gitignore
+++ b/agentic-workloads/bedrock-image-url-bridge/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+*.egg-info/
+.pytest_cache/
+.venv/

--- a/agentic-workloads/bedrock-image-url-bridge/README.md
+++ b/agentic-workloads/bedrock-image-url-bridge/README.md
@@ -89,6 +89,10 @@ AWS_PROFILE=your-aws-profile AWS_REGION=us-east-1 BRIDGE_LIVE_TEST=1 \
 - **[docs/CACHING.md](./docs/CACHING.md)** -- the optional `session=`
   and `cache=` kwargs: connection pooling and URL-keyed result caching,
   both opt-in and no-ops when unused, both live-verified.
+- **[docs/PREPROCESSING.md](./docs/PREPROCESSING.md)** -- optional
+  client-side image resizing (OpenAI patch-mode / Anthropic tile-mode)
+  that cuts vision-token cost 88-96% on large images, via the
+  `preprocess=` hook, live-verified with a real Bedrock call.
 - **[docs/HOSTING.md](./docs/HOSTING.md)** -- where this runs: inline in
   an existing service, AWS Lambda, or a container/EC2 process.
 - **[docs/SCALING.md](./docs/SCALING.md)** -- concurrency patterns and a

--- a/agentic-workloads/bedrock-image-url-bridge/README.md
+++ b/agentic-workloads/bedrock-image-url-bridge/README.md
@@ -134,3 +134,30 @@ top: connection pooling (a shared `requests.Session`), a concurrency limit
 image is fetched repeatedly. None of that is included here deliberately --
 it adds real complexity and this sample's only job is to show the
 interception pattern clearly.
+
+## Alternative: use an AI gateway instead of a hand-rolled bridge
+
+If you're calling more than one model/provider and want this handled for
+you instead of maintaining `resolve_image_urls()` yourself, put an AI
+gateway in front of Bedrock and let it own image URL normalization:
+
+- **[LiteLLM](https://docs.litellm.ai/docs/proxy/architecture)** already
+  implements this exact pattern generically: it detects an `image_url` in
+  the request, checks whether the target provider accepts URLs natively,
+  and if not, downloads the image (capped at `MAX_IMAGE_URL_DOWNLOAD_SIZE_MB`,
+  50 MB by default), converts it to base64, and caches up to 10 converted
+  images in memory to cut latency on repeated calls. LiteLLM also has a
+  dedicated [Bedrock Mantle provider](https://docs.litellm.ai/docs/providers/bedrock_mantle),
+  so routing through it gets you the URL-handling fix plus routing,
+  fallbacks, retries, budgets, and spend tracking across every provider you
+  use, at the cost of running (and securing) an extra proxy service.
+- Any OpenAI-compatible gateway with similar "fetch-and-inline" middleware
+  (e.g. a custom API Gateway + Lambda layer) can apply the same idea --
+  the security guards in `bridge/core.py` (SSRF guard, size cap, format
+  verification) are exactly what such middleware needs regardless of
+  where it runs.
+
+Use this sample as-is when you want a single dependency-light function
+with no extra infrastructure. Reach for a gateway like LiteLLM when you're
+already managing multiple providers/models and want URL handling, routing,
+and cost tracking solved together instead of piecemeal.

--- a/agentic-workloads/bedrock-image-url-bridge/README.md
+++ b/agentic-workloads/bedrock-image-url-bridge/README.md
@@ -33,12 +33,17 @@ runs Python:
   just call `resolve_image_urls(payload)` before your existing Bedrock
   call. No new infrastructure at all. This is the expected case for most
   readers.
-- **AWS Lambda** -- see `examples/lambda_handler.py`: a complete handler
-  that accepts `{"image_url", "prompt", "model"}` (directly, or via an API
-  Gateway proxy `body`) and returns the model's answer. Deploy it with
-  whatever you already use for Lambda (SAM, CDK, Terraform, console zip) --
-  package `bridge/`, `requests`, and `Pillow` into the deployment artifact
-  (`boto3` ships with the Python runtime already), and grant the
+- **AWS Lambda** -- see `examples/lambda_handler.py`: a handler that
+  accepts the *exact* Chat Completions request schema
+  (`{"model": ..., "messages": [...]}`) and returns the *exact* Chat
+  Completions response JSON, unmodified. Point an existing OpenAI Chat
+  Completions client at this Lambda's Function URL / API Gateway
+  endpoint instead of at `bedrock-mantle` directly, and it works with no
+  request/response adaptation -- the only behavior added is resolving
+  `http(s)://` image URLs before the request reaches Bedrock. Deploy it
+  with whatever you already use for Lambda (SAM, CDK, Terraform, console
+  zip) -- package `bridge/`, `requests`, and `Pillow` into the deployment
+  artifact (`boto3` ships with the Python runtime already), and grant the
   function's execution role `bedrock:InvokeModel` for the model(s) you
   call.
 - **Container / ECS / EC2** -- same idea, just a normal Python process;
@@ -49,6 +54,17 @@ runs Python:
 In every case the guards in `bridge/core.py` run in the same process as
 the caller -- there's no separate bridge process to secure, scale, or
 monitor independently of your own application.
+
+### Why schema fidelity matters
+
+Every example in this repo -- including the Lambda handler -- takes and
+returns the *exact* request/response shape of the API it's fronting
+(Chat Completions in, Chat Completions out; Responses API in, Responses
+API out). The bridge never introduces a custom envelope. That's what
+makes migration a drop-in change: swap the base URL your client points
+at, keep the client code and its request/response parsing exactly as
+is, and image URLs that would otherwise 400 against `bedrock-mantle`
+just work.
 
 ## Quick start
 
@@ -152,11 +168,22 @@ export AWS_REGION=us-east-1
 python -c "
 from examples.lambda_handler import handler
 print(handler({
-    'image_url': 'https://placehold.co/64x64.jpg',
-    'prompt': 'Describe this image in one sentence.',
+    'model': 'qwen.qwen3-vl-235b-a22b-instruct',
+    'messages': [
+        {'role': 'user', 'content': [
+            {'type': 'text', 'text': 'Describe this image in one sentence.'},
+            {'type': 'image_url', 'image_url': {'url': 'https://placehold.co/64x64.jpg'}},
+        ]}
+    ],
 }, None))
 "
 ```
+
+The input is a standard Chat Completions request body; the output is a
+standard Chat Completions response body wrapped in an API-Gateway-proxy
+envelope (`statusCode`/`headers`/`body`). Errors follow the OpenAI error
+shape (`{"error": {"message", "type"}}`) so client-side error handling
+needs no changes either.
 
 To actually deploy it, zip up `bridge/`, `examples/lambda_handler.py`,
 `examples/mantle_chat_completions.py`, `requests`, and `Pillow` (boto3 is

--- a/agentic-workloads/bedrock-image-url-bridge/README.md
+++ b/agentic-workloads/bedrock-image-url-bridge/README.md
@@ -1,0 +1,136 @@
+# bedrock-image-url-bridge
+
+**Problem:** Amazon Bedrock's OpenAI-compatible `bedrock-mantle` endpoint (Chat
+Completions / Responses APIs) rejects a plain `https://` `image_url` value.
+Verified live against a real account:
+
+```json
+{"error":{"code":"validation_error","message":"Only inline image data URLs and S3 URLs are supported.","type":"invalid_request_error"}}
+```
+
+It *does* accept `s3://bucket/key` (fetched server-side) and `data:<mime>;base64,...`
+URIs natively. The native `bedrock-runtime` Converse API is stricter still: it has
+no `image_url` concept at all -- only raw bytes.
+
+**Solution:** `resolve_image_urls()` walks a request payload and rewrites only
+the `http(s)://` image URLs into inline `data:` URIs. `s3://` and `data:` URIs
+pass through untouched. One function, no server, no cache -- copy it into your
+own code.
+
+## Quick start
+
+```python
+from bridge import resolve_image_urls
+
+payload = {
+    "messages": [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe this image."},
+                {"type": "image_url", "image_url": {"url": "https://example.com/cat.jpg"}},
+            ],
+        }
+    ]
+}
+
+payload = resolve_image_urls(payload)  # http(s) url -> inline data: URI
+# ... send payload to bedrock-mantle as before
+```
+
+## Security guards (and why)
+
+- **HTTPS-only by default** -- plain `http://` is rejected unless you pass
+  `allow_insecure_http=True` (local testing only). Avoids sending requests
+  in the clear.
+- **SSRF guard** -- the hostname is resolved and the IP checked *before*
+  connecting. Loopback, private, link-local, and the cloud metadata address
+  (`169.254.169.254`) are all blocked. Without this, an attacker-supplied
+  URL could make your server fetch its own internal endpoints or cloud
+  credentials.
+- **Size cap** (`max_bytes`, default 20 MiB) -- enforced against both the
+  `Content-Length` header and the actual streamed byte count, whichever
+  hits first. Stops a malicious or misconfigured host from exhausting
+  memory with an unbounded response.
+- **Bounded, re-validated redirects** (max 2 hops) -- each redirect target
+  is re-checked against the same scheme/SSRF guard, so a redirect can't be
+  used to smuggle a request past the guard.
+- **Real format verification** -- downloaded bytes are verified with
+  Pillow's `Image.verify()` and the mime type is derived from the verified
+  format, never from the URL extension or a server-supplied
+  `Content-Type` header (both can lie).
+
+## Examples
+
+Three example endpoints, all using the same `resolve_image_urls()` bridge:
+
+| Example | Endpoint | Image URL handling before the bridge |
+|---|---|---|
+| `examples/mantle_chat_completions.py` | `bedrock-mantle` `/v1/chat/completions` | rejects https, accepts s3/data |
+| `examples/mantle_responses_api.py` | `bedrock-mantle` `/v1/responses` | rejects https, accepts s3/data |
+| `examples/runtime_converse.py` | `bedrock-runtime` Converse | no URL support at all -- bytes only |
+
+**Live-verified status** (region us-east-1, profile `agentcore-deploy`):
+- `mantle_chat_completions.py` -- verified end to end with a real vision
+  model (`qwen.qwen3-vl-235b-a22b-instruct`).
+- `runtime_converse.py` -- verified end to end with
+  `us.anthropic.claude-haiku-4-5-20251001-v1:0`.
+- `mantle_responses_api.py` -- the bridge output is schema-correct and
+  the payload passes Mantle's request validation, but as of this
+  writing no model in this account that supports the `/v1/responses`
+  API is also vision-capable: `openai.gpt-oss-120b` supports
+  `/v1/responses` per AWS's [API compatibility table](https://docs.aws.amazon.com/bedrock/latest/userguide/models-api-compatibility.html)
+  but is text-only, so it accepts an `input_image` block at the schema
+  level and then fails at inference time with a generic
+  `server_error`. `qwen3-vl` (the vision model used above) does not
+  support `/v1/responses` at all. This is a model-availability gap on
+  AWS's side, not a bug in the bridge -- re-check the compatibility
+  table as new models ship, and swap `--model` once a vision + Responses
+  API combination is available.
+
+### Run a demo
+
+```bash
+export AWS_PROFILE=agentcore-deploy
+export AWS_REGION=us-east-1
+
+python -m examples.mantle_chat_completions \
+  --image-url https://placehold.co/64x64.jpg \
+  --prompt "Describe this image in one sentence." \
+  --model qwen.qwen3-vl-235b-a22b-instruct
+
+python -m examples.mantle_responses_api \
+  --image-url https://placehold.co/64x64.jpg \
+  --prompt "Describe this image in one sentence."
+
+python -m examples.runtime_converse \
+  --image-url https://placehold.co/64x64.jpg \
+  --prompt "Describe this image in one sentence." \
+  --model anthropic.claude-haiku-4-5
+```
+
+## Run tests
+
+```bash
+pip install -e ".[dev]"
+
+# unit tests -- no network, no AWS calls
+pytest tests/test_bridge_unit.py -v
+
+# live tests -- real calls against bedrock-mantle and bedrock-runtime
+AWS_PROFILE=agentcore-deploy AWS_REGION=us-east-1 BRIDGE_LIVE_TEST=1 \
+  pytest tests/test_bridge_live.py -v
+```
+
+## Scaling notes
+
+This sample is intentionally synchronous, per-request, and uncached --
+that's what makes the interception pattern easy to read. It's directly
+usable as-is in a Lambda handler or any single-request context.
+
+For high-volume or highly concurrent image fetching, add your own layer on
+top: connection pooling (a shared `requests.Session`), a concurrency limit
+(semaphore or thread pool bound), and a cache keyed on URL if the same
+image is fetched repeatedly. None of that is included here deliberately --
+it adds real complexity and this sample's only job is to show the
+interception pattern clearly.

--- a/agentic-workloads/bedrock-image-url-bridge/README.md
+++ b/agentic-workloads/bedrock-image-url-bridge/README.md
@@ -70,7 +70,7 @@ Three example endpoints, all using the same `resolve_image_urls()` bridge:
 | `examples/mantle_responses_api.py` | `bedrock-mantle` `/v1/responses` | rejects https, accepts s3/data |
 | `examples/runtime_converse.py` | `bedrock-runtime` Converse | no URL support at all -- bytes only |
 
-**Live-verified status** (region us-east-1, profile `agentcore-deploy`):
+**Live-verified status** (region us-east-1):
 - `mantle_chat_completions.py` -- verified end to end with a real vision
   model (`qwen.qwen3-vl-235b-a22b-instruct`).
 - `runtime_converse.py` -- verified end to end with
@@ -91,7 +91,7 @@ Three example endpoints, all using the same `resolve_image_urls()` bridge:
 ### Run a demo
 
 ```bash
-export AWS_PROFILE=agentcore-deploy
+export AWS_PROFILE=your-aws-profile
 export AWS_REGION=us-east-1
 
 python -m examples.mantle_chat_completions \
@@ -118,7 +118,7 @@ pip install -e ".[dev]"
 pytest tests/test_bridge_unit.py -v
 
 # live tests -- real calls against bedrock-mantle and bedrock-runtime
-AWS_PROFILE=agentcore-deploy AWS_REGION=us-east-1 BRIDGE_LIVE_TEST=1 \
+AWS_PROFILE=your-aws-profile AWS_REGION=us-east-1 BRIDGE_LIVE_TEST=1 \
   pytest tests/test_bridge_live.py -v
 ```
 

--- a/agentic-workloads/bedrock-image-url-bridge/README.md
+++ b/agentic-workloads/bedrock-image-url-bridge/README.md
@@ -1,70 +1,19 @@
 # bedrock-image-url-bridge
 
-**Problem:** Amazon Bedrock's OpenAI-compatible `bedrock-mantle` endpoint (Chat
-Completions / Responses APIs) rejects a plain `https://` `image_url` value.
-Verified live against a real account:
+**Problem:** Amazon Bedrock's OpenAI-compatible `bedrock-mantle` endpoint
+(Chat Completions / Responses APIs) rejects a plain `https://` `image_url`:
 
 ```json
 {"error":{"code":"validation_error","message":"Only inline image data URLs and S3 URLs are supported.","type":"invalid_request_error"}}
 ```
 
-It *does* accept `s3://bucket/key` (fetched server-side) and `data:<mime>;base64,...`
-URIs natively. The native `bedrock-runtime` Converse API is stricter still: it has
-no `image_url` concept at all -- only raw bytes.
+It accepts `s3://bucket/key` and `data:<mime>;base64,...` natively. The
+native `bedrock-runtime` Converse API is stricter still: no URL concept
+at all, only raw bytes.
 
-**Solution:** `resolve_image_urls()` walks a request payload and rewrites only
-the `http(s)://` image URLs into inline `data:` URIs. `s3://` and `data:` URIs
-pass through untouched. One function, no server, no cache -- copy it into your
-own code.
-
-## How this is hosted / how you use it
-
-**The bridge is not a service you deploy.** `resolve_image_urls()` is a plain
-Python function with no state and no listening port. You call it inline,
-wherever your code already builds a Bedrock request, right before sending
-that request. There is nothing to run continuously and nothing to keep
-alive -- copy `bridge/core.py` into your project (or `pip install -e .`
-this directory as a local editable dependency) and import it.
-
-What you host is *your own calling code* -- and that can be anything that
-runs Python:
-
-- **Already-running service** (existing API, worker, notebook, CLI) --
-  just call `resolve_image_urls(payload)` before your existing Bedrock
-  call. No new infrastructure at all. This is the expected case for most
-  readers.
-- **AWS Lambda** -- see `examples/lambda_handler.py`: a handler that
-  accepts the *exact* Chat Completions request schema
-  (`{"model": ..., "messages": [...]}`) and returns the *exact* Chat
-  Completions response JSON, unmodified. Point an existing OpenAI Chat
-  Completions client at this Lambda's Function URL / API Gateway
-  endpoint instead of at `bedrock-mantle` directly, and it works with no
-  request/response adaptation -- the only behavior added is resolving
-  `http(s)://` image URLs before the request reaches Bedrock. Deploy it
-  with whatever you already use for Lambda (SAM, CDK, Terraform, console
-  zip) -- package `bridge/`, `requests`, and `Pillow` into the deployment
-  artifact (`boto3` ships with the Python runtime already), and grant the
-  function's execution role `bedrock:InvokeModel` for the model(s) you
-  call.
-- **Container / ECS / EC2** -- same idea, just a normal Python process;
-  `examples/mantle_chat_completions.py` and the other example scripts are
-  runnable as-is and show the exact call shape to wrap in your own
-  service.
-
-In every case the guards in `bridge/core.py` run in the same process as
-the caller -- there's no separate bridge process to secure, scale, or
-monitor independently of your own application.
-
-### Why schema fidelity matters
-
-Every example in this repo -- including the Lambda handler -- takes and
-returns the *exact* request/response shape of the API it's fronting
-(Chat Completions in, Chat Completions out; Responses API in, Responses
-API out). The bridge never introduces a custom envelope. That's what
-makes migration a drop-in change: swap the base URL your client points
-at, keep the client code and its request/response parsing exactly as
-is, and image URLs that would otherwise 400 against `bedrock-mantle`
-just work.
+**Solution:** `resolve_image_urls()` rewrites only `http(s)://` image
+URLs into inline `data:` URIs. `s3://` and `data:` pass through
+untouched. One function, no server -- copy it into your own code.
 
 ## Quick start
 
@@ -87,56 +36,23 @@ payload = resolve_image_urls(payload)  # http(s) url -> inline data: URI
 # ... send payload to bedrock-mantle as before
 ```
 
-## Security guards (and why)
-
-- **HTTPS-only by default** -- plain `http://` is rejected unless you pass
-  `allow_insecure_http=True` (local testing only). Avoids sending requests
-  in the clear.
-- **SSRF guard** -- the hostname is resolved and the IP checked *before*
-  connecting. Loopback, private, link-local, and the cloud metadata address
-  (`169.254.169.254`) are all blocked. Without this, an attacker-supplied
-  URL could make your server fetch its own internal endpoints or cloud
-  credentials.
-- **Size cap** (`max_bytes`, default 20 MiB) -- enforced against both the
-  `Content-Length` header and the actual streamed byte count, whichever
-  hits first. Stops a malicious or misconfigured host from exhausting
-  memory with an unbounded response.
-- **Bounded, re-validated redirects** (max 2 hops) -- each redirect target
-  is re-checked against the same scheme/SSRF guard, so a redirect can't be
-  used to smuggle a request past the guard.
-- **Real format verification** -- downloaded bytes are verified with
-  Pillow's `Image.verify()` and the mime type is derived from the verified
-  format, never from the URL extension or a server-supplied
-  `Content-Type` header (both can lie).
+Every example -- including the Lambda handler -- mimics the *exact*
+request/response schema of the API it fronts, so pointing an existing
+client at it is a base-URL swap, not a rewrite. See
+[docs/MIGRATION.md](./docs/MIGRATION.md).
 
 ## Examples
 
-Four example entry points, all using the same `resolve_image_urls()` bridge:
+| Example | Endpoint / hosting shape |
+|---|---|
+| `examples/mantle_chat_completions.py` | `bedrock-mantle` `/v1/chat/completions`, CLI script |
+| `examples/mantle_responses_api.py` | `bedrock-mantle` `/v1/responses`, CLI script |
+| `examples/runtime_converse.py` | native `bedrock-runtime` Converse, CLI script |
+| `examples/lambda_handler.py` | AWS Lambda handler, schema-faithful to Chat Completions |
 
-| Example | Endpoint / hosting shape | Image URL handling before the bridge |
-|---|---|---|
-| `examples/mantle_chat_completions.py` | `bedrock-mantle` `/v1/chat/completions`, runnable CLI script | rejects https, accepts s3/data |
-| `examples/mantle_responses_api.py` | `bedrock-mantle` `/v1/responses`, runnable CLI script | rejects https, accepts s3/data |
-| `examples/runtime_converse.py` | `bedrock-runtime` Converse, runnable CLI script | no URL support at all -- bytes only |
-| `examples/lambda_handler.py` | AWS Lambda handler (same Chat Completions call, wrapped for `event`/`context`) | rejects https, accepts s3/data |
-
-**Live-verified status** (region us-east-1):
-- `mantle_chat_completions.py` -- verified end to end with a real vision
-  model (`qwen.qwen3-vl-235b-a22b-instruct`).
-- `runtime_converse.py` -- verified end to end with
-  `us.anthropic.claude-haiku-4-5-20251001-v1:0`.
-- `mantle_responses_api.py` -- the bridge output is schema-correct and
-  the payload passes Mantle's request validation, but as of this
-  writing no model in this account that supports the `/v1/responses`
-  API is also vision-capable: `openai.gpt-oss-120b` supports
-  `/v1/responses` per AWS's [API compatibility table](https://docs.aws.amazon.com/bedrock/latest/userguide/models-api-compatibility.html)
-  but is text-only, so it accepts an `input_image` block at the schema
-  level and then fails at inference time with a generic
-  `server_error`. `qwen3-vl` (the vision model used above) does not
-  support `/v1/responses` at all. This is a model-availability gap on
-  AWS's side, not a bug in the bridge -- re-check the compatibility
-  table as new models ship, and swap `--model` once a vision + Responses
-  API combination is available.
+All live-verified against a real AWS account (region `us-east-1`) --
+see [docs/MIGRATION.md](./docs/MIGRATION.md) for per-example status and a
+live-discovered model-availability gap on the Responses API path.
 
 ### Run a demo
 
@@ -148,48 +64,10 @@ python -m examples.mantle_chat_completions \
   --image-url https://placehold.co/64x64.jpg \
   --prompt "Describe this image in one sentence." \
   --model qwen.qwen3-vl-235b-a22b-instruct
-
-python -m examples.mantle_responses_api \
-  --image-url https://placehold.co/64x64.jpg \
-  --prompt "Describe this image in one sentence."
-
-python -m examples.runtime_converse \
-  --image-url https://placehold.co/64x64.jpg \
-  --prompt "Describe this image in one sentence." \
-  --model anthropic.claude-haiku-4-5
 ```
 
-### Try the Lambda handler locally (no deployment needed)
-
-```bash
-export AWS_PROFILE=your-aws-profile
-export AWS_REGION=us-east-1
-
-python -c "
-from examples.lambda_handler import handler
-print(handler({
-    'model': 'qwen.qwen3-vl-235b-a22b-instruct',
-    'messages': [
-        {'role': 'user', 'content': [
-            {'type': 'text', 'text': 'Describe this image in one sentence.'},
-            {'type': 'image_url', 'image_url': {'url': 'https://placehold.co/64x64.jpg'}},
-        ]}
-    ],
-}, None))
-"
-```
-
-The input is a standard Chat Completions request body; the output is a
-standard Chat Completions response body wrapped in an API-Gateway-proxy
-envelope (`statusCode`/`headers`/`body`). Errors follow the OpenAI error
-shape (`{"error": {"message", "type"}}`) so client-side error handling
-needs no changes either.
-
-To actually deploy it, zip up `bridge/`, `examples/lambda_handler.py`,
-`examples/mantle_chat_completions.py`, `requests`, and `Pillow` (boto3 is
-already in the Lambda Python runtime) and create a Lambda function with
-`examples.lambda_handler.handler` as the entry point. Grant its execution
-role `bedrock:InvokeModel`.
+Try the Lambda handler locally (no deployment needed) and see how to
+deploy it: [docs/HOSTING.md](./docs/HOSTING.md).
 
 ## Run tests
 
@@ -204,42 +82,18 @@ AWS_PROFILE=your-aws-profile AWS_REGION=us-east-1 BRIDGE_LIVE_TEST=1 \
   pytest tests/test_bridge_live.py -v
 ```
 
-## Scaling notes
+## Docs
 
-This sample is intentionally synchronous, per-request, and uncached --
-that's what makes the interception pattern easy to read. It's directly
-usable as-is in a Lambda handler or any single-request context.
-
-For high-volume or highly concurrent image fetching, add your own layer on
-top: connection pooling (a shared `requests.Session`), a concurrency limit
-(semaphore or thread pool bound), and a cache keyed on URL if the same
-image is fetched repeatedly. None of that is included here deliberately --
-it adds real complexity and this sample's only job is to show the
-interception pattern clearly.
-
-## Alternative: use an AI gateway instead of a hand-rolled bridge
-
-If you're calling more than one model/provider and want this handled for
-you instead of maintaining `resolve_image_urls()` yourself, put an AI
-gateway in front of Bedrock and let it own image URL normalization:
-
-- **[LiteLLM](https://docs.litellm.ai/docs/proxy/architecture)** already
-  implements this exact pattern generically: it detects an `image_url` in
-  the request, checks whether the target provider accepts URLs natively,
-  and if not, downloads the image (capped at `MAX_IMAGE_URL_DOWNLOAD_SIZE_MB`,
-  50 MB by default), converts it to base64, and caches up to 10 converted
-  images in memory to cut latency on repeated calls. LiteLLM also has a
-  dedicated [Bedrock Mantle provider](https://docs.litellm.ai/docs/providers/bedrock_mantle),
-  so routing through it gets you the URL-handling fix plus routing,
-  fallbacks, retries, budgets, and spend tracking across every provider you
-  use, at the cost of running (and securing) an extra proxy service.
-- Any OpenAI-compatible gateway with similar "fetch-and-inline" middleware
-  (e.g. a custom API Gateway + Lambda layer) can apply the same idea --
-  the security guards in `bridge/core.py` (SSRF guard, size cap, format
-  verification) are exactly what such middleware needs regardless of
-  where it runs.
-
-Use this sample as-is when you want a single dependency-light function
-with no extra infrastructure. Reach for a gateway like LiteLLM when you're
-already managing multiple providers/models and want URL handling, routing,
-and cost tracking solved together instead of piecemeal.
+- **[docs/SECURITY.md](./docs/SECURITY.md)** -- the security guards
+  (SSRF, size cap, redirects, format verification) and why each exists.
+- **[docs/CACHING.md](./docs/CACHING.md)** -- the optional `session=`
+  and `cache=` kwargs: connection pooling and URL-keyed result caching,
+  both opt-in and no-ops when unused, both live-verified.
+- **[docs/HOSTING.md](./docs/HOSTING.md)** -- where this runs: inline in
+  an existing service, AWS Lambda, or a container/EC2 process.
+- **[docs/SCALING.md](./docs/SCALING.md)** -- concurrency patterns and a
+  real cost breakdown (S3/Lambda/model-inference pricing) at volume.
+- **[docs/MIGRATION.md](./docs/MIGRATION.md)** -- per-example
+  schema-fidelity notes and the Responses API model-availability gap.
+- **[docs/ALTERNATIVES.md](./docs/ALTERNATIVES.md)** -- when to reach
+  for an AI gateway like LiteLLM instead of this sample.

--- a/agentic-workloads/bedrock-image-url-bridge/README.md
+++ b/agentic-workloads/bedrock-image-url-bridge/README.md
@@ -17,6 +17,39 @@ the `http(s)://` image URLs into inline `data:` URIs. `s3://` and `data:` URIs
 pass through untouched. One function, no server, no cache -- copy it into your
 own code.
 
+## How this is hosted / how you use it
+
+**The bridge is not a service you deploy.** `resolve_image_urls()` is a plain
+Python function with no state and no listening port. You call it inline,
+wherever your code already builds a Bedrock request, right before sending
+that request. There is nothing to run continuously and nothing to keep
+alive -- copy `bridge/core.py` into your project (or `pip install -e .`
+this directory as a local editable dependency) and import it.
+
+What you host is *your own calling code* -- and that can be anything that
+runs Python:
+
+- **Already-running service** (existing API, worker, notebook, CLI) --
+  just call `resolve_image_urls(payload)` before your existing Bedrock
+  call. No new infrastructure at all. This is the expected case for most
+  readers.
+- **AWS Lambda** -- see `examples/lambda_handler.py`: a complete handler
+  that accepts `{"image_url", "prompt", "model"}` (directly, or via an API
+  Gateway proxy `body`) and returns the model's answer. Deploy it with
+  whatever you already use for Lambda (SAM, CDK, Terraform, console zip) --
+  package `bridge/`, `requests`, and `Pillow` into the deployment artifact
+  (`boto3` ships with the Python runtime already), and grant the
+  function's execution role `bedrock:InvokeModel` for the model(s) you
+  call.
+- **Container / ECS / EC2** -- same idea, just a normal Python process;
+  `examples/mantle_chat_completions.py` and the other example scripts are
+  runnable as-is and show the exact call shape to wrap in your own
+  service.
+
+In every case the guards in `bridge/core.py` run in the same process as
+the caller -- there's no separate bridge process to secure, scale, or
+monitor independently of your own application.
+
 ## Quick start
 
 ```python
@@ -62,13 +95,14 @@ payload = resolve_image_urls(payload)  # http(s) url -> inline data: URI
 
 ## Examples
 
-Three example endpoints, all using the same `resolve_image_urls()` bridge:
+Four example entry points, all using the same `resolve_image_urls()` bridge:
 
-| Example | Endpoint | Image URL handling before the bridge |
+| Example | Endpoint / hosting shape | Image URL handling before the bridge |
 |---|---|---|
-| `examples/mantle_chat_completions.py` | `bedrock-mantle` `/v1/chat/completions` | rejects https, accepts s3/data |
-| `examples/mantle_responses_api.py` | `bedrock-mantle` `/v1/responses` | rejects https, accepts s3/data |
-| `examples/runtime_converse.py` | `bedrock-runtime` Converse | no URL support at all -- bytes only |
+| `examples/mantle_chat_completions.py` | `bedrock-mantle` `/v1/chat/completions`, runnable CLI script | rejects https, accepts s3/data |
+| `examples/mantle_responses_api.py` | `bedrock-mantle` `/v1/responses`, runnable CLI script | rejects https, accepts s3/data |
+| `examples/runtime_converse.py` | `bedrock-runtime` Converse, runnable CLI script | no URL support at all -- bytes only |
+| `examples/lambda_handler.py` | AWS Lambda handler (same Chat Completions call, wrapped for `event`/`context`) | rejects https, accepts s3/data |
 
 **Live-verified status** (region us-east-1):
 - `mantle_chat_completions.py` -- verified end to end with a real vision
@@ -109,13 +143,34 @@ python -m examples.runtime_converse \
   --model anthropic.claude-haiku-4-5
 ```
 
+### Try the Lambda handler locally (no deployment needed)
+
+```bash
+export AWS_PROFILE=your-aws-profile
+export AWS_REGION=us-east-1
+
+python -c "
+from examples.lambda_handler import handler
+print(handler({
+    'image_url': 'https://placehold.co/64x64.jpg',
+    'prompt': 'Describe this image in one sentence.',
+}, None))
+"
+```
+
+To actually deploy it, zip up `bridge/`, `examples/lambda_handler.py`,
+`examples/mantle_chat_completions.py`, `requests`, and `Pillow` (boto3 is
+already in the Lambda Python runtime) and create a Lambda function with
+`examples.lambda_handler.handler` as the entry point. Grant its execution
+role `bedrock:InvokeModel`.
+
 ## Run tests
 
 ```bash
 pip install -e ".[dev]"
 
 # unit tests -- no network, no AWS calls
-pytest tests/test_bridge_unit.py -v
+pytest tests/test_bridge_unit.py tests/test_lambda_handler.py -v
 
 # live tests -- real calls against bedrock-mantle and bedrock-runtime
 AWS_PROFILE=your-aws-profile AWS_REGION=us-east-1 BRIDGE_LIVE_TEST=1 \

--- a/agentic-workloads/bedrock-image-url-bridge/bridge/__init__.py
+++ b/agentic-workloads/bedrock-image-url-bridge/bridge/__init__.py
@@ -2,5 +2,11 @@
 Bedrock's OpenAI-compatible (mantle) and native (runtime) APIs.
 """
 from .core import resolve_image_urls
+from .preprocess import preprocess_images, preprocess_patch_mode, preprocess_tile_mode
 
-__all__ = ["resolve_image_urls"]
+__all__ = [
+    "resolve_image_urls",
+    "preprocess_patch_mode",
+    "preprocess_tile_mode",
+    "preprocess_images",
+]

--- a/agentic-workloads/bedrock-image-url-bridge/bridge/__init__.py
+++ b/agentic-workloads/bedrock-image-url-bridge/bridge/__init__.py
@@ -1,0 +1,6 @@
+"""bedrock-image-url-bridge: make http(s) image URLs safe to send to
+Bedrock's OpenAI-compatible (mantle) and native (runtime) APIs.
+"""
+from .core import resolve_image_urls
+
+__all__ = ["resolve_image_urls"]

--- a/agentic-workloads/bedrock-image-url-bridge/bridge/core.py
+++ b/agentic-workloads/bedrock-image-url-bridge/bridge/core.py
@@ -24,7 +24,7 @@ import io
 import ipaddress
 import socket
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urljoin
 
 import requests
 from PIL import Image, UnidentifiedImageError
@@ -93,17 +93,25 @@ def _download_image_bytes(
             resp.close()
             if not location:
                 raise ValueError(f"Redirect from {current_url!r} had no Location header")
-            current_url = location
+            current_url = urljoin(current_url, location)
             continue
 
         resp.raise_for_status()
 
         content_length = resp.headers.get("Content-Length")
-        if content_length is not None and int(content_length) > max_bytes:
-            resp.close()
-            raise ValueError(
-                f"Refusing download from {current_url!r}: "
-                f"Content-Length {content_length} exceeds max_bytes={max_bytes}"
+        if content_length is not None:
+            try:
+                content_length_int = int(content_length)
+            except ValueError:
+                resp.close()
+                raise ValueError(
+                    f"Malformed Content-Length header from {current_url!r}: {content_length!r}"
+                )
+            if content_length_int > max_bytes:
+                resp.close()
+                raise ValueError(
+                    f"Refusing download from {current_url!r}: "
+                    f"Content-Length {content_length_int} exceeds max_bytes={max_bytes}"
             )
 
         chunks: list[bytes] = []

--- a/agentic-workloads/bedrock-image-url-bridge/bridge/core.py
+++ b/agentic-workloads/bedrock-image-url-bridge/bridge/core.py
@@ -24,7 +24,7 @@ import io
 import ipaddress
 import socket
 import threading
-from typing import Any, MutableMapping
+from typing import Any, Callable, MutableMapping
 from urllib.parse import urlparse, urljoin
 
 import requests
@@ -179,6 +179,7 @@ def _resolve_url(
     allow_insecure_http: bool,
     session: requests.Session,
     cache: MutableMapping[str, str] | None,
+    preprocess: Callable[[bytes], bytes] | None,
 ) -> str:
     """Resolve a single image_url string: pass through s3:// and data:,
     convert http(s):// to a data: URI (via cache when provided), reject
@@ -195,6 +196,8 @@ def _resolve_url(
             allow_insecure_http=allow_insecure_http,
             session=session,
         )
+        if preprocess is not None:
+            raw = preprocess(raw)
         data_uri = _bytes_to_data_uri(raw)
         if cache is not None:
             cache[url] = data_uri
@@ -212,6 +215,7 @@ def resolve_image_urls(
     allow_insecure_http: bool = False,
     session: requests.Session | None = None,
     cache: MutableMapping[str, str] | None = None,
+    preprocess: Callable[[bytes], bytes] | None = None,
 ) -> dict[str, Any]:
     """Rewrite plain http(s):// image_url values in a Bedrock-mantle
     request payload into inline data: URIs, leaving s3:// and data: URIs
@@ -248,6 +252,22 @@ def resolve_image_urls(
             The bridge does not manage eviction, TTL, or size limits on
             the cache; that is the caller's responsibility, same as
             constructing and owning the object passed in.
+        preprocess: Optional callable applied to the raw downloaded image
+            bytes after the existing SSRF guard, size cap, and redirect
+            re-validation have already run, and before the bytes are
+            turned into a data: URI. Use this to plug in
+            bridge.preprocess.preprocess_patch_mode /
+            preprocess_tile_mode (or your own bytes-in/bytes-out
+            function) to shrink images before they're inlined --
+            typical use: `preprocess=lambda b: preprocess_tile_mode(b).to_bytes()`.
+            Not provided by default -- no preprocessing happens unless
+            the caller opts in by passing one. The callable's output is
+            still re-verified as a real image by the same Pillow check
+            used on unprocessed downloads (_bytes_to_data_uri); that
+            verification is never skipped, preprocessed or not. Only
+            applied to freshly-downloaded http(s):// bytes -- it does
+            not run on cache hits (nothing was downloaded) or on
+            passed-through s3:// / data: URIs.
 
     Returns:
         A new dict with any http(s):// image_url values replaced by
@@ -277,6 +297,7 @@ def resolve_image_urls(
                         allow_insecure_http=allow_insecure_http,
                         session=active_session,
                         cache=cache,
+                        preprocess=preprocess,
                     )
                 elif isinstance(image_url, dict) and "url" in image_url:
                     image_url["url"] = _resolve_url(
@@ -286,6 +307,7 @@ def resolve_image_urls(
                         allow_insecure_http=allow_insecure_http,
                         session=active_session,
                         cache=cache,
+                        preprocess=preprocess,
                     )
             elif block_type == "input_image":
                 image_url = block.get("image_url")
@@ -297,6 +319,7 @@ def resolve_image_urls(
                         allow_insecure_http=allow_insecure_http,
                         session=active_session,
                         cache=cache,
+                        preprocess=preprocess,
                     )
 
     for message in result.get("messages", []) if isinstance(result.get("messages"), list) else []:

--- a/agentic-workloads/bedrock-image-url-bridge/bridge/core.py
+++ b/agentic-workloads/bedrock-image-url-bridge/bridge/core.py
@@ -1,0 +1,248 @@
+"""Utilities to make OpenAI-style image_url content blocks safe to send to
+Amazon Bedrock's OpenAI-compatible bedrock-mantle endpoint (and any other
+endpoint that only accepts inline data or s3:// URIs, not arbitrary https
+URLs).
+
+Amazon Bedrock Mantle rejects plain https image_url values with:
+
+    "Only inline image data URLs and S3 URLs are supported."
+
+It natively accepts:
+  - s3://bucket/key            (Mantle fetches it itself)
+  - data:<mime>;base64,<...>   (inline)
+
+This module rewrites only http(s):// URLs into inline data: URIs, leaving
+s3:// and data: URIs untouched. It is deliberately dependency-light
+(requests + Pillow only) and framework-free -- it is meant to be read,
+understood, and copied into your own code, not installed as a library.
+"""
+from __future__ import annotations
+
+import base64
+import copy
+import io
+import ipaddress
+import socket
+from typing import Any
+from urllib.parse import urlparse
+
+import requests
+from PIL import Image, UnidentifiedImageError
+
+_METADATA_IP = ipaddress.ip_address("169.254.169.254")
+
+
+def _is_blocked_ip(ip_str: str) -> bool:
+    """Return True if the IP is loopback, private, link-local, or the
+    cloud metadata address -- the classic SSRF target set."""
+    ip = ipaddress.ip_address(ip_str)
+    if ip == _METADATA_IP:
+        return True
+    return ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved
+
+
+def _validate_fetch_target(url: str, *, allow_insecure_http: bool) -> None:
+    """Validate scheme and resolved IP before making a request. Raises
+    ValueError on any policy violation. Called once per redirect hop."""
+    parsed = urlparse(url)
+    if parsed.scheme == "http" and not allow_insecure_http:
+        raise ValueError(
+            f"Refusing to fetch insecure http:// URL: {url!r} "
+            "(pass allow_insecure_http=True to override for local testing only)"
+        )
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"Unsupported URL scheme for fetch: {parsed.scheme!r} in {url!r}")
+    if not parsed.hostname:
+        raise ValueError(f"URL has no hostname: {url!r}")
+
+    try:
+        resolved = socket.getaddrinfo(parsed.hostname, None)
+    except socket.gaierror as exc:
+        raise ValueError(f"Could not resolve host {parsed.hostname!r}: {exc}") from exc
+
+    for family, _, _, _, sockaddr in resolved:
+        ip_str = sockaddr[0]
+        if _is_blocked_ip(ip_str):
+            raise ValueError(
+                f"Refusing to fetch {url!r}: resolves to blocked address {ip_str} "
+                "(private/loopback/link-local/metadata IP -- possible SSRF)"
+            )
+
+
+def _download_image_bytes(
+    url: str,
+    *,
+    max_bytes: int,
+    timeout_seconds: float,
+    allow_insecure_http: bool,
+    max_redirects: int = 2,
+) -> bytes:
+    """Stream-download url with SSRF guard, size cap, and a bounded,
+    re-validated redirect chain. Returns raw bytes on success."""
+    current_url = url
+    for _hop in range(max_redirects + 1):
+        _validate_fetch_target(current_url, allow_insecure_http=allow_insecure_http)
+        resp = requests.get(
+            current_url,
+            stream=True,
+            timeout=timeout_seconds,
+            allow_redirects=False,
+        )
+        if resp.is_redirect or resp.status_code in (301, 302, 303, 307, 308):
+            location = resp.headers.get("Location")
+            resp.close()
+            if not location:
+                raise ValueError(f"Redirect from {current_url!r} had no Location header")
+            current_url = location
+            continue
+
+        resp.raise_for_status()
+
+        content_length = resp.headers.get("Content-Length")
+        if content_length is not None and int(content_length) > max_bytes:
+            resp.close()
+            raise ValueError(
+                f"Refusing download from {current_url!r}: "
+                f"Content-Length {content_length} exceeds max_bytes={max_bytes}"
+            )
+
+        chunks: list[bytes] = []
+        total = 0
+        for chunk in resp.iter_content(chunk_size=65536):
+            total += len(chunk)
+            if total > max_bytes:
+                resp.close()
+                raise ValueError(
+                    f"Refusing download from {current_url!r}: "
+                    f"exceeded max_bytes={max_bytes} while streaming"
+                )
+            chunks.append(chunk)
+        resp.close()
+        return b"".join(chunks)
+
+    raise ValueError(f"Too many redirects (> {max_redirects}) fetching {url!r}")
+
+
+def _bytes_to_data_uri(raw: bytes) -> str:
+    """Verify raw bytes are a real image (via Pillow) and return a
+    data:<mime>;base64,<...> URI. The mime type comes from the verified
+    image format, never from the URL or a server-supplied header."""
+    try:
+        img = Image.open(io.BytesIO(raw))
+        img.verify()
+        fmt = img.format
+    except (UnidentifiedImageError, OSError) as exc:
+        raise ValueError(f"Downloaded content is not a valid image: {exc}") from exc
+
+    if not fmt:
+        raise ValueError("Could not determine image format after verification")
+
+    mime = Image.MIME.get(fmt, f"image/{fmt.lower()}")
+    encoded = base64.b64encode(raw).decode("ascii")
+    return f"data:{mime};base64,{encoded}"
+
+
+def _resolve_url(
+    url: str,
+    *,
+    max_bytes: int,
+    timeout_seconds: float,
+    allow_insecure_http: bool,
+) -> str:
+    """Resolve a single image_url string: pass through s3:// and data:,
+    convert http(s):// to a data: URI, reject anything else."""
+    if url.startswith("s3://") or url.startswith("data:"):
+        return url
+    if url.startswith("http://") or url.startswith("https://"):
+        raw = _download_image_bytes(
+            url,
+            max_bytes=max_bytes,
+            timeout_seconds=timeout_seconds,
+            allow_insecure_http=allow_insecure_http,
+        )
+        return _bytes_to_data_uri(raw)
+
+    scheme = url.split(":", 1)[0] if ":" in url else "(none)"
+    raise ValueError(f"Unsupported image_url scheme {scheme!r} in {url!r}")
+
+
+def resolve_image_urls(
+    payload: dict[str, Any],
+    *,
+    max_bytes: int = 20 * 1024 * 1024,
+    timeout_seconds: float = 10.0,
+    allow_insecure_http: bool = False,
+) -> dict[str, Any]:
+    """Rewrite plain http(s):// image_url values in a Bedrock-mantle
+    request payload into inline data: URIs, leaving s3:// and data: URIs
+    untouched.
+
+    Walks both supported payload shapes:
+      - Chat Completions: payload["messages"][*]["content"][*] blocks of
+        {"type": "image_url", "image_url": "<url>" | {"url": "<url>"}}
+      - Responses API: payload["input"][*]["content"][*] blocks of
+        {"type": "input_image", "image_url": "<url>"}
+
+    Args:
+        payload: A Chat Completions or Responses API request body (dict).
+        max_bytes: Maximum bytes to download per image (default 20 MiB).
+            Enforced against both the Content-Length header and the actual
+            number of bytes streamed, whichever is hit first.
+        timeout_seconds: Combined connect+read timeout per HTTP request
+            (default 10s). Applied per redirect hop.
+        allow_insecure_http: If True, permit fetching plain http:// URLs
+            (default False -- only https:// is fetched by default). Only
+            enable this for local/offline testing against non-TLS hosts.
+
+    Returns:
+        A new dict with any http(s):// image_url values replaced by
+        data:<mime>;base64,<...> URIs. The input payload is not mutated.
+
+    Raises:
+        ValueError: on an unsupported URL scheme, a blocked SSRF target,
+            an oversized download, or content that is not a valid image.
+    """
+    result = copy.deepcopy(payload)
+
+    def _walk_content(content: Any) -> None:
+        if not isinstance(content, list):
+            return
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            block_type = block.get("type")
+            if block_type == "image_url":
+                image_url = block.get("image_url")
+                if isinstance(image_url, str):
+                    block["image_url"] = _resolve_url(
+                        image_url,
+                        max_bytes=max_bytes,
+                        timeout_seconds=timeout_seconds,
+                        allow_insecure_http=allow_insecure_http,
+                    )
+                elif isinstance(image_url, dict) and "url" in image_url:
+                    image_url["url"] = _resolve_url(
+                        image_url["url"],
+                        max_bytes=max_bytes,
+                        timeout_seconds=timeout_seconds,
+                        allow_insecure_http=allow_insecure_http,
+                    )
+            elif block_type == "input_image":
+                image_url = block.get("image_url")
+                if isinstance(image_url, str):
+                    block["image_url"] = _resolve_url(
+                        image_url,
+                        max_bytes=max_bytes,
+                        timeout_seconds=timeout_seconds,
+                        allow_insecure_http=allow_insecure_http,
+                    )
+
+    for message in result.get("messages", []) if isinstance(result.get("messages"), list) else []:
+        if isinstance(message, dict):
+            _walk_content(message.get("content"))
+
+    for item in result.get("input", []) if isinstance(result.get("input"), list) else []:
+        if isinstance(item, dict):
+            _walk_content(item.get("content"))
+
+    return result

--- a/agentic-workloads/bedrock-image-url-bridge/bridge/core.py
+++ b/agentic-workloads/bedrock-image-url-bridge/bridge/core.py
@@ -23,13 +23,33 @@ import copy
 import io
 import ipaddress
 import socket
-from typing import Any
+import threading
+from typing import Any, MutableMapping
 from urllib.parse import urlparse, urljoin
 
 import requests
 from PIL import Image, UnidentifiedImageError
 
 _METADATA_IP = ipaddress.ip_address("169.254.169.254")
+
+# Lazily-created, module-level requests.Session reused across calls in
+# this process. requests.Session already pools TCP/TLS connections per
+# host -- we just need to reuse one instance instead of opening a fresh
+# connection on every requests.get() call. Callers never need to touch
+# this: it's an invisible default. A caller with its own session
+# requirements (custom retries, a proxy, mTLS) can pass `session=...`
+# to resolve_image_urls() to override it.
+_default_session: requests.Session | None = None
+_default_session_lock = threading.Lock()
+
+
+def _get_default_session() -> requests.Session:
+    global _default_session
+    if _default_session is None:
+        with _default_session_lock:
+            if _default_session is None:
+                _default_session = requests.Session()
+    return _default_session
 
 
 def _is_blocked_ip(ip_str: str) -> bool:
@@ -75,6 +95,7 @@ def _download_image_bytes(
     max_bytes: int,
     timeout_seconds: float,
     allow_insecure_http: bool,
+    session: requests.Session,
     max_redirects: int = 2,
 ) -> bytes:
     """Stream-download url with SSRF guard, size cap, and a bounded,
@@ -82,7 +103,7 @@ def _download_image_bytes(
     current_url = url
     for _hop in range(max_redirects + 1):
         _validate_fetch_target(current_url, allow_insecure_http=allow_insecure_http)
-        resp = requests.get(
+        resp = session.get(
             current_url,
             stream=True,
             timeout=timeout_seconds,
@@ -156,19 +177,28 @@ def _resolve_url(
     max_bytes: int,
     timeout_seconds: float,
     allow_insecure_http: bool,
+    session: requests.Session,
+    cache: MutableMapping[str, str] | None,
 ) -> str:
     """Resolve a single image_url string: pass through s3:// and data:,
-    convert http(s):// to a data: URI, reject anything else."""
+    convert http(s):// to a data: URI (via cache when provided), reject
+    anything else."""
     if url.startswith("s3://") or url.startswith("data:"):
         return url
     if url.startswith("http://") or url.startswith("https://"):
+        if cache is not None and url in cache:
+            return cache[url]
         raw = _download_image_bytes(
             url,
             max_bytes=max_bytes,
             timeout_seconds=timeout_seconds,
             allow_insecure_http=allow_insecure_http,
+            session=session,
         )
-        return _bytes_to_data_uri(raw)
+        data_uri = _bytes_to_data_uri(raw)
+        if cache is not None:
+            cache[url] = data_uri
+        return data_uri
 
     scheme = url.split(":", 1)[0] if ":" in url else "(none)"
     raise ValueError(f"Unsupported image_url scheme {scheme!r} in {url!r}")
@@ -180,6 +210,8 @@ def resolve_image_urls(
     max_bytes: int = 20 * 1024 * 1024,
     timeout_seconds: float = 10.0,
     allow_insecure_http: bool = False,
+    session: requests.Session | None = None,
+    cache: MutableMapping[str, str] | None = None,
 ) -> dict[str, Any]:
     """Rewrite plain http(s):// image_url values in a Bedrock-mantle
     request payload into inline data: URIs, leaving s3:// and data: URIs
@@ -201,6 +233,21 @@ def resolve_image_urls(
         allow_insecure_http: If True, permit fetching plain http:// URLs
             (default False -- only https:// is fetched by default). Only
             enable this for local/offline testing against non-TLS hosts.
+        session: Optional requests.Session to use for downloads. Defaults
+            to a lazily-created, module-level session shared across calls
+            in this process, so connections to the same host are pooled
+            and reused automatically with no caller action required. Pass
+            your own session for custom retry/proxy/TLS configuration.
+        cache: Optional mutable mapping (e.g. a plain dict, an
+            functools-backed LRU store, or a Redis/DynamoDB-backed object
+            implementing __contains__/__getitem__/__setitem__) from image
+            URL to the resolved data: URI. When provided, a URL already
+            in the cache skips the download entirely; a newly-resolved
+            URL is written back for next time. Not provided by default --
+            no caching happens unless the caller opts in by passing one.
+            The bridge does not manage eviction, TTL, or size limits on
+            the cache; that is the caller's responsibility, same as
+            constructing and owning the object passed in.
 
     Returns:
         A new dict with any http(s):// image_url values replaced by
@@ -211,6 +258,7 @@ def resolve_image_urls(
             an oversized download, or content that is not a valid image.
     """
     result = copy.deepcopy(payload)
+    active_session = session if session is not None else _get_default_session()
 
     def _walk_content(content: Any) -> None:
         if not isinstance(content, list):
@@ -227,6 +275,8 @@ def resolve_image_urls(
                         max_bytes=max_bytes,
                         timeout_seconds=timeout_seconds,
                         allow_insecure_http=allow_insecure_http,
+                        session=active_session,
+                        cache=cache,
                     )
                 elif isinstance(image_url, dict) and "url" in image_url:
                     image_url["url"] = _resolve_url(
@@ -234,6 +284,8 @@ def resolve_image_urls(
                         max_bytes=max_bytes,
                         timeout_seconds=timeout_seconds,
                         allow_insecure_http=allow_insecure_http,
+                        session=active_session,
+                        cache=cache,
                     )
             elif block_type == "input_image":
                 image_url = block.get("image_url")
@@ -243,6 +295,8 @@ def resolve_image_urls(
                         max_bytes=max_bytes,
                         timeout_seconds=timeout_seconds,
                         allow_insecure_http=allow_insecure_http,
+                        session=active_session,
+                        cache=cache,
                     )
 
     for message in result.get("messages", []) if isinstance(result.get("messages"), list) else []:

--- a/agentic-workloads/bedrock-image-url-bridge/bridge/preprocess.py
+++ b/agentic-workloads/bedrock-image-url-bridge/bridge/preprocess.py
@@ -1,0 +1,585 @@
+"""Client-side image preprocessing for Bedrock inference requests.
+
+Amazon Bedrock does not preprocess images server-side the way OpenAI and
+Anthropic's native APIs do: a raw 4000x3000 photo sent through Bedrock
+costs roughly 30,000 tokens, versus ~1,600-2,000 tokens for the same
+photo through OpenAI or Anthropic after their built-in resizing/tiling.
+This module replicates that missing preprocessing step client-side:
+resize an image down to a token budget *before* it is base64-encoded and
+sent to a model, using the same patch/tile math those providers use.
+
+Design decision -- this module is bytes-in, bytes-out only. It does not
+fetch URLs, read from S3, or perform any network I/O of its own. All of
+that already happens in ``bridge.core`` behind an SSRF guard, a size
+cap, and redirect re-validation (see ``resolve_image_urls()`` and its
+``preprocess=`` hook). Reimplementing fetch logic here would duplicate
+those guards and risk a second, unguarded path to fetch arbitrary URLs.
+Callers get bytes from ``resolve_image_urls()`` (or anywhere else they
+trust) and pass them into the functions below; the functions here never
+reach out to the network themselves.
+
+Preprocessing algorithms ported from bedrock-image-preprocessor
+(MIT License, Copyright (c) 2026 Aditya Shahani). No repository URL is
+cited here because none was discoverable in that project's package.json
+or README at the time of this port.
+"""
+from __future__ import annotations
+
+import base64
+import io
+import math
+from dataclasses import dataclass
+from typing import Literal
+
+from PIL import Image, ImageOps, ImageStat
+
+DetailLevel = Literal["low", "high", "original"]
+OutputFormat = Literal["jpeg", "png", "auto"]
+PreprocessMode = Literal["patch", "tile"]
+
+_PATCH_TOKEN_MULTIPLIER = 1.62
+_PATCH_SIZE = 32
+_TILE_SIZE = 512
+_ANTHROPIC_TOKENS_PER_PIXEL_DIVISOR = 750
+_ANTHROPIC_MAX_SQUARE = 2048
+_ANTHROPIC_MAX_LONG_EDGE = 1568
+_ANTHROPIC_MAX_SHORT_EDGE = 768
+_LOW_DETAIL_FIXED_SIZE = 512
+_JPEG_QUALITY_DEFAULT = 85
+
+# detail -> (max_patches, max_dimension); 'low' is handled separately as
+# a fixed 512x512 resize (there is no patch-budget check for it).
+_PATCH_BUDGETS: dict[str, tuple[int, int]] = {
+    "high": (2500, 2048),
+    "original": (10000, 6000),
+}
+
+
+@dataclass(frozen=True)
+class ImageDimensions:
+    """Width/height pair in pixels."""
+
+    width: int
+    height: int
+
+
+@dataclass(frozen=True)
+class PatchMetadata:
+    """Metadata returned alongside a patch-mode (OpenAI-style) result."""
+
+    original_dimensions: ImageDimensions
+    resized_dimensions: ImageDimensions
+    patch_count: int
+    estimated_tokens: int
+
+
+@dataclass(frozen=True)
+class TileMetadata:
+    """Metadata returned alongside a tile-mode (Anthropic-style) result."""
+
+    original_dimensions: ImageDimensions
+    resized_dimensions: ImageDimensions
+    tile_count: int
+    estimated_tokens: int
+
+
+@dataclass(frozen=True)
+class ProcessedImage:
+    """Result of preprocessing a single image.
+
+    ``base64`` holds the encoded output image bytes; combine with
+    ``mime_type`` to build a ``data:`` URI (see ``to_data_uri()``), or
+    decode with ``to_bytes()`` to get raw bytes -- e.g. to pass as the
+    return value of the ``preprocess=`` callable accepted by
+    ``bridge.core.resolve_image_urls()``.
+    """
+
+    base64: str
+    mime_type: Literal["image/jpeg", "image/png"]
+    metadata: PatchMetadata | TileMetadata
+
+    def to_data_uri(self) -> str:
+        """Return a ``data:<mime>;base64,<...>`` URI, built the same way
+        ``bridge.core._bytes_to_data_uri`` builds one."""
+        return f"data:{self.mime_type};base64,{self.base64}"
+
+    def to_bytes(self) -> bytes:
+        """Decode ``base64`` back to raw image bytes."""
+        return base64.b64decode(self.base64)
+
+
+def calculate_patch_count(width: int, height: int) -> int:
+    """Port of ``calculatePatchCount``: number of 32x32 patches needed to
+    cover a ``width`` x ``height`` image, per OpenAI's patch tokenizer."""
+    return math.ceil(width / _PATCH_SIZE) * math.ceil(height / _PATCH_SIZE)
+
+
+def calculate_scaled_dimensions(
+    original: ImageDimensions, max_width: int, max_height: int
+) -> ImageDimensions:
+    """Port of ``calculateScaledDimensions``: scale ``original`` down
+    (never up) to fit within ``max_width`` x ``max_height``, preserving
+    aspect ratio."""
+    scale_x = max_width / original.width
+    scale_y = max_height / original.height
+    scale = min(scale_x, scale_y, 1)
+    return ImageDimensions(
+        width=round(original.width * scale), height=round(original.height * scale)
+    )
+
+
+def _calculate_anthropic_tokens(width: int, height: int) -> int:
+    """Port of ``calculateAnthropicTokens``: Anthropic's token formula,
+    ``(width * height) / 750``."""
+    return round((width * height) / _ANTHROPIC_TOKENS_PER_PIXEL_DIVISOR)
+
+
+def _calculate_tile_count(width: int, height: int) -> int:
+    """Port of ``calculateTileCount``: number of 512x512 tiles needed to
+    cover a ``width`` x ``height`` image."""
+    return math.ceil(width / _TILE_SIZE) * math.ceil(height / _TILE_SIZE)
+
+
+def is_photographic(image_bytes: bytes) -> bool:
+    """Port of ``isPhotographic``: heuristic for whether an image is a
+    photo (JPEG-worthy) versus a diagram/screenshot (PNG-worthy).
+
+    - JPEG source -> True (already a photo format).
+    - PNG with an alpha channel -> False (screenshots/diagrams commonly
+      carry transparency; photos essentially never do).
+    - PNG without alpha -> compute the average per-channel standard
+      deviation (normalized to 0-1) across channels; True if > 0.15
+      (photos have more per-pixel variance than flat-color UI/diagram
+      images).
+    - WebP -> True.
+    - Anything else (e.g. GIF) -> False.
+
+    Port note: the TS original uses sharp's ``.stats()``, which reports
+    per-channel mean/stdev directly from libvips. Pillow has no
+    identical API; the closest equivalent is ``PIL.ImageStat.Stat``,
+    which computes the same per-channel standard deviation from decoded
+    pixel data. The formula (``stdev / 255`` averaged across channels,
+    threshold 0.15) is preserved exactly; only the statistics backend
+    differs, and results should match sharp's within normal floating
+    point / resampling differences.
+    """
+    img = Image.open(io.BytesIO(image_bytes))
+    fmt = (img.format or "").upper()
+
+    if fmt == "JPEG":
+        return True
+
+    if fmt == "PNG":
+        has_alpha = img.mode in ("RGBA", "LA", "PA") or (
+            img.mode == "P" and "transparency" in img.info
+        )
+        if has_alpha:
+            return False
+
+        stat_img = img if img.mode in ("RGB", "L") else img.convert("RGB")
+        stat = ImageStat.Stat(stat_img)
+        avg_stdev_ratio = sum(s / 255 for s in stat.stddev) / len(stat.stddev)
+        return avg_stdev_ratio > 0.15
+
+    return fmt == "WEBP"
+
+
+def _fit_to_patch_budget(
+    dimensions: ImageDimensions, max_patches: int, max_dimension: int
+) -> ImageDimensions:
+    """Port of ``fitToPatchBudget``: scale down to fit both the max
+    pixel dimension and the max patch count, in that order, with a 1%
+    safety margin per iteration on the patch-count loop (patch counts
+    round up via ceil, so a plain sqrt-scale can still overshoot by one
+    row/column of patches without the margin)."""
+    width, height = dimensions.width, dimensions.height
+
+    max_dim = max(width, height)
+    if max_dim > max_dimension:
+        scale = max_dimension / max_dim
+        width = round(width * scale)
+        height = round(height * scale)
+
+    patches = calculate_patch_count(width, height)
+    while patches > max_patches:
+        scale = math.sqrt(max_patches / patches) * 0.99
+        width = round(width * scale)
+        height = round(height * scale)
+        patches = calculate_patch_count(width, height)
+
+    return ImageDimensions(width=width, height=height)
+
+
+def _fit_to_anthropic_constraints(dimensions: ImageDimensions) -> ImageDimensions:
+    """Port of ``fitToAnthropicConstraints``: three sequential,
+    cascading proportional scale-downs -- fit within 2048x2048, then cap
+    the long edge at 1568px, then cap the short edge at 768px. Order
+    matters: each stage operates on the output of the previous one."""
+    width, height = dimensions.width, dimensions.height
+
+    max_dim = max(width, height)
+    if max_dim > _ANTHROPIC_MAX_SQUARE:
+        scale = _ANTHROPIC_MAX_SQUARE / max_dim
+        width = round(width * scale)
+        height = round(height * scale)
+
+    long_edge = max(width, height)
+    if long_edge > _ANTHROPIC_MAX_LONG_EDGE:
+        scale = _ANTHROPIC_MAX_LONG_EDGE / long_edge
+        width = round(width * scale)
+        height = round(height * scale)
+
+    short_edge = min(width, height)
+    if short_edge > _ANTHROPIC_MAX_SHORT_EDGE:
+        scale = _ANTHROPIC_MAX_SHORT_EDGE / short_edge
+        width = round(width * scale)
+        height = round(height * scale)
+
+    return ImageDimensions(width=width, height=height)
+
+
+def _fit_to_token_budget(dimensions: ImageDimensions, max_tokens: int) -> ImageDimensions:
+    """Port of ``fitToTokenBudget``: scale down further (never up) so
+    the Anthropic token estimate for ``dimensions`` does not exceed
+    ``max_tokens``."""
+    width, height = dimensions.width, dimensions.height
+    current_tokens = _calculate_anthropic_tokens(width, height)
+    if current_tokens <= max_tokens:
+        return ImageDimensions(width=width, height=height)
+
+    scale = math.sqrt(max_tokens / current_tokens)
+    return ImageDimensions(width=round(width * scale), height=round(height * scale))
+
+
+def _load_original_dimensions(image_bytes: bytes) -> ImageDimensions:
+    with Image.open(io.BytesIO(image_bytes)) as img:
+        return ImageDimensions(width=img.width, height=img.height)
+
+
+def _encode(
+    img: Image.Image, *, use_jpeg: bool, jpeg_quality: int
+) -> bytes:
+    buf = io.BytesIO()
+    if use_jpeg:
+        if img.mode in ("RGBA", "LA", "P"):
+            img = img.convert("RGB")
+        img.save(buf, format="JPEG", quality=jpeg_quality)
+    else:
+        img.save(buf, format="PNG", compress_level=6)
+    return buf.getvalue()
+
+
+def _resolve_use_jpeg(image_bytes: bytes, output_format: OutputFormat) -> bool:
+    if output_format == "auto":
+        return is_photographic(image_bytes)
+    return output_format == "jpeg"
+
+
+def preprocess_patch_mode(
+    image_bytes: bytes,
+    *,
+    detail: DetailLevel,
+    output_format: OutputFormat = "auto",
+    jpeg_quality: int = _JPEG_QUALITY_DEFAULT,
+) -> ProcessedImage:
+    """Port of ``preprocessPatchMode``: resize ``image_bytes`` to fit
+    OpenAI's patch-based (32x32 patch) token budget for the given
+    ``detail`` level, then re-encode as JPEG or PNG.
+
+    Detail levels:
+      - ``"low"``: fixed 512x512 resize (cover-fit, may enlarge).
+      - ``"high"``: max 2,500 patches OR 2048px max dimension (inside-fit,
+        never enlarges).
+      - ``"original"``: max 10,000 patches OR 6000px max dimension
+        (inside-fit, never enlarges).
+
+    Args:
+        image_bytes: Raw, already-fetched/verified image bytes.
+        detail: Patch budget to apply -- ``"low"``, ``"high"``, or
+            ``"original"``.
+        output_format: ``"auto"`` (detect photo vs. diagram via
+            ``is_photographic``), ``"jpeg"``, or ``"png"``.
+        jpeg_quality: JPEG quality (1-100) used when the output is JPEG.
+
+    Returns:
+        A ``ProcessedImage`` with the resized/re-encoded bytes (base64)
+        and ``PatchMetadata`` describing the resize and token estimate.
+    """
+    original_dimensions = _load_original_dimensions(image_bytes)
+
+    if detail == "low":
+        target_dimensions = ImageDimensions(
+            width=_LOW_DETAIL_FIXED_SIZE, height=_LOW_DETAIL_FIXED_SIZE
+        )
+    else:
+        max_patches, max_dimension = _PATCH_BUDGETS[detail]
+        target_dimensions = _fit_to_patch_budget(
+            original_dimensions, max_patches, max_dimension
+        )
+
+    needs_resize = (
+        target_dimensions.width != original_dimensions.width
+        or target_dimensions.height != original_dimensions.height
+    )
+
+    with Image.open(io.BytesIO(image_bytes)) as opened:
+        img = ImageOps.exif_transpose(opened)
+
+    if needs_resize:
+        if detail == "low":
+            # cover fit + allow enlargement (sharp: fit:'cover',
+            # withoutEnlargement:false) -- scale to fully cover the
+            # target box, then center-crop to it exactly.
+            img = ImageOps.fit(
+                img,
+                (target_dimensions.width, target_dimensions.height),
+                method=Image.LANCZOS,
+                centering=(0.5, 0.5),
+            )
+        else:
+            # inside fit + no enlargement (sharp: fit:'inside',
+            # withoutEnlargement:true) -- target_dimensions was computed
+            # by _fit_to_patch_budget as a uniform, aspect-preserving
+            # down-scale of the original, so a direct resize lands
+            # exactly inside the budget without distorting aspect ratio.
+            img = img.resize(
+                (target_dimensions.width, target_dimensions.height), Image.LANCZOS
+            )
+
+    use_jpeg = _resolve_use_jpeg(image_bytes, output_format)
+    output_bytes = _encode(img, use_jpeg=use_jpeg, jpeg_quality=jpeg_quality)
+
+    with Image.open(io.BytesIO(output_bytes)) as final_img:
+        final_dimensions = ImageDimensions(width=final_img.width, height=final_img.height)
+
+    patch_count = calculate_patch_count(final_dimensions.width, final_dimensions.height)
+
+    metadata = PatchMetadata(
+        original_dimensions=original_dimensions,
+        resized_dimensions=final_dimensions,
+        patch_count=patch_count,
+        estimated_tokens=round(patch_count * _PATCH_TOKEN_MULTIPLIER),
+    )
+
+    return ProcessedImage(
+        base64=base64.b64encode(output_bytes).decode("ascii"),
+        mime_type="image/jpeg" if use_jpeg else "image/png",
+        metadata=metadata,
+    )
+
+
+def preprocess_tile_mode(
+    image_bytes: bytes,
+    *,
+    max_token_budget: int | None = None,
+    output_format: OutputFormat = "auto",
+    jpeg_quality: int = _JPEG_QUALITY_DEFAULT,
+) -> ProcessedImage:
+    """Port of ``preprocessTileMode``: resize ``image_bytes`` to fit
+    Anthropic's tile-based token budget, then re-encode as JPEG or PNG.
+
+    Applies, in order: fit within 2048x2048, cap the long edge at
+    1568px, cap the short edge at 768px; then, if ``max_token_budget``
+    is given, scale down further so the Anthropic token estimate
+    (``width * height / 750``) does not exceed it. Never enlarges.
+
+    Args:
+        image_bytes: Raw, already-fetched/verified image bytes.
+        max_token_budget: Optional cap on estimated tokens for this
+            image; scales dimensions down further to hit it.
+        output_format: ``"auto"`` (detect photo vs. diagram via
+            ``is_photographic``), ``"jpeg"``, or ``"png"``.
+        jpeg_quality: JPEG quality (1-100) used when the output is JPEG.
+
+    Returns:
+        A ``ProcessedImage`` with the resized/re-encoded bytes (base64)
+        and ``TileMetadata`` describing the resize and token estimate.
+    """
+    original_dimensions = _load_original_dimensions(image_bytes)
+
+    target_dimensions = _fit_to_anthropic_constraints(original_dimensions)
+    if max_token_budget:
+        target_dimensions = _fit_to_token_budget(target_dimensions, max_token_budget)
+
+    needs_resize = (
+        target_dimensions.width != original_dimensions.width
+        or target_dimensions.height != original_dimensions.height
+    )
+
+    with Image.open(io.BytesIO(image_bytes)) as opened:
+        img = ImageOps.exif_transpose(opened)
+
+    if needs_resize:
+        # inside fit + no enlargement, same reasoning as patch mode's
+        # high/original branch: target_dimensions is already a uniform
+        # aspect-preserving down-scale, so a direct resize is correct.
+        img = img.resize(
+            (target_dimensions.width, target_dimensions.height), Image.LANCZOS
+        )
+
+    use_jpeg = _resolve_use_jpeg(image_bytes, output_format)
+    output_bytes = _encode(img, use_jpeg=use_jpeg, jpeg_quality=jpeg_quality)
+
+    with Image.open(io.BytesIO(output_bytes)) as final_img:
+        final_dimensions = ImageDimensions(width=final_img.width, height=final_img.height)
+
+    tile_count = _calculate_tile_count(final_dimensions.width, final_dimensions.height)
+
+    metadata = TileMetadata(
+        original_dimensions=original_dimensions,
+        resized_dimensions=final_dimensions,
+        tile_count=tile_count,
+        estimated_tokens=_calculate_anthropic_tokens(
+            final_dimensions.width, final_dimensions.height
+        ),
+    )
+
+    return ProcessedImage(
+        base64=base64.b64encode(output_bytes).decode("ascii"),
+        mime_type="image/jpeg" if use_jpeg else "image/png",
+        metadata=metadata,
+    )
+
+
+def _reduce_patch_detail(current: DetailLevel, factor: float) -> DetailLevel:
+    """Port of ``reducePatchDetail``: step the detail level down when a
+    batch redistribution factor is tight."""
+    if factor < 0.3:
+        return "low"
+    if current == "original" and factor < 0.7:
+        return "high"
+    return current
+
+
+def _redistribute_token_budget(
+    images: list[bytes],
+    initial_results: list[ProcessedImage],
+    max_total_tokens: int,
+    *,
+    mode: PreprocessMode,
+    detail: DetailLevel,
+    output_format: OutputFormat,
+    jpeg_quality: int,
+) -> list[ProcessedImage]:
+    """Port of ``redistributeTokenBudget``: if the batch's total
+    estimated tokens exceeds ``max_total_tokens``, reprocess every image
+    at a scaled-down target proportional to how far over budget the
+    batch is."""
+    total_tokens = sum(r.metadata.estimated_tokens for r in initial_results)
+    if total_tokens <= max_total_tokens:
+        return initial_results
+
+    reduction_factor = max_total_tokens / total_tokens
+
+    results: list[ProcessedImage] = []
+    for image_bytes, initial in zip(images, initial_results):
+        target_tokens = math.floor(initial.metadata.estimated_tokens * reduction_factor)
+
+        if mode == "tile":
+            results.append(
+                preprocess_tile_mode(
+                    image_bytes,
+                    max_token_budget=target_tokens,
+                    output_format=output_format,
+                    jpeg_quality=jpeg_quality,
+                )
+            )
+        else:
+            lower_detail = _reduce_patch_detail(detail, reduction_factor)
+            results.append(
+                preprocess_patch_mode(
+                    image_bytes,
+                    detail=lower_detail,
+                    output_format=output_format,
+                    jpeg_quality=jpeg_quality,
+                )
+            )
+
+    return results
+
+
+def preprocess_images(
+    images: list[bytes],
+    *,
+    mode: PreprocessMode,
+    detail: DetailLevel = "high",
+    max_total_tokens: int | None = None,
+    output_format: OutputFormat = "auto",
+    jpeg_quality: int = _JPEG_QUALITY_DEFAULT,
+) -> list[ProcessedImage]:
+    """Port of ``preprocessImages`` + ``redistributeTokenBudget``: batch
+    process every image, then, if ``max_total_tokens`` is given and the
+    batch total exceeds it, reprocess every image at a proportionally
+    reduced target so the total fits (approximately) within budget.
+
+    Args:
+        images: Raw, already-fetched/verified image bytes, one per
+            image.
+        mode: ``"patch"`` (OpenAI-style, via ``preprocess_patch_mode``)
+            or ``"tile"`` (Anthropic-style, via ``preprocess_tile_mode``).
+        detail: Patch detail level used in patch mode (ignored in tile
+            mode). Default ``"high"``.
+        max_total_tokens: Optional cap on the sum of estimated tokens
+            across the whole batch. In tile mode, an even per-image
+            share of the budget is also applied on the first pass;
+            in patch mode, the first pass ignores the budget and only
+            the redistribution pass (if triggered) reduces detail.
+        output_format: ``"auto"``, ``"jpeg"``, or ``"png"``, forwarded
+            to each image's processing call.
+        jpeg_quality: JPEG quality (1-100), forwarded to each image's
+            processing call.
+
+    Returns:
+        A list of ``ProcessedImage``, one per input image, in order.
+        Empty input returns an empty list.
+    """
+    if not images:
+        return []
+
+    if mode == "patch":
+        results = [
+            preprocess_patch_mode(
+                img, detail=detail, output_format=output_format, jpeg_quality=jpeg_quality
+            )
+            for img in images
+        ]
+        if max_total_tokens:
+            return _redistribute_token_budget(
+                images,
+                results,
+                max_total_tokens,
+                mode=mode,
+                detail=detail,
+                output_format=output_format,
+                jpeg_quality=jpeg_quality,
+            )
+        return results
+
+    # Tile mode: an even per-image token share is applied up front (if a
+    # budget was given), then a redistribution pass tightens further if
+    # the batch is still over budget after that first pass.
+    per_image_budget = math.floor(max_total_tokens / len(images)) if max_total_tokens else None
+    results = [
+        preprocess_tile_mode(
+            img,
+            max_token_budget=per_image_budget,
+            output_format=output_format,
+            jpeg_quality=jpeg_quality,
+        )
+        for img in images
+    ]
+
+    if max_total_tokens:
+        total_tokens = sum(r.metadata.estimated_tokens for r in results)
+        if total_tokens > max_total_tokens:
+            return _redistribute_token_budget(
+                images,
+                results,
+                max_total_tokens,
+                mode=mode,
+                detail=detail,
+                output_format=output_format,
+                jpeg_quality=jpeg_quality,
+            )
+
+    return results

--- a/agentic-workloads/bedrock-image-url-bridge/docs/ALTERNATIVES.md
+++ b/agentic-workloads/bedrock-image-url-bridge/docs/ALTERNATIVES.md
@@ -1,0 +1,35 @@
+# Alternative: use an AI gateway instead of a hand-rolled bridge
+
+If you're calling more than one model/provider and want URL handling
+solved for you instead of maintaining `resolve_image_urls()` yourself,
+put an AI gateway in front of Bedrock and let it own image URL
+normalization.
+
+**[LiteLLM](https://docs.litellm.ai/docs/proxy/architecture)** already
+implements this exact pattern generically: it detects an `image_url` in
+the request, checks whether the target provider accepts URLs natively,
+and if not, downloads the image (capped at
+`MAX_IMAGE_URL_DOWNLOAD_SIZE_MB`, 50 MB by default), converts it to
+base64, and caches up to 10 converted images in memory to cut latency on
+repeated calls. LiteLLM also has a dedicated
+[Bedrock Mantle provider](https://docs.litellm.ai/docs/providers/bedrock_mantle),
+so routing through it gets you the URL-handling fix plus routing,
+fallbacks, retries, budgets, and spend tracking across every provider
+you use -- at the cost of running (and securing) an extra proxy service.
+
+Any OpenAI-compatible gateway with similar "fetch-and-inline" middleware
+(a custom API Gateway + Lambda layer, for example) can apply the same
+idea -- the security guards in [`bridge/core.py`](../bridge/core.py)
+(SSRF guard, size cap, format verification; see
+[SECURITY.md](./SECURITY.md)) are exactly what such middleware needs
+regardless of where it runs.
+
+## When to use which
+
+- **This sample, as-is**: you want a single dependency-light function
+  with no extra infrastructure, calling one Bedrock endpoint (or a
+  handful) directly.
+- **A gateway like LiteLLM**: you're already managing multiple
+  providers/models and want URL handling, routing, and cost tracking
+  solved together instead of piecemeal, and are fine operating an
+  additional proxy service.

--- a/agentic-workloads/bedrock-image-url-bridge/docs/CACHING.md
+++ b/agentic-workloads/bedrock-image-url-bridge/docs/CACHING.md
@@ -1,0 +1,88 @@
+# Bridge internals: connection pooling and caching
+
+`resolve_image_urls()` accepts two optional keyword arguments that make
+repeated calls cheaper without changing default behavior at all when
+they're not used.
+
+## Connection pooling (`session`)
+
+Every HTTP download in `bridge/core.py` goes through a
+[`requests.Session`](https://requests.readthedocs.io/en/latest/user/advanced/#session-objects)
+instead of the module-level `requests.get()`. A `Session` keeps a
+per-host connection pool (`HTTPAdapter`, default 10 pooled connections
+per host) and reuses TCP+TLS handshakes across calls instead of paying
+that setup cost on every single image fetch.
+
+You don't have to do anything to get this: `resolve_image_urls()` lazily
+creates one module-level `Session` the first time it's called and reuses
+it for the lifetime of the process (thread-safe, created once behind a
+lock). Pass your own `session=requests.Session()` only if you need custom
+retry policy, a proxy, or mTLS -- otherwise the default is correct.
+
+```python
+import requests
+from bridge.core import resolve_image_urls
+
+# Optional: bring your own session (e.g. with retries configured)
+custom_session = requests.Session()
+payload = resolve_image_urls(payload, session=custom_session)
+```
+
+**Live-verified** (region us-east-1): the default session is created on
+first call and the identical `Session` object is confirmed reused on a
+second call; its HTTPS adapter reports a pool size of 10 connections per
+host.
+
+## Caching (`cache`)
+
+If the same image URL appears across multiple requests -- a recurring
+prompt template, a retry, a batch of requests referencing a shared asset
+-- there's no reason to re-download and re-verify it every time. Pass any
+object that behaves like a `MutableMapping[str, str]` (a plain `dict` is
+enough) as `cache=`, and `resolve_image_urls()` will:
+
+1. Check `url in cache` before downloading. On a hit, return the cached
+   `data:` URI immediately -- no network call, no re-verification.
+2. On a miss, download and verify as normal, then write
+   `cache[url] = data_uri` before returning.
+
+```python
+cache: dict[str, str] = {}  # or any dict-like store you already have
+
+payload = resolve_image_urls(payload, cache=cache)          # downloads
+payload_again = resolve_image_urls(other_payload, cache=cache)  # reuses if same URL
+```
+
+**No caching happens unless you pass one in** -- this is the exact same
+behavior as before caching was added if you don't opt in. The bridge does
+not create, own, size-limit, or expire anything on your behalf. What you
+pass in is what gets used, verbatim:
+
+- A plain `dict()` -- unbounded, process-lifetime, no eviction. Fine for
+  a single Lambda invocation reusing images within a request, or a short
+  batch job.
+- `functools.lru_cache`-style wrapping, or any bounded LRU dict
+  implementation -- if you need a size cap.
+- A Redis- or DynamoDB-backed object implementing
+  `__contains__`/`__getitem__`/`__setitem__` -- if you need the cache to
+  survive process restarts or be shared across concurrent
+  Lambda/container instances. The bridge has no idea what's backing the
+  mapping; any object satisfying that minimal interface works.
+
+**Live-verified** (region us-east-1): first `resolve_image_urls()` call
+against a real https image URL took ~0.07s (network download + Pillow
+verification); an identical second call with the same `cache` dict took
+0.000s (skip). The resolved payload was byte-identical between the two
+calls, and the cached `data:` URI was confirmed to work in an actual
+`bedrock-mantle` Chat Completions call.
+
+## What this does *not* do
+
+- No TTL, no expiration, no invalidation -- if the underlying image
+  changes at the same URL, a caller-owned cache will keep serving the
+  stale version until the caller clears it.
+- No cross-process sharing by default -- a plain `dict` is scoped to one
+  process. Share a Redis/DynamoDB-backed mapping instead if that matters.
+- No concurrency control -- see [SCALING.md](./SCALING.md) for bounding
+  concurrent fetches; caching and concurrency limits are independent
+  concerns and compose fine together.

--- a/agentic-workloads/bedrock-image-url-bridge/docs/HOSTING.md
+++ b/agentic-workloads/bedrock-image-url-bridge/docs/HOSTING.md
@@ -1,0 +1,74 @@
+# Hosting
+
+`resolve_image_urls()` is a plain, stateless Python function -- no
+listening port, no background process, nothing to keep alive. You call
+it inline, wherever your code already builds a Bedrock request, right
+before sending it. What you host is *your own calling code*, not the
+bridge itself.
+
+## Already-running service
+
+If you have an existing API, worker, notebook, or CLI that already
+calls `bedrock-mantle` or `bedrock-runtime`, add one line before the
+existing call:
+
+```python
+payload = resolve_image_urls(payload)
+# ... send payload as before
+```
+
+No new infrastructure. This is the expected case for most callers.
+
+## AWS Lambda
+
+`examples/lambda_handler.py` is a complete handler that accepts the
+*exact* Chat Completions request schema (`{"model": ..., "messages":
+[...]}`) and returns the *exact* Chat Completions response JSON,
+unmodified -- see [MIGRATION.md](./MIGRATION.md) for why that schema
+fidelity matters.
+
+Try it locally first, no deployment needed:
+
+```bash
+export AWS_PROFILE=your-aws-profile
+export AWS_REGION=us-east-1
+
+python -c "
+from examples.lambda_handler import handler
+print(handler({
+    'model': 'qwen.qwen3-vl-235b-a22b-instruct',
+    'messages': [
+        {'role': 'user', 'content': [
+            {'type': 'text', 'text': 'Describe this image in one sentence.'},
+            {'type': 'image_url', 'image_url': {'url': 'https://placehold.co/64x64.jpg'}},
+        ]}
+    ],
+}, None))
+"
+```
+
+To deploy: package `bridge/`, `examples/lambda_handler.py`,
+`examples/mantle_chat_completions.py`, `requests`, and `Pillow` (boto3
+ships with the Lambda Python runtime already) using whatever you
+already use for Lambda -- SAM, CDK, Terraform, or a console zip upload.
+There is nothing bridge-specific about the deployment mechanics. Create
+the function with `examples.lambda_handler.handler` as the entry point,
+and grant its execution role `bedrock:InvokeModel` for the model(s) you
+call.
+
+An optional top-level `region` key in the request overrides the AWS
+region used to call `bedrock-mantle` (default `us-east-1`); it's stripped
+before forwarding since it isn't part of the Chat Completions schema.
+
+## Container / ECS / EC2
+
+Same idea as "already-running service" -- a normal, long-running Python
+process. `examples/mantle_chat_completions.py`, `examples/mantle_responses_api.py`,
+and `examples/runtime_converse.py` are runnable as-is and show the exact
+call shape to wrap in your own service.
+
+## In every case
+
+The security guards in `bridge/core.py` run in the same process as the
+caller. There's no separate bridge process, network hop, or service to
+secure, deploy, or monitor independently of your own application.

--- a/agentic-workloads/bedrock-image-url-bridge/docs/MIGRATION.md
+++ b/agentic-workloads/bedrock-image-url-bridge/docs/MIGRATION.md
@@ -1,0 +1,57 @@
+# Migration: pointing an existing client at this bridge
+
+Every example in this repo, including the Lambda handler, takes and
+returns the *exact* request/response schema of the API it's fronting.
+The bridge never introduces a custom envelope. That's the whole point:
+migration is swapping a base URL, not rewriting a client.
+
+## Chat Completions (`mantle_chat_completions.py`, `lambda_handler.py`)
+
+Input: the exact OpenAI Chat Completions request body --
+`{"model": ..., "messages": [{"role", "content": [...]}]}`.
+
+Output: the exact Chat Completions response JSON, unmodified --
+`{"choices": [{"message": {"content": ...}}], ...}`.
+
+An existing OpenAI-compatible client pointed at this Lambda's Function
+URL (or API Gateway endpoint) instead of directly at `bedrock-mantle`
+works with zero client-side changes, including for `https://` image URLs
+that `bedrock-mantle` would otherwise reject with:
+
+```
+"Only inline image data URLs and S3 URLs are supported."
+```
+
+## Responses API (`mantle_responses_api.py`)
+
+Input: the exact OpenAI Responses API request body --
+`{"model": ..., "input": [{"role", "content": [...]}]}`.
+
+Output: the exact Responses API response JSON, unmodified.
+
+Note the live-verified model-availability gap: as of this writing, no
+model in a typical Bedrock account supports both the `/v1/responses` API
+*and* vision at inference time -- `openai.gpt-oss-120b` supports
+`/v1/responses` but is text-only (it accepts an `input_image` block at
+the schema level, then fails at inference with a generic `server_error`);
+vision models like `qwen3-vl` don't support `/v1/responses` at all. This
+is a Bedrock model-availability constraint, not a bug in the bridge --
+recheck AWS's
+[API compatibility table](https://docs.aws.amazon.com/bedrock/latest/userguide/models-api-compatibility.html)
+as new models ship.
+
+## Converse (`runtime_converse.py`)
+
+`bedrock-runtime` Converse has no OpenAI-compatible schema to migrate
+from -- it's Bedrock's own native API, with no `image_url` concept at
+all, only raw bytes. This example exists as a contrast case: it reuses
+the same `resolve_image_urls()` bridge purely as a URL-to-bytes utility
+(feeding a Chat-Completions-shaped payload into the bridge, then
+extracting the resulting bytes for the native Converse call), to show
+the bridge is genuinely endpoint-agnostic rather than Mantle-specific.
+
+## Error shape parity
+
+The Lambda handler returns errors in the OpenAI error envelope --
+`{"error": {"message": ..., "type": ...}}` -- so client-side error
+handling needs no changes either, not just the happy path.

--- a/agentic-workloads/bedrock-image-url-bridge/docs/PREPROCESSING.md
+++ b/agentic-workloads/bedrock-image-url-bridge/docs/PREPROCESSING.md
@@ -1,0 +1,121 @@
+# Preprocessing: reducing image token cost before it reaches Bedrock
+
+## The problem
+
+Amazon Bedrock does not preprocess images server-side the way OpenAI and
+Anthropic's own APIs do. When you send an image through Bedrock's
+Converse API or the `bedrock-mantle` endpoint, the raw base64-encoded
+bytes go straight to the model -- no resizing, no tiling, no
+compression. A raw 4000x3000 photo costs roughly **30,000 tokens**
+through Bedrock; the same photo through OpenAI or Anthropic's native
+APIs costs roughly **1,600-2,000 tokens**, because those providers
+resize/tile it first.
+
+That gap adds up fast in multi-image workflows: 10-15 images per request
+is a common target, but at ~30,000 tokens each, 10 images alone consume
+300,000 tokens -- more than a 128K context window can hold before you've
+sent a single word of prompt text.
+
+`bridge/preprocess.py` closes that gap client-side: shrink the image to
+a token budget *before* it's base64-encoded and sent to a model, using
+the same math OpenAI and Anthropic use server-side.
+
+## The two token formulas
+
+**OpenAI patch-based** (`preprocess_patch_mode`): images are divided
+into 32x32 pixel patches. Patch count is
+`ceil(width/32) * ceil(height/32)`; estimated tokens is
+`patch_count * 1.62`. Three detail levels control the resize budget:
+
+| Detail | Budget |
+|---|---|
+| `low` | Fixed 512x512 resize (may enlarge small images) |
+| `high` | Max 2,500 patches OR 2048px max dimension |
+| `original` | Max 10,000 patches OR 6000px max dimension |
+
+**Anthropic tile-based** (`preprocess_tile_mode`): images are resized
+through a three-stage cascade -- fit within 2048x2048, then cap the
+long edge at 1568px, then cap the short edge at 768px -- and divided
+into 512x512 tiles. Estimated tokens is `(width * height) / 750`. An
+optional `max_token_budget` scales the image down further past the
+cascade if you need a tighter cap.
+
+Neither formula's constants are guesses -- they're taken directly from
+the token math OpenAI and Anthropic document/exhibit for their own
+native APIs; the point of this module is matching that behavior
+client-side for Bedrock, not inventing a new one.
+
+## Usage
+
+Standalone, on raw image bytes you already have:
+
+```python
+from bridge.preprocess import preprocess_patch_mode, preprocess_tile_mode
+
+result = preprocess_tile_mode(image_bytes, max_token_budget=2000)
+print(result.metadata.estimated_tokens)   # e.g. 1050
+print(result.metadata.resized_dimensions) # e.g. ImageDimensions(width=768, height=1025)
+data_uri = result.to_data_uri()           # ready to drop into a request payload
+```
+
+Composed with `resolve_image_urls()` via the `preprocess=` hook, so a
+fetched `http(s)://` image is shrunk before it's inlined -- the SSRF
+guard, size cap, and format verification in `bridge/core.py` still run
+exactly as before; `preprocess=` only transforms the bytes in between:
+
+```python
+from bridge import resolve_image_urls
+from bridge.preprocess import preprocess_tile_mode
+
+payload = resolve_image_urls(
+    payload,
+    preprocess=lambda raw: preprocess_tile_mode(raw, max_token_budget=2000).to_bytes(),
+)
+```
+
+Batch, with a shared token budget across many images
+(`preprocess_images`) -- processes every image, and if the batch total
+exceeds `max_total_tokens`, reprocesses every image at a proportionally
+reduced target so the total fits:
+
+```python
+from bridge.preprocess import preprocess_images
+
+processed = preprocess_images(image_byte_list, mode="tile", max_total_tokens=30000)
+```
+
+See `examples/preprocess_demo.py` for a runnable before/after comparison
+-- no AWS credentials required to see the token savings; set
+`AWS_PROFILE` to also make a live `bedrock-mantle` call with the
+preprocessed image.
+
+## Live-verified
+
+Against a real 4000x5338 photo, region `us-east-1`:
+
+| Mode | Before | After | Reduction |
+|---|---|---|---|
+| Tile (Anthropic-style) | 28,469 tokens | 1,050 tokens | 96.3% |
+| Patch (OpenAI-style, high detail) | 33,818 tokens | 4,040 tokens | 88.1% |
+
+Both preprocessed images were fed through a real `bedrock-mantle` Chat
+Completions call and the model correctly described the photo's actual
+content in both cases -- confirming the shrunk image is still visually
+usable to the model, not just smaller.
+
+## Design note
+
+`bridge/preprocess.py` is bytes-in, bytes-out only -- it does no URL
+fetching, S3 access, or network I/O of its own. All of that already
+happens safely inside `bridge/core.py`'s SSRF-guarded download path.
+Reimplementing fetch logic here would duplicate (and risk bypassing)
+those guards; instead, preprocessing composes with the existing pipeline
+purely as a bytes transform via the `preprocess=` hook.
+
+## Attribution
+
+The patch/tile resize algorithms in `bridge/preprocess.py` are ported
+from **bedrock-image-preprocessor** (MIT License, Copyright (c) 2026
+Aditya Shahani). No repository URL is cited because none was
+discoverable in that project's `package.json` or README at the time of
+this port.

--- a/agentic-workloads/bedrock-image-url-bridge/docs/SCALING.md
+++ b/agentic-workloads/bedrock-image-url-bridge/docs/SCALING.md
@@ -1,0 +1,87 @@
+# Scaling
+
+This sample is intentionally synchronous, per-request, and (by default)
+uncached -- that's what keeps the core interception pattern in
+`bridge/core.py` easy to read in one sitting. It's directly usable as-is
+in a Lambda handler or any single-request context. This doc covers what
+changes as volume grows, and what it costs.
+
+## Concurrency
+
+`resolve_image_urls()` does not manage concurrency itself -- it's a
+plain function, safe to call from multiple threads or async tasks
+because it doesn't share mutable state across calls (the module-level
+`requests.Session` used for pooling is thread-safe by design). Bounding
+*how many* calls run at once is the caller's decision, made where the
+caller already controls concurrency:
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+from bridge.core import resolve_image_urls
+
+def resolve_one(payload):
+    return resolve_image_urls(payload)
+
+with ThreadPoolExecutor(max_workers=8) as pool:
+    resolved_payloads = list(pool.map(resolve_one, payloads))
+```
+
+From an `async` caller, run it in a thread pool executor rather than
+forking the function into sync/async variants -- the OpenAI SDKs
+themselves split sync/async at the client layer, not the wire protocol,
+so this composes the same way:
+
+```python
+import asyncio
+
+resolved = await asyncio.get_running_loop().run_in_executor(
+    None, resolve_image_urls, payload
+)
+```
+
+## Connection pooling and caching
+
+See [CACHING.md](./CACHING.md) for the `session=` and `cache=` kwargs --
+both opt-in, both no-ops when not passed, both live-verified against a
+real AWS account (session reuse confirmed across calls; a cache hit
+measured at effectively 0ms vs ~70ms for a live download+verify).
+
+## Cost estimate
+
+Three cost components scale with image-URL volume; none scale with
+adding this bridge specifically -- it adds no billed AWS resource of its
+own, only the compute already running your calling code.
+
+**Image download** (per unique URL, until cached or re-fetched):
+negligible for image hosts you control; if fetching from S3, GET
+requests are $0.0004 per 1,000 (Standard tier, `us-east-1`, per
+[AWS S3 pricing](https://aws.amazon.com/s3/pricing/)) -- 1M image fetches
+≈ $0.40 in request fees alone, before any data transfer.
+
+**Compute, if hosted on Lambda**: $0.20 per 1M requests +
+$0.0000166667 per GB-second (x86; ~20% less on arm64), per
+[AWS Lambda pricing](https://aws.amazon.com/lambda/pricing/). A
+512MB function spending ~200ms per invocation resolving one image costs
+roughly $0.20 (requests) + $1.70 (compute) per 1M invocations ≈ $1.90/1M
+-- caching cuts the compute side further for repeated URLs, since a
+cache hit skips the download+verify work entirely.
+
+**Model inference (the dominant cost)**: vision tokens, not the bridge,
+drive the real bill. Anthropic Claude models bill roughly
+`(width × height) / 750` input tokens per image (capped around 1,568px
+on the long edge on most Claude models); a 1024×768 image is ~1,050
+tokens. At Claude Haiku 4.5's Bedrock on-demand price of $1.00/1M input
+tokens, that's roughly $0.001 per image purely for vision input tokens,
+before the text prompt and output. OpenAI-style tile-based models charge
+a fixed base (e.g. 85 tokens) plus a per-tile charge; check
+[Amazon Bedrock pricing](https://aws.amazon.com/bedrock/pricing/) for the
+specific model you're calling, since Bedrock Mantle and Bedrock Runtime
+have model-specific per-token rates that vary widely by provider and
+model size.
+
+**Bottom line**: at meaningful volume, image download/compute costs are
+a rounding error next to model inference cost. The `cache=` option
+matters most when the *same* image URL recurs across many requests
+(shared assets, templated prompts) -- it eliminates repeat download+
+verification cost, but does not reduce vision token cost on the model
+side, since each request still sends the same image bytes to the model.

--- a/agentic-workloads/bedrock-image-url-bridge/docs/SECURITY.md
+++ b/agentic-workloads/bedrock-image-url-bridge/docs/SECURITY.md
@@ -1,0 +1,64 @@
+# Security guards
+
+`resolve_image_urls()` only touches `http(s)://` URLs -- `s3://` and
+`data:` URIs pass through untouched. Every `http(s)://` URL goes through
+the following guards, in `bridge/core.py`, before its bytes are ever
+handed to a model.
+
+## HTTPS-only by default
+
+Plain `http://` is rejected unless you explicitly pass
+`allow_insecure_http=True`. This exists so a caller can't accidentally
+route image fetches over an unencrypted connection in production;
+enabling it is meant for local testing against non-TLS hosts only.
+
+## SSRF guard
+
+Before connecting, the target hostname is resolved via
+`socket.getaddrinfo()` and every returned IP is checked against the
+classic SSRF target set: loopback (`127.0.0.1`), private ranges
+(`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`), link-local, and the
+cloud instance metadata address (`169.254.169.254`). Any match raises
+`ValueError` before a socket is opened.
+
+Without this, an attacker-supplied `image_url` could make your server
+fetch its own internal endpoints -- including, on EC2/ECS/Lambda, the
+instance metadata service that can hand back IAM credentials.
+
+## Bounded, re-validated redirects
+
+Each request follows at most 2 redirect hops. The guard above is
+re-applied to *every* redirect target, not just the original URL --
+including resolving relative `Location` headers with `urljoin()` before
+validating. A redirect chain can't be used to smuggle a request past the
+SSRF check after the first hop passes.
+
+## Size cap
+
+Downloads are capped at `max_bytes` (default 20 MiB), enforced twice:
+against the `Content-Length` response header (rejected before any body
+bytes are read) and against the actual number of bytes streamed
+(rejected mid-stream if a server lies about `Content-Length` or omits
+it). This stops a malicious or misconfigured host from exhausting memory
+with an unbounded or falsely-labeled response.
+
+## Real format verification
+
+Downloaded bytes are opened and verified with Pillow's
+[`Image.verify()`](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.verify),
+and the resulting `data:` URI's mime type comes from the verified image
+format (`Image.MIME[fmt]`) -- never from the URL's file extension or a
+server-supplied `Content-Type` header, both of which can be spoofed. Content
+that isn't a real, decodable image raises `ValueError` and never reaches
+the model call.
+
+## What's explicitly out of scope
+
+- **Content moderation / NSFW filtering** -- this guards against SSRF
+  and resource-exhaustion attacks, not what the image actually depicts.
+  Bedrock Guardrails or a dedicated moderation service is the right tool
+  for that, applied to the resolved payload before or after this bridge.
+- **Authentication on the fetched URL** -- if the image host requires
+  auth (a signed URL, a bearer token), that's outside this function's
+  concern; pass an already-authenticated URL, or a custom `session=`
+  with the auth baked in via headers.

--- a/agentic-workloads/bedrock-image-url-bridge/docs/SECURITY.md
+++ b/agentic-workloads/bedrock-image-url-bridge/docs/SECURITY.md
@@ -62,3 +62,28 @@ the model call.
   auth (a signed URL, a bearer token), that's outside this function's
   concern; pass an already-authenticated URL, or a custom `session=`
   with the auth baked in via headers.
+
+## Shared responsibility
+
+This sample follows the [AWS Shared Responsibility
+Model](https://aws.amazon.com/compliance/shared-responsibility-model/).
+AWS is responsible for security **of** the cloud -- the Bedrock service,
+its underlying infrastructure, and hardware. You are responsible for
+security **in** the cloud once you copy this code into your own service,
+including:
+
+- The IAM role/policy your process runs under (least-privilege access
+  to Bedrock and any other AWS APIs it calls).
+- Network placement -- if this runs in a VPC, its security groups and
+  egress rules are an additional layer alongside the SSRF guard above,
+  not a replacement for it.
+- Encryption in transit for anything you build around this bridge (the
+  guards here already enforce HTTPS-only by default; see above).
+- Monitoring, logging, and incident response for your deployment.
+
+The guards documented above (SSRF blocklist, size cap, redirect
+revalidation, format verification) are this sample's contribution to
+*your* side of that line. They are a reference implementation for one
+specific risk (fetching attacker-influenced URLs), not a complete
+security posture -- review and harden this code for your own threat
+model before running it against production traffic.

--- a/agentic-workloads/bedrock-image-url-bridge/examples/__init__.py
+++ b/agentic-workloads/bedrock-image-url-bridge/examples/__init__.py
@@ -1,0 +1,4 @@
+"""Example scripts showing the bedrock-image-url-bridge pattern applied to
+three different Bedrock endpoints: Mantle Chat Completions, Mantle
+Responses API, and native Runtime Converse.
+"""

--- a/agentic-workloads/bedrock-image-url-bridge/examples/lambda_handler.py
+++ b/agentic-workloads/bedrock-image-url-bridge/examples/lambda_handler.py
@@ -1,0 +1,87 @@
+"""AWS Lambda handler example: hosting the bridge behind a Lambda function.
+
+This is the "how do I actually host this" answer for the sample: the
+bridge itself (`bridge/core.py`) is not a service -- it's a function you
+call from wherever your application already builds a Bedrock request.
+This file shows one common hosting shape: a Lambda function that accepts
+{"image_url", "prompt", "model"} (e.g. from API Gateway or a direct
+Lambda invoke) and returns the model's answer.
+
+Deploy this however you deploy any Lambda function (SAM, CDK, Terraform,
+console zip upload) -- there is nothing bridge-specific about the
+deployment mechanics. Package `bridge/`, `requests`, `Pillow`, and
+`boto3` (or use the boto3 already bundled in the Lambda Python runtime)
+into your function's deployment artifact, and grant the function's
+execution role `bedrock:InvokeModel` for the model(s) you call.
+
+Local smoke test (no deployment needed):
+    python -c "
+from examples.lambda_handler import handler
+print(handler({
+    'image_url': 'https://placehold.co/64x64.jpg',
+    'prompt': 'Describe this image in one sentence.',
+}, None))
+"
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from bridge import resolve_image_urls
+from examples.mantle_chat_completions import DEFAULT_MODEL, call_mantle_chat_completions
+
+
+def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    """Lambda entry point.
+
+    Expects `event` to contain (either directly, or under a JSON-encoded
+    "body" key as API Gateway proxy integrations send it):
+      - image_url (required): https://, s3://, or data: image URL
+      - prompt (optional): defaults to a generic description prompt
+      - model (optional): defaults to DEFAULT_MODEL
+      - region (optional): defaults to AWS_REGION / us-east-1
+
+    Returns an API-Gateway-proxy-compatible response dict. Direct Lambda
+    invokes can ignore statusCode/headers and read body themselves.
+    """
+    body = event
+    if isinstance(event.get("body"), str):
+        body = json.loads(event["body"])
+
+    image_url = body.get("image_url")
+    if not image_url:
+        return {"statusCode": 400, "body": json.dumps({"error": "image_url is required"})}
+
+    prompt = body.get("prompt", "Describe this image in one sentence.")
+    model = body.get("model", DEFAULT_MODEL)
+    region = body.get("region", "us-east-1")
+
+    payload = {
+        "model": model,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": prompt},
+                    {"type": "image_url", "image_url": {"url": image_url}},
+                ],
+            }
+        ],
+    }
+
+    try:
+        resolved = resolve_image_urls(payload)
+        response = call_mantle_chat_completions(resolved, region=region)
+    except ValueError as exc:
+        # resolve_image_urls() raises ValueError for every rejection case
+        # (bad scheme, SSRF block, oversized download, invalid image) --
+        # these are caller errors, not server errors.
+        return {"statusCode": 400, "body": json.dumps({"error": str(exc)})}
+    except RuntimeError as exc:
+        # call_mantle_chat_completions() raises RuntimeError on a non-200
+        # response from bedrock-mantle.
+        return {"statusCode": 502, "body": json.dumps({"error": str(exc)})}
+
+    answer = response["choices"][0]["message"]["content"]
+    return {"statusCode": 200, "body": json.dumps({"answer": answer})}

--- a/agentic-workloads/bedrock-image-url-bridge/examples/lambda_handler.py
+++ b/agentic-workloads/bedrock-image-url-bridge/examples/lambda_handler.py
@@ -1,25 +1,39 @@
-"""AWS Lambda handler example: hosting the bridge behind a Lambda function.
+"""AWS Lambda handler example: hosting the bridge behind a Lambda function,
+using the *exact* Chat Completions request/response schema.
 
-This is the "how do I actually host this" answer for the sample: the
-bridge itself (`bridge/core.py`) is not a service -- it's a function you
-call from wherever your application already builds a Bedrock request.
-This file shows one common hosting shape: a Lambda function that accepts
-{"image_url", "prompt", "model"} (e.g. from API Gateway or a direct
-Lambda invoke) and returns the model's answer.
+This is deliberately schema-faithful, not a custom API: the handler
+accepts the same body you'd POST to `bedrock-mantle`'s
+`/v1/chat/completions` (or to OpenAI's `/v1/chat/completions`) --
+`{"model": ..., "messages": [...]}` -- and returns the same response
+shape a Chat Completions call returns. The only behavior added is that
+`http(s)://` image URLs in the request are resolved to inline `data:`
+URIs before the request reaches Bedrock.
+
+Why schema parity matters for migration: point an existing OpenAI Chat
+Completions client (or anything speaking that wire format) at this
+Lambda's Function URL or API Gateway endpoint instead of directly at
+`bedrock-mantle`, and it works unmodified -- including with `https://`
+image URLs that `bedrock-mantle` would otherwise reject. No custom
+request/response shape to adapt to.
 
 Deploy this however you deploy any Lambda function (SAM, CDK, Terraform,
 console zip upload) -- there is nothing bridge-specific about the
-deployment mechanics. Package `bridge/`, `requests`, `Pillow`, and
-`boto3` (or use the boto3 already bundled in the Lambda Python runtime)
-into your function's deployment artifact, and grant the function's
-execution role `bedrock:InvokeModel` for the model(s) you call.
+deployment mechanics. Package `bridge/`, `requests`, and `Pillow` (boto3
+ships with the Lambda Python runtime already) into your function's
+deployment artifact, and grant the function's execution role
+`bedrock:InvokeModel` for the model(s) you call.
 
 Local smoke test (no deployment needed):
     python -c "
 from examples.lambda_handler import handler
 print(handler({
-    'image_url': 'https://placehold.co/64x64.jpg',
-    'prompt': 'Describe this image in one sentence.',
+    'model': 'qwen.qwen3-vl-235b-a22b-instruct',
+    'messages': [
+        {'role': 'user', 'content': [
+            {'type': 'text', 'text': 'Describe this image in one sentence.'},
+            {'type': 'image_url', 'image_url': {'url': 'https://placehold.co/64x64.jpg'}},
+        ]}
+    ],
 }, None))
 "
 """
@@ -29,46 +43,44 @@ import json
 from typing import Any
 
 from bridge import resolve_image_urls
-from examples.mantle_chat_completions import DEFAULT_MODEL, call_mantle_chat_completions
+from examples.mantle_chat_completions import call_mantle_chat_completions
+
+_DEFAULT_REGION = "us-east-1"
+
+
+def _openai_error(status_code: int, message: str, error_type: str) -> dict[str, Any]:
+    """Build an OpenAI-style error envelope so error handling is also
+    drop-in compatible with an OpenAI Chat Completions client."""
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps({"error": {"message": message, "type": error_type}}),
+    }
 
 
 def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
-    """Lambda entry point.
+    """Lambda entry point. `event` is the exact Chat Completions request
+    body (`{"model": ..., "messages": [...]}`), passed either directly
+    (a raw Lambda invoke) or as a JSON-encoded API Gateway proxy `body`.
 
-    Expects `event` to contain (either directly, or under a JSON-encoded
-    "body" key as API Gateway proxy integrations send it):
-      - image_url (required): https://, s3://, or data: image URL
-      - prompt (optional): defaults to a generic description prompt
-      - model (optional): defaults to DEFAULT_MODEL
-      - region (optional): defaults to AWS_REGION / us-east-1
+    An optional top-level `region` key overrides the AWS region used to
+    call `bedrock-mantle` (defaults to `us-east-1`); it is stripped
+    before the request is forwarded, since it is not part of the Chat
+    Completions schema.
 
-    Returns an API-Gateway-proxy-compatible response dict. Direct Lambda
-    invokes can ignore statusCode/headers and read body themselves.
+    Returns an API-Gateway-proxy-compatible response dict whose `body`
+    is the *exact* Chat Completions response JSON on success, or an
+    OpenAI-style `{"error": {...}}` envelope on failure -- both are
+    what an unmodified OpenAI client already expects.
     """
-    body = event
+    payload = event
     if isinstance(event.get("body"), str):
-        body = json.loads(event["body"])
+        payload = json.loads(event["body"])
 
-    image_url = body.get("image_url")
-    if not image_url:
-        return {"statusCode": 400, "body": json.dumps({"error": "image_url is required"})}
+    if "messages" not in payload:
+        return _openai_error(400, "'messages' is a required property", "invalid_request_error")
 
-    prompt = body.get("prompt", "Describe this image in one sentence.")
-    model = body.get("model", DEFAULT_MODEL)
-    region = body.get("region", "us-east-1")
-
-    payload = {
-        "model": model,
-        "messages": [
-            {
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": prompt},
-                    {"type": "image_url", "image_url": {"url": image_url}},
-                ],
-            }
-        ],
-    }
+    region = payload.pop("region", _DEFAULT_REGION)
 
     try:
         resolved = resolve_image_urls(payload)
@@ -77,11 +89,14 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         # resolve_image_urls() raises ValueError for every rejection case
         # (bad scheme, SSRF block, oversized download, invalid image) --
         # these are caller errors, not server errors.
-        return {"statusCode": 400, "body": json.dumps({"error": str(exc)})}
+        return _openai_error(400, str(exc), "invalid_request_error")
     except RuntimeError as exc:
         # call_mantle_chat_completions() raises RuntimeError on a non-200
         # response from bedrock-mantle.
-        return {"statusCode": 502, "body": json.dumps({"error": str(exc)})}
+        return _openai_error(502, str(exc), "upstream_error")
 
-    answer = response["choices"][0]["message"]["content"]
-    return {"statusCode": 200, "body": json.dumps({"answer": answer})}
+    return {
+        "statusCode": 200,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(response),
+    }

--- a/agentic-workloads/bedrock-image-url-bridge/examples/mantle_chat_completions.py
+++ b/agentic-workloads/bedrock-image-url-bridge/examples/mantle_chat_completions.py
@@ -1,0 +1,83 @@
+"""Mantle Chat Completions example.
+
+Sends a Chat Completions request to the bedrock-mantle endpoint with a
+plain https image URL, routing it through resolve_image_urls() first
+since Mantle rejects raw https image_url values.
+
+Usage:
+    python -m examples.mantle_chat_completions \\
+        --image-url https://placehold.co/64x64.jpg \\
+        --prompt "Describe this image in one sentence." \\
+        --model qwen.qwen3-vl-235b-a22b-instruct
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+
+import boto3
+import requests
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+
+from bridge import resolve_image_urls
+
+DEFAULT_MODEL = "qwen.qwen3-vl-235b-a22b-instruct"
+
+
+def call_mantle_chat_completions(payload: dict, region: str = "us-east-1") -> dict:
+    """POST a Chat Completions payload to bedrock-mantle, SigV4-signed
+    using the credentials from AWS_PROFILE (or the default credential
+    chain) and AWS_REGION/region.
+
+    Raises RuntimeError with the response body on any non-200 response.
+    """
+    session = boto3.Session(profile_name=os.environ.get("AWS_PROFILE"), region_name=region)
+    creds = session.get_credentials()
+    if creds is None:
+        raise RuntimeError("No AWS credentials found (check AWS_PROFILE / credential chain)")
+    frozen = creds.get_frozen_credentials()
+
+    host = f"bedrock-mantle.{region}.api.aws"
+    url = f"https://{host}/v1/chat/completions"
+    data = json.dumps(payload)
+
+    req = AWSRequest(method="POST", url=url, data=data, headers={"Content-Type": "application/json"})
+    SigV4Auth(frozen, "bedrock", region).add_auth(req)
+    prepped = req.prepare()
+
+    resp = requests.post(url, headers=dict(prepped.headers), data=data, timeout=30)
+    if resp.status_code != 200:
+        raise RuntimeError(f"bedrock-mantle chat/completions failed ({resp.status_code}): {resp.text}")
+    return resp.json()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image-url", required=True, help="https:// or s3:// image URL")
+    parser.add_argument("--prompt", default="Describe this image in one sentence.")
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-east-1"))
+    args = parser.parse_args()
+
+    payload = {
+        "model": args.model,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": args.prompt},
+                    {"type": "image_url", "image_url": {"url": args.image_url}},
+                ],
+            }
+        ],
+    }
+
+    resolved = resolve_image_urls(payload)
+    response = call_mantle_chat_completions(resolved, region=args.region)
+    print(response["choices"][0]["message"]["content"])
+
+
+if __name__ == "__main__":
+    main()

--- a/agentic-workloads/bedrock-image-url-bridge/examples/mantle_responses_api.py
+++ b/agentic-workloads/bedrock-image-url-bridge/examples/mantle_responses_api.py
@@ -1,0 +1,101 @@
+"""Mantle Responses API example.
+
+Same interception pattern as mantle_chat_completions.py, but against the
+OpenAI Responses API shape (payload["input"][*]["content"][*] blocks of
+type "input_image").
+
+Usage:
+    python -m examples.mantle_responses_api \\
+        --image-url https://placehold.co/64x64.jpg \\
+        --prompt "Describe this image in one sentence." \\
+        --model qwen.qwen3-vl-235b-a22b-instruct
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+
+import boto3
+import requests
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+
+from bridge import resolve_image_urls
+
+# openai.gpt-oss-120b supports the /v1/responses API with vision input.
+# qwen3-vl (used for chat/completions) does NOT support /v1/responses --
+# verified live: "does not support the '/v1/responses' API".
+DEFAULT_MODEL = "openai.gpt-oss-120b"
+
+
+def call_mantle_responses(payload: dict, region: str = "us-east-1") -> dict:
+    """POST a Responses API payload to bedrock-mantle, SigV4-signed using
+    the credentials from AWS_PROFILE (or the default credential chain)
+    and AWS_REGION/region.
+
+    Raises RuntimeError with the response body on any non-200 response.
+    """
+    session = boto3.Session(profile_name=os.environ.get("AWS_PROFILE"), region_name=region)
+    creds = session.get_credentials()
+    if creds is None:
+        raise RuntimeError("No AWS credentials found (check AWS_PROFILE / credential chain)")
+    frozen = creds.get_frozen_credentials()
+
+    host = f"bedrock-mantle.{region}.api.aws"
+    url = f"https://{host}/v1/responses"
+    data = json.dumps(payload)
+
+    req = AWSRequest(method="POST", url=url, data=data, headers={"Content-Type": "application/json"})
+    SigV4Auth(frozen, "bedrock", region).add_auth(req)
+    prepped = req.prepare()
+
+    resp = requests.post(url, headers=dict(prepped.headers), data=data, timeout=30)
+    if resp.status_code != 200:
+        raise RuntimeError(f"bedrock-mantle responses failed ({resp.status_code}): {resp.text}")
+    return resp.json()
+
+
+def _extract_text(response: dict) -> str:
+    """Pull the assistant's text out of a Responses API result, skipping
+    reasoning blocks."""
+    for item in response.get("output", []):
+        if item.get("type") == "message":
+            for block in item.get("content", []):
+                if block.get("type") == "output_text":
+                    return block.get("text", "")
+    return ""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image-url", required=True, help="https:// or s3:// image URL")
+    parser.add_argument("--prompt", default="Describe this image in one sentence.")
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-east-1"))
+    args = parser.parse_args()
+
+    payload = {
+        "model": args.model,
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": args.prompt},
+                    # NOTE: "detail" is required here -- omitting it makes
+                    # bedrock-mantle's Rust-side deserializer reject the
+                    # whole input_image variant with a generic
+                    # "did not match any expected variant" error.
+                    {"type": "input_image", "image_url": args.image_url, "detail": "auto"},
+                ],
+            }
+        ],
+    }
+
+    resolved = resolve_image_urls(payload)
+    response = call_mantle_responses(resolved, region=args.region)
+    print(_extract_text(response))
+
+
+if __name__ == "__main__":
+    main()

--- a/agentic-workloads/bedrock-image-url-bridge/examples/preprocess_demo.py
+++ b/agentic-workloads/bedrock-image-url-bridge/examples/preprocess_demo.py
@@ -1,0 +1,184 @@
+"""Preprocessing demo: token-savings comparison, no AWS credentials needed.
+
+Demonstrates bridge.preprocess's patch-mode (OpenAI-style) and tile-mode
+(Anthropic-style) resizing against a real image, printing a before/after
+token estimate comparison so the savings are visible without making any
+Bedrock call. Optionally, if AWS_PROFILE is set, also runs a live
+bedrock-mantle Chat Completions call using the preprocessed image via
+resolve_image_urls()'s preprocess= hook (best-effort -- the script's core
+value, the token comparison, does not depend on this succeeding).
+
+Usage:
+    python -m examples.preprocess_demo --image-path ./photo.jpg --mode tile
+    python -m examples.preprocess_demo --image-path ./photo.jpg --mode patch --detail high
+    python -m examples.preprocess_demo --image-url https://example.com/photo.jpg --mode tile --max-tokens 2000
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import io
+import os
+
+from PIL import Image
+
+from bridge import resolve_image_urls
+from bridge.preprocess import (
+    calculate_patch_count,
+    is_photographic,
+    preprocess_patch_mode,
+    preprocess_tile_mode,
+)
+
+DEFAULT_MODEL = "qwen.qwen3-vl-235b-a22b-instruct"
+
+_PATCH_TOKEN_MULTIPLIER = 1.62
+_ANTHROPIC_TOKENS_PER_PIXEL_DIVISOR = 750
+
+
+def _load_image_bytes(args: argparse.Namespace) -> bytes:
+    """Return raw image bytes from --image-path (local file) or
+    --image-url (fetched through the SSRF-guarded resolve_image_urls
+    download path, without preprocessing, just to get raw bytes)."""
+    if args.image_path:
+        with open(args.image_path, "rb") as f:
+            return f.read()
+
+    # Fetch via the same guarded path resolve_image_urls uses, but we
+    # only want the raw bytes here (not a data: URI), so build a
+    # throwaway payload and pull the decoded bytes back out.
+    payload = {
+        "messages": [
+            {"role": "user", "content": [{"type": "image_url", "image_url": {"url": args.image_url}}]}
+        ]
+    }
+    resolved = resolve_image_urls(payload)
+    data_uri = resolved["messages"][0]["content"][0]["image_url"]["url"]
+    b64_part = data_uri.split(",", 1)[1]
+    return base64.b64decode(b64_part)
+
+
+def _naive_raw_token_estimate(width: int, height: int, mode: str) -> int:
+    """Estimate tokens for the RAW, unprocessed image using the same
+    formula the target mode would apply -- i.e. what it would cost
+    Bedrock today, with no client-side preprocessing at all."""
+    if mode == "patch":
+        patches = calculate_patch_count(width, height)
+        return round(patches * _PATCH_TOKEN_MULTIPLIER)
+    return round((width * height) / _ANTHROPIC_TOKENS_PER_PIXEL_DIVISOR)
+
+
+def _print_comparison(
+    mode: str,
+    original_width: int,
+    original_height: int,
+    raw_tokens: int,
+    resized_width: int,
+    resized_height: int,
+    final_tokens: int,
+) -> None:
+    print("Token usage summary:")
+    print(f"  Mode: {mode}")
+    print(f"  Before: {original_width}x{original_height} (~{raw_tokens} tokens, unprocessed)")
+    print(f"  After:  {resized_width}x{resized_height} (~{final_tokens} tokens, preprocessed)")
+    if raw_tokens > 0:
+        reduction_pct = 100 * (1 - final_tokens / raw_tokens)
+        print(f"  Reduction: {reduction_pct:.1f}% ({raw_tokens} -> {final_tokens} tokens)")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--image-path", help="Path to a local image file")
+    group.add_argument("--image-url", help="https:// or s3:// image URL")
+    parser.add_argument("--mode", choices=["patch", "tile"], default="tile")
+    parser.add_argument(
+        "--detail",
+        choices=["low", "high", "original"],
+        default="high",
+        help="Patch mode detail level (ignored for tile mode)",
+    )
+    parser.add_argument("--max-tokens", type=int, default=None, help="Optional token budget for the preprocessed image")
+    parser.add_argument("--prompt", default="Describe this image in one sentence.")
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-east-1"))
+    args = parser.parse_args()
+
+    raw_bytes = _load_image_bytes(args)
+
+    with Image.open(io.BytesIO(raw_bytes)) as img:
+        original_width, original_height = img.width, img.height
+
+    raw_tokens = _naive_raw_token_estimate(original_width, original_height, args.mode)
+
+    if args.mode == "patch":
+        result = preprocess_patch_mode(raw_bytes, detail=args.detail)
+    else:
+        result = preprocess_tile_mode(raw_bytes, max_token_budget=args.max_tokens)
+
+    resized = result.metadata.resized_dimensions
+    photo_kind = "jpeg/photo" if is_photographic(raw_bytes) else "diagram/screenshot"
+    print(f"  (photographic detection: {photo_kind} -> {result.mime_type})")
+    _print_comparison(
+        args.mode,
+        original_width,
+        original_height,
+        raw_tokens,
+        resized.width,
+        resized.height,
+        result.metadata.estimated_tokens,
+    )
+
+    # Optional, best-effort: if AWS credentials are configured, also
+    # demonstrate feeding the preprocessed bytes through
+    # resolve_image_urls()'s preprocess= hook and making a live
+    # bedrock-mantle call. This is not required for the script to prove
+    # its core value (the token comparison above).
+    if os.environ.get("AWS_PROFILE"):
+        print()
+        print("AWS_PROFILE detected -- attempting a live bedrock-mantle call...")
+        try:
+            from examples.mantle_chat_completions import call_mantle_chat_completions
+
+            if args.image_path:
+                # Local file: build a data: URI directly since there's no
+                # http(s) URL for resolve_image_urls to fetch.
+                data_uri = f"data:{result.mime_type};base64,{result.base64}"
+            else:
+                def _preprocess_hook(b: bytes) -> bytes:
+                    if args.mode == "patch":
+                        return preprocess_patch_mode(b, detail=args.detail).to_bytes()
+                    return preprocess_tile_mode(b, max_token_budget=args.max_tokens).to_bytes()
+
+                image_payload = {
+                    "messages": [
+                        {"role": "user", "content": [{"type": "image_url", "image_url": {"url": args.image_url}}]}
+                    ]
+                }
+                resolved = resolve_image_urls(image_payload, preprocess=_preprocess_hook)
+                data_uri = resolved["messages"][0]["content"][0]["image_url"]["url"]
+
+            chat_payload = {
+                "model": args.model,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": args.prompt},
+                            {"type": "image_url", "image_url": {"url": data_uri}},
+                        ],
+                    }
+                ],
+            }
+            response = call_mantle_chat_completions(chat_payload, region=args.region)
+            print("Model response:")
+            print(f"  {response['choices'][0]['message']['content']}")
+        except Exception as exc:  # best-effort: never fail the demo on this
+            print(f"  Live call skipped/failed (non-fatal): {exc}")
+    else:
+        print()
+        print("(Set AWS_PROFILE to also try a live bedrock-mantle call with the preprocessed image.)")
+
+
+if __name__ == "__main__":
+    main()

--- a/agentic-workloads/bedrock-image-url-bridge/examples/runtime_converse.py
+++ b/agentic-workloads/bedrock-image-url-bridge/examples/runtime_converse.py
@@ -1,0 +1,94 @@
+"""Bedrock Runtime Converse API example.
+
+Contrast case: unlike bedrock-mantle, the native bedrock-runtime Converse
+API has no image_url concept at all -- image blocks only accept raw
+bytes (or an s3Location for some models). It never accepts an arbitrary
+https URL. This example reuses the same resolve_image_urls() bridge to
+turn a Chat-Completions-shaped payload's http(s) image_url into a
+data: URI, then extracts the base64 bytes for a native Converse call.
+
+This shows the bridge is genuinely endpoint-agnostic: the same
+"make this URL into safe inline bytes" utility feeds both an
+OpenAI-compatible endpoint (which wants a data: URI) and a native
+endpoint (which wants raw bytes).
+
+Usage:
+    python -m examples.runtime_converse \\
+        --image-url https://placehold.co/64x64.jpg \\
+        --prompt "Describe this image in one sentence." \\
+        --model anthropic.claude-haiku-4-5
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import os
+
+import boto3
+
+from bridge import resolve_image_urls
+
+# Cross-region inference profile ID -- required for on-demand Converse
+# calls to this model in most accounts/regions.
+DEFAULT_MODEL = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+_MIME_TO_FORMAT = {
+    "image/jpeg": "jpeg",
+    "image/png": "png",
+    "image/gif": "gif",
+    "image/webp": "webp",
+}
+
+
+def _data_uri_to_bytes_and_format(data_uri: str) -> tuple[bytes, str]:
+    """Split a data:<mime>;base64,<...> URI into (raw_bytes, converse_format)."""
+    header, encoded = data_uri.split(",", 1)
+    mime = header.split(":", 1)[1].split(";", 1)[0]
+    fmt = _MIME_TO_FORMAT.get(mime)
+    if fmt is None:
+        raise ValueError(f"Unsupported image mime type for Converse: {mime!r}")
+    return base64.b64decode(encoded), fmt
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image-url", required=True, help="https:// image URL")
+    parser.add_argument("--prompt", default="Describe this image in one sentence.")
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-east-1"))
+    args = parser.parse_args()
+
+    # Reuse the same bridge shape (Chat Completions) purely as a
+    # convenient carrier for the URL -> data: URI conversion.
+    carrier_payload = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"type": "image_url", "image_url": {"url": args.image_url}}],
+            }
+        ]
+    }
+    resolved = resolve_image_urls(carrier_payload)
+    data_uri = resolved["messages"][0]["content"][0]["image_url"]["url"]
+    image_bytes, image_format = _data_uri_to_bytes_and_format(data_uri)
+
+    session = boto3.Session(profile_name=os.environ.get("AWS_PROFILE"), region_name=args.region)
+    client = session.client("bedrock-runtime", region_name=args.region)
+
+    response = client.converse(
+        modelId=args.model,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"image": {"format": image_format, "source": {"bytes": image_bytes}}},
+                    {"text": args.prompt},
+                ],
+            }
+        ],
+    )
+    print(response["output"]["message"]["content"][0]["text"])
+
+
+if __name__ == "__main__":
+    main()

--- a/agentic-workloads/bedrock-image-url-bridge/pyproject.toml
+++ b/agentic-workloads/bedrock-image-url-bridge/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "bedrock-image-url-bridge"
+version = "0.1.0"
+description = "Make http(s) image URLs safe to send to Amazon Bedrock's mantle and runtime APIs"
+requires-python = ">=3.10"
+dependencies = [
+    "requests>=2.31",
+    "Pillow>=10.0",
+    "boto3>=1.34",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.4"]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["bridge*", "examples*"]

--- a/agentic-workloads/bedrock-image-url-bridge/tests/test_bridge_live.py
+++ b/agentic-workloads/bedrock-image-url-bridge/tests/test_bridge_live.py
@@ -1,0 +1,98 @@
+"""Live integration tests -- real calls against bedrock-mantle and
+bedrock-runtime. Skipped by default; set BRIDGE_LIVE_TEST=1 to enable.
+
+Requires AWS_PROFILE and AWS_REGION env vars pointing at an account with
+Bedrock Mantle + Runtime access (verified against profile
+agentcore-deploy, region us-east-1).
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from bridge import resolve_image_urls
+from examples.mantle_chat_completions import call_mantle_chat_completions
+from examples.mantle_responses_api import _extract_text, call_mantle_responses
+
+LIVE = os.environ.get("BRIDGE_LIVE_TEST") == "1"
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+TEST_IMAGE_URL = "https://placehold.co/64x64.jpg"
+TEST_MODEL = "qwen.qwen3-vl-235b-a22b-instruct"
+
+skip_reason = "Set BRIDGE_LIVE_TEST=1 (with AWS_PROFILE/AWS_REGION) to run live Bedrock calls"
+
+
+@pytest.mark.skipif(not LIVE, reason=skip_reason)
+def test_mantle_chat_completions_live():
+    payload = {
+        "model": TEST_MODEL,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this image in one short sentence."},
+                    {"type": "image_url", "image_url": {"url": TEST_IMAGE_URL}},
+                ],
+            }
+        ],
+    }
+    resolved = resolve_image_urls(payload)
+    response = call_mantle_chat_completions(resolved, region=REGION)
+    content = response["choices"][0]["message"]["content"]
+    assert isinstance(content, str)
+    assert len(content) > 0
+
+
+@pytest.mark.skipif(not LIVE, reason=skip_reason)
+def test_mantle_responses_api_live():
+    payload = {
+        "model": "openai.gpt-oss-120b",
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "Say hello in one short sentence."},
+                ],
+            }
+        ],
+    }
+    # text-only sanity check on the Responses API path (image_url on
+    # Responses API is exercised via resolve_image_urls unit tests; this
+    # confirms the live call plumbing itself works end to end)
+    response = call_mantle_responses(payload, region=REGION)
+    text = _extract_text(response)
+    assert isinstance(text, str)
+    assert len(text) > 0
+
+
+@pytest.mark.skipif(not LIVE, reason=skip_reason)
+def test_runtime_converse_live():
+    import boto3
+
+    from examples.runtime_converse import _data_uri_to_bytes_and_format
+
+    carrier_payload = {
+        "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": TEST_IMAGE_URL}}]}]
+    }
+    resolved = resolve_image_urls(carrier_payload)
+    data_uri = resolved["messages"][0]["content"][0]["image_url"]["url"]
+    image_bytes, image_format = _data_uri_to_bytes_and_format(data_uri)
+
+    session = boto3.Session(profile_name=os.environ.get("AWS_PROFILE"), region_name=REGION)
+    client = session.client("bedrock-runtime", region_name=REGION)
+    response = client.converse(
+        modelId="anthropic.claude-haiku-4-5",
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"image": {"format": image_format, "source": {"bytes": image_bytes}}},
+                    {"text": "Describe this image in one short sentence."},
+                ],
+            }
+        ],
+    )
+    text = response["output"]["message"]["content"][0]["text"]
+    assert isinstance(text, str)
+    assert len(text) > 0

--- a/agentic-workloads/bedrock-image-url-bridge/tests/test_bridge_live.py
+++ b/agentic-workloads/bedrock-image-url-bridge/tests/test_bridge_live.py
@@ -2,8 +2,8 @@
 bedrock-runtime. Skipped by default; set BRIDGE_LIVE_TEST=1 to enable.
 
 Requires AWS_PROFILE and AWS_REGION env vars pointing at an account with
-Bedrock Mantle + Runtime access (verified against profile
-agentcore-deploy, region us-east-1).
+Bedrock Mantle + Runtime access (verified live against a real account,
+region us-east-1).
 """
 from __future__ import annotations
 

--- a/agentic-workloads/bedrock-image-url-bridge/tests/test_bridge_unit.py
+++ b/agentic-workloads/bedrock-image-url-bridge/tests/test_bridge_unit.py
@@ -1,0 +1,265 @@
+"""Unit tests for bridge.core.resolve_image_urls.
+
+No network or AWS calls -- all HTTP is mocked via unittest.mock.
+"""
+from __future__ import annotations
+
+import base64
+import io
+import unittest
+from unittest import mock
+
+from PIL import Image
+
+from bridge.core import resolve_image_urls
+
+
+def _make_jpeg_bytes() -> bytes:
+    img = Image.new("RGB", (4, 4), color=(255, 0, 0))
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+class _FakeResponse:
+    """Minimal stand-in for requests.Response covering what core.py uses."""
+
+    def __init__(self, content: bytes, status_code: int = 200, headers: dict | None = None):
+        self._content = content
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.is_redirect = False
+        self._closed = False
+
+    def iter_content(self, chunk_size: int = 65536):
+        data = self._content
+        for i in range(0, len(data), chunk_size):
+            yield data[i : i + chunk_size]
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise Exception(f"HTTP {self.status_code}")
+
+    def close(self):
+        self._closed = True
+
+
+class PassthroughTests(unittest.TestCase):
+    def test_s3_url_passthrough_chat_completions(self):
+        payload = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "image_url", "image_url": {"url": "s3://bucket/key.jpg"}}],
+                }
+            ]
+        }
+        result = resolve_image_urls(payload)
+        self.assertEqual(
+            result["messages"][0]["content"][0]["image_url"]["url"], "s3://bucket/key.jpg"
+        )
+
+    def test_data_uri_passthrough(self):
+        data_uri = "data:image/jpeg;base64,AAAA"
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": data_uri}}]}]
+        }
+        result = resolve_image_urls(payload)
+        self.assertEqual(result["messages"][0]["content"][0]["image_url"]["url"], data_uri)
+
+    def test_no_image_blocks_unchanged(self):
+        payload = {"messages": [{"role": "user", "content": [{"type": "text", "text": "hello"}]}]}
+        result = resolve_image_urls(payload)
+        self.assertEqual(result, payload)
+
+    def test_does_not_mutate_input(self):
+        payload = {
+            "messages": [
+                {"role": "user", "content": [{"type": "image_url", "image_url": {"url": "s3://bucket/key.jpg"}}]}
+            ]
+        }
+        original = {
+            "messages": [
+                {"role": "user", "content": [{"type": "image_url", "image_url": {"url": "s3://bucket/key.jpg"}}]}
+            ]
+        }
+        resolve_image_urls(payload)
+        self.assertEqual(payload, original)
+
+
+class HttpsConversionTests(unittest.TestCase):
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    @mock.patch("bridge.core.requests.get")
+    def test_https_url_converted_to_data_uri_string_form(self, mock_get, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+        jpeg_bytes = _make_jpeg_bytes()
+        mock_get.return_value = _FakeResponse(jpeg_bytes, headers={"Content-Length": str(len(jpeg_bytes))})
+
+        payload = {
+            "input": [
+                {
+                    "role": "user",
+                    "content": [{"type": "input_image", "image_url": "https://example.com/cat.jpg"}],
+                }
+            ]
+        }
+        result = resolve_image_urls(payload)
+        resolved_url = result["input"][0]["content"][0]["image_url"]
+        self.assertTrue(resolved_url.startswith("data:image/jpeg;base64,"))
+        b64_part = resolved_url.split(",", 1)[1]
+        self.assertEqual(base64.b64decode(b64_part), jpeg_bytes)
+
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    @mock.patch("bridge.core.requests.get")
+    def test_https_url_converted_object_form(self, mock_get, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+        jpeg_bytes = _make_jpeg_bytes()
+        mock_get.return_value = _FakeResponse(jpeg_bytes, headers={"Content-Length": str(len(jpeg_bytes))})
+
+        payload = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "image_url", "image_url": {"url": "https://example.com/cat.jpg"}}],
+                }
+            ]
+        }
+        result = resolve_image_urls(payload)
+        resolved_url = result["messages"][0]["content"][0]["image_url"]["url"]
+        self.assertTrue(resolved_url.startswith("data:image/jpeg;base64,"))
+
+
+class SchemeAndInsecureHttpTests(unittest.TestCase):
+    def test_unsupported_scheme_raises(self):
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "file:///etc/passwd"}}]}]
+        }
+        with self.assertRaisesRegex(ValueError, "Unsupported image_url scheme"):
+            resolve_image_urls(payload)
+
+    def test_http_rejected_by_default(self):
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "http://example.com/cat.jpg"}}]}]
+        }
+        with self.assertRaisesRegex(ValueError, "insecure http"):
+            resolve_image_urls(payload)
+
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    @mock.patch("bridge.core.requests.get")
+    def test_http_allowed_with_override(self, mock_get, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+        jpeg_bytes = _make_jpeg_bytes()
+        mock_get.return_value = _FakeResponse(jpeg_bytes, headers={"Content-Length": str(len(jpeg_bytes))})
+
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "http://example.com/cat.jpg"}}]}]
+        }
+        result = resolve_image_urls(payload, allow_insecure_http=True)
+        resolved_url = result["messages"][0]["content"][0]["image_url"]["url"]
+        self.assertTrue(resolved_url.startswith("data:image/jpeg;base64,"))
+
+
+class SsrfGuardTests(unittest.TestCase):
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    def test_blocks_loopback_ip(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("127.0.0.1", 0))]
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://evil.example/x.jpg"}}]}]
+        }
+        with self.assertRaisesRegex(ValueError, "blocked address"):
+            resolve_image_urls(payload)
+
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    def test_blocks_metadata_ip(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("169.254.169.254", 0))]
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://evil.example/x.jpg"}}]}]
+        }
+        with self.assertRaisesRegex(ValueError, "blocked address"):
+            resolve_image_urls(payload)
+
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    def test_blocks_private_ip(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("10.0.0.5", 0))]
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://evil.example/x.jpg"}}]}]
+        }
+        with self.assertRaisesRegex(ValueError, "blocked address"):
+            resolve_image_urls(payload)
+
+
+class SizeCapTests(unittest.TestCase):
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    @mock.patch("bridge.core.requests.get")
+    def test_content_length_over_cap_raises_before_reading_body(self, mock_get, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+
+        class _NeverIterateResponse(_FakeResponse):
+            def iter_content(self, chunk_size: int = 65536):
+                raise AssertionError("iter_content should not be called when Content-Length already exceeds cap")
+
+        mock_get.return_value = _NeverIterateResponse(b"x" * 10, headers={"Content-Length": str(50 * 1024 * 1024)})
+
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://example.com/huge.jpg"}}]}]
+        }
+        with self.assertRaisesRegex(ValueError, "exceeds max_bytes"):
+            resolve_image_urls(payload, max_bytes=20 * 1024 * 1024)
+
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    @mock.patch("bridge.core.requests.get")
+    def test_streamed_body_over_cap_without_content_length(self, mock_get, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+        big_body = b"x" * (1024 * 1024)  # 1 MiB, no Content-Length header
+        mock_get.return_value = _FakeResponse(big_body, headers={})
+
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://example.com/huge.jpg"}}]}]
+        }
+        with self.assertRaisesRegex(ValueError, "exceeded max_bytes"):
+            resolve_image_urls(payload, max_bytes=1024)  # tiny cap forces overflow mid-stream
+
+
+class InvalidImageTests(unittest.TestCase):
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    @mock.patch("bridge.core.requests.get")
+    def test_non_image_bytes_rejected(self, mock_get, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+        not_an_image = b"not an image, just plain text bytes"
+        mock_get.return_value = _FakeResponse(not_an_image, headers={"Content-Length": str(len(not_an_image))})
+
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://example.com/fake.jpg"}}]}]
+        }
+        with self.assertRaisesRegex(ValueError, "not a valid image"):
+            resolve_image_urls(payload)
+
+
+class MixedShapeTests(unittest.TestCase):
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    @mock.patch("bridge.core.requests.get")
+    def test_both_chat_completions_and_responses_shapes_in_one_call(self, mock_get, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+        jpeg_bytes = _make_jpeg_bytes()
+        mock_get.return_value = _FakeResponse(jpeg_bytes, headers={"Content-Length": str(len(jpeg_bytes))})
+
+        chat_payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://example.com/a.jpg"}}]}]
+        }
+        responses_payload = {
+            "input": [{"role": "user", "content": [{"type": "input_image", "image_url": "https://example.com/b.jpg"}]}]
+        }
+
+        chat_result = resolve_image_urls(chat_payload)
+        responses_result = resolve_image_urls(responses_payload)
+
+        self.assertTrue(
+            chat_result["messages"][0]["content"][0]["image_url"]["url"].startswith("data:image/jpeg;base64,")
+        )
+        self.assertTrue(
+            responses_result["input"][0]["content"][0]["image_url"].startswith("data:image/jpeg;base64,")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agentic-workloads/bedrock-image-url-bridge/tests/test_bridge_unit.py
+++ b/agentic-workloads/bedrock-image-url-bridge/tests/test_bridge_unit.py
@@ -24,11 +24,11 @@ def _make_jpeg_bytes() -> bytes:
 class _FakeResponse:
     """Minimal stand-in for requests.Response covering what core.py uses."""
 
-    def __init__(self, content: bytes, status_code: int = 200, headers: dict | None = None):
+    def __init__(self, content: bytes, status_code: int = 200, headers: dict | None = None, is_redirect: bool = False):
         self._content = content
         self.status_code = status_code
         self.headers = headers or {}
-        self.is_redirect = False
+        self.is_redirect = is_redirect
         self._closed = False
 
     def iter_content(self, chunk_size: int = 65536):
@@ -233,6 +233,142 @@ class InvalidImageTests(unittest.TestCase):
         }
         with self.assertRaisesRegex(ValueError, "not a valid image"):
             resolve_image_urls(payload)
+
+
+class RedirectTests(unittest.TestCase):
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    @mock.patch("bridge.core.requests.get")
+    def test_redirect_follows_absolute_url(self, mock_get, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+        jpeg_bytes = _make_jpeg_bytes()
+
+        # First response: redirect
+        redirect_response = _FakeResponse(b"", status_code=302, headers={"Location": "https://example.com/new.jpg"}, is_redirect=True)
+        # Second response: actual image
+        final_response = _FakeResponse(jpeg_bytes, headers={"Content-Length": str(len(jpeg_bytes))})
+
+        mock_get.side_effect = [redirect_response, final_response]
+
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://example.com/old.jpg"}}]}]
+        }
+        result = resolve_image_urls(payload)
+        resolved_url = result["messages"][0]["content"][0]["image_url"]["url"]
+        self.assertTrue(resolved_url.startswith("data:image/jpeg;base64,"))
+
+        # Should call both URLs
+        self.assertEqual(mock_get.call_count, 2)
+        mock_get.assert_any_call("https://example.com/old.jpg", stream=True, timeout=10.0, allow_redirects=False)
+        mock_get.assert_any_call("https://example.com/new.jpg", stream=True, timeout=10.0, allow_redirects=False)
+
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    @mock.patch("bridge.core.requests.get")
+    def test_redirect_resolves_relative_url(self, mock_get, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+        jpeg_bytes = _make_jpeg_bytes()
+
+        # First response: relative redirect
+        redirect_response = _FakeResponse(b"", status_code=302, headers={"Location": "../images/new.jpg"}, is_redirect=True)
+        # Second response: actual image
+        final_response = _FakeResponse(jpeg_bytes, headers={"Content-Length": str(len(jpeg_bytes))})
+
+        mock_get.side_effect = [redirect_response, final_response]
+
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://example.com/old/cat.jpg"}}]}]
+        }
+        result = resolve_image_urls(payload)
+        resolved_url = result["messages"][0]["content"][0]["image_url"]["url"]
+        self.assertTrue(resolved_url.startswith("data:image/jpeg;base64,"))
+
+        # Should resolve relative URL correctly
+        self.assertEqual(mock_get.call_count, 2)
+        mock_get.assert_any_call("https://example.com/old/cat.jpg", stream=True, timeout=10.0, allow_redirects=False)
+        mock_get.assert_any_call("https://example.com/images/new.jpg", stream=True, timeout=10.0, allow_redirects=False)
+
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    @mock.patch("bridge.core.requests.get")
+    def test_redirect_validates_each_hop(self, mock_get, mock_getaddrinfo):
+        # First URL resolves to safe IP, second to blocked IP
+        def side_effect_getaddrinfo(hostname, port):
+            if hostname == "safe.example":
+                return [(None, None, None, None, ("93.184.216.34", 0))]
+            elif hostname == "evil.example":
+                return [(None, None, None, None, ("127.0.0.1", 0))]
+
+        mock_getaddrinfo.side_effect = side_effect_getaddrinfo
+
+        # Redirect to blocked host
+        redirect_response = _FakeResponse(b"", status_code=302, headers={"Location": "https://evil.example/hack.jpg"}, is_redirect=True)
+        mock_get.return_value = redirect_response
+
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://safe.example/cat.jpg"}}]}]
+        }
+        with self.assertRaisesRegex(ValueError, "blocked address"):
+            resolve_image_urls(payload)
+
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    @mock.patch("bridge.core.requests.get")
+    def test_redirect_missing_location_header(self, mock_get, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+
+        # Redirect without Location header
+        redirect_response = _FakeResponse(b"", status_code=302, headers={}, is_redirect=True)
+        mock_get.return_value = redirect_response
+
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://example.com/cat.jpg"}}]}]
+        }
+        with self.assertRaisesRegex(ValueError, "no Location header"):
+            resolve_image_urls(payload)
+
+
+class MalformedHeaderTests(unittest.TestCase):
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    @mock.patch("bridge.core.requests.get")
+    def test_malformed_content_length_raises(self, mock_get, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+
+        # Content-Length with non-numeric value
+        mock_get.return_value = _FakeResponse(b"x" * 10, headers={"Content-Length": "not-a-number"})
+
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://example.com/cat.jpg"}}]}]
+        }
+        with self.assertRaisesRegex(ValueError, "Malformed Content-Length header"):
+            resolve_image_urls(payload)
+
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    @mock.patch("bridge.core.requests.get")
+    def test_empty_content_length_raises(self, mock_get, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+
+        # Empty Content-Length header
+        mock_get.return_value = _FakeResponse(b"x" * 10, headers={"Content-Length": ""})
+
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://example.com/cat.jpg"}}]}]
+        }
+        with self.assertRaisesRegex(ValueError, "Malformed Content-Length header"):
+            resolve_image_urls(payload)
+
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    @mock.patch("bridge.core.requests.get")
+    def test_negative_content_length_accepted(self, mock_get, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+        jpeg_bytes = _make_jpeg_bytes()
+
+        # Negative Content-Length (weird but technically valid integer)
+        mock_get.return_value = _FakeResponse(jpeg_bytes, headers={"Content-Length": "-1"})
+
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://example.com/cat.jpg"}}]}]
+        }
+        # Should not raise - negative is less than max_bytes, so check is bypassed
+        result = resolve_image_urls(payload)
+        resolved_url = result["messages"][0]["content"][0]["image_url"]["url"]
+        self.assertTrue(resolved_url.startswith("data:image/jpeg;base64,"))
 
 
 class MixedShapeTests(unittest.TestCase):

--- a/agentic-workloads/bedrock-image-url-bridge/tests/test_bridge_unit.py
+++ b/agentic-workloads/bedrock-image-url-bridge/tests/test_bridge_unit.py
@@ -471,6 +471,91 @@ class CacheTests(unittest.TestCase):
         self.assertEqual(mock_get.call_count, 2)
 
 
+class PreprocessHookTests(unittest.TestCase):
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    @mock.patch("bridge.core.requests.Session.get")
+    def test_preprocess_hook_receives_downloaded_bytes(self, mock_get, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+        jpeg_bytes = _make_jpeg_bytes()
+        mock_get.return_value = _FakeResponse(jpeg_bytes, headers={"Content-Length": str(len(jpeg_bytes))})
+
+        received: list[bytes] = []
+
+        def _preprocess(raw: bytes) -> bytes:
+            received.append(raw)
+            return raw
+
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://example.com/a.jpg"}}]}]
+        }
+        resolve_image_urls(payload, preprocess=_preprocess)
+
+        self.assertEqual(len(received), 1)
+        self.assertEqual(received[0], jpeg_bytes)
+
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    @mock.patch("bridge.core.requests.Session.get")
+    def test_preprocess_hook_output_reflected_in_data_uri(self, mock_get, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+        jpeg_bytes = _make_jpeg_bytes()
+        mock_get.return_value = _FakeResponse(jpeg_bytes, headers={"Content-Length": str(len(jpeg_bytes))})
+
+        # A real preprocess step: re-encode a smaller version of the same
+        # image via bridge.preprocess so the output is still a valid,
+        # independently-verifiable image (not just a byte transform).
+        from bridge.preprocess import preprocess_patch_mode
+
+        def _preprocess(raw: bytes) -> bytes:
+            return preprocess_patch_mode(raw, detail="low").to_bytes()
+
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://example.com/a.jpg"}}]}]
+        }
+        result = resolve_image_urls(payload, preprocess=_preprocess)
+        resolved_url = result["messages"][0]["content"][0]["image_url"]["url"]
+        self.assertTrue(resolved_url.startswith("data:image/jpeg;base64,"))
+
+        b64_part = resolved_url.split(",", 1)[1]
+        decoded = base64.b64decode(b64_part)
+        # The preprocessed output differs from the raw download (it was
+        # resized to 512x512 by 'low' detail) but is still re-verified as
+        # a valid image by _bytes_to_data_uri.
+        self.assertNotEqual(decoded, jpeg_bytes)
+        with Image.open(io.BytesIO(decoded)) as img:
+            img.verify()
+
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    @mock.patch("bridge.core.requests.Session.get")
+    def test_preprocess_none_is_unchanged_default_behavior(self, mock_get, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+        jpeg_bytes = _make_jpeg_bytes()
+        mock_get.return_value = _FakeResponse(jpeg_bytes, headers={"Content-Length": str(len(jpeg_bytes))})
+
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://example.com/a.jpg"}}]}]
+        }
+        result = resolve_image_urls(payload)  # preprocess not passed -- default None
+        resolved_url = result["messages"][0]["content"][0]["image_url"]["url"]
+        b64_part = resolved_url.split(",", 1)[1]
+        self.assertEqual(base64.b64decode(b64_part), jpeg_bytes)
+
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    @mock.patch("bridge.core.requests.Session.get")
+    def test_preprocess_invalid_output_still_rejected(self, mock_get, mock_getaddrinfo):
+        """Preprocessed output that isn't a real image must still be
+        rejected by the existing Pillow verification -- the hook cannot
+        bypass that check."""
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+        jpeg_bytes = _make_jpeg_bytes()
+        mock_get.return_value = _FakeResponse(jpeg_bytes, headers={"Content-Length": str(len(jpeg_bytes))})
+
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://example.com/a.jpg"}}]}]
+        }
+        with self.assertRaisesRegex(ValueError, "not a valid image"):
+            resolve_image_urls(payload, preprocess=lambda raw: b"not an image anymore")
+
+
 class SessionReuseTests(unittest.TestCase):
     @mock.patch("bridge.core.socket.getaddrinfo")
     def test_default_session_is_reused_across_calls(self, mock_getaddrinfo):

--- a/agentic-workloads/bedrock-image-url-bridge/tests/test_bridge_unit.py
+++ b/agentic-workloads/bedrock-image-url-bridge/tests/test_bridge_unit.py
@@ -9,6 +9,7 @@ import io
 import unittest
 from unittest import mock
 
+import requests
 from PIL import Image
 
 from bridge.core import resolve_image_urls
@@ -89,7 +90,7 @@ class PassthroughTests(unittest.TestCase):
 
 class HttpsConversionTests(unittest.TestCase):
     @mock.patch("bridge.core.socket.getaddrinfo")
-    @mock.patch("bridge.core.requests.get")
+    @mock.patch("bridge.core.requests.Session.get")
     def test_https_url_converted_to_data_uri_string_form(self, mock_get, mock_getaddrinfo):
         mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
         jpeg_bytes = _make_jpeg_bytes()
@@ -110,7 +111,7 @@ class HttpsConversionTests(unittest.TestCase):
         self.assertEqual(base64.b64decode(b64_part), jpeg_bytes)
 
     @mock.patch("bridge.core.socket.getaddrinfo")
-    @mock.patch("bridge.core.requests.get")
+    @mock.patch("bridge.core.requests.Session.get")
     def test_https_url_converted_object_form(self, mock_get, mock_getaddrinfo):
         mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
         jpeg_bytes = _make_jpeg_bytes()
@@ -145,7 +146,7 @@ class SchemeAndInsecureHttpTests(unittest.TestCase):
             resolve_image_urls(payload)
 
     @mock.patch("bridge.core.socket.getaddrinfo")
-    @mock.patch("bridge.core.requests.get")
+    @mock.patch("bridge.core.requests.Session.get")
     def test_http_allowed_with_override(self, mock_get, mock_getaddrinfo):
         mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
         jpeg_bytes = _make_jpeg_bytes()
@@ -190,7 +191,7 @@ class SsrfGuardTests(unittest.TestCase):
 
 class SizeCapTests(unittest.TestCase):
     @mock.patch("bridge.core.socket.getaddrinfo")
-    @mock.patch("bridge.core.requests.get")
+    @mock.patch("bridge.core.requests.Session.get")
     def test_content_length_over_cap_raises_before_reading_body(self, mock_get, mock_getaddrinfo):
         mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
 
@@ -207,7 +208,7 @@ class SizeCapTests(unittest.TestCase):
             resolve_image_urls(payload, max_bytes=20 * 1024 * 1024)
 
     @mock.patch("bridge.core.socket.getaddrinfo")
-    @mock.patch("bridge.core.requests.get")
+    @mock.patch("bridge.core.requests.Session.get")
     def test_streamed_body_over_cap_without_content_length(self, mock_get, mock_getaddrinfo):
         mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
         big_body = b"x" * (1024 * 1024)  # 1 MiB, no Content-Length header
@@ -222,7 +223,7 @@ class SizeCapTests(unittest.TestCase):
 
 class InvalidImageTests(unittest.TestCase):
     @mock.patch("bridge.core.socket.getaddrinfo")
-    @mock.patch("bridge.core.requests.get")
+    @mock.patch("bridge.core.requests.Session.get")
     def test_non_image_bytes_rejected(self, mock_get, mock_getaddrinfo):
         mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
         not_an_image = b"not an image, just plain text bytes"
@@ -237,7 +238,7 @@ class InvalidImageTests(unittest.TestCase):
 
 class RedirectTests(unittest.TestCase):
     @mock.patch("bridge.core.socket.getaddrinfo")
-    @mock.patch("bridge.core.requests.get")
+    @mock.patch("bridge.core.requests.Session.get")
     def test_redirect_follows_absolute_url(self, mock_get, mock_getaddrinfo):
         mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
         jpeg_bytes = _make_jpeg_bytes()
@@ -262,7 +263,7 @@ class RedirectTests(unittest.TestCase):
         mock_get.assert_any_call("https://example.com/new.jpg", stream=True, timeout=10.0, allow_redirects=False)
 
     @mock.patch("bridge.core.socket.getaddrinfo")
-    @mock.patch("bridge.core.requests.get")
+    @mock.patch("bridge.core.requests.Session.get")
     def test_redirect_resolves_relative_url(self, mock_get, mock_getaddrinfo):
         mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
         jpeg_bytes = _make_jpeg_bytes()
@@ -287,7 +288,7 @@ class RedirectTests(unittest.TestCase):
         mock_get.assert_any_call("https://example.com/images/new.jpg", stream=True, timeout=10.0, allow_redirects=False)
 
     @mock.patch("bridge.core.socket.getaddrinfo")
-    @mock.patch("bridge.core.requests.get")
+    @mock.patch("bridge.core.requests.Session.get")
     def test_redirect_validates_each_hop(self, mock_get, mock_getaddrinfo):
         # First URL resolves to safe IP, second to blocked IP
         def side_effect_getaddrinfo(hostname, port):
@@ -309,7 +310,7 @@ class RedirectTests(unittest.TestCase):
             resolve_image_urls(payload)
 
     @mock.patch("bridge.core.socket.getaddrinfo")
-    @mock.patch("bridge.core.requests.get")
+    @mock.patch("bridge.core.requests.Session.get")
     def test_redirect_missing_location_header(self, mock_get, mock_getaddrinfo):
         mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
 
@@ -326,7 +327,7 @@ class RedirectTests(unittest.TestCase):
 
 class MalformedHeaderTests(unittest.TestCase):
     @mock.patch("bridge.core.socket.getaddrinfo")
-    @mock.patch("bridge.core.requests.get")
+    @mock.patch("bridge.core.requests.Session.get")
     def test_malformed_content_length_raises(self, mock_get, mock_getaddrinfo):
         mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
 
@@ -340,7 +341,7 @@ class MalformedHeaderTests(unittest.TestCase):
             resolve_image_urls(payload)
 
     @mock.patch("bridge.core.socket.getaddrinfo")
-    @mock.patch("bridge.core.requests.get")
+    @mock.patch("bridge.core.requests.Session.get")
     def test_empty_content_length_raises(self, mock_get, mock_getaddrinfo):
         mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
 
@@ -354,7 +355,7 @@ class MalformedHeaderTests(unittest.TestCase):
             resolve_image_urls(payload)
 
     @mock.patch("bridge.core.socket.getaddrinfo")
-    @mock.patch("bridge.core.requests.get")
+    @mock.patch("bridge.core.requests.Session.get")
     def test_negative_content_length_accepted(self, mock_get, mock_getaddrinfo):
         mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
         jpeg_bytes = _make_jpeg_bytes()
@@ -373,7 +374,7 @@ class MalformedHeaderTests(unittest.TestCase):
 
 class MixedShapeTests(unittest.TestCase):
     @mock.patch("bridge.core.socket.getaddrinfo")
-    @mock.patch("bridge.core.requests.get")
+    @mock.patch("bridge.core.requests.Session.get")
     def test_both_chat_completions_and_responses_shapes_in_one_call(self, mock_get, mock_getaddrinfo):
         mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
         jpeg_bytes = _make_jpeg_bytes()
@@ -395,6 +396,126 @@ class MixedShapeTests(unittest.TestCase):
         self.assertTrue(
             responses_result["input"][0]["content"][0]["image_url"].startswith("data:image/jpeg;base64,")
         )
+
+
+class CacheTests(unittest.TestCase):
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    @mock.patch("bridge.core.requests.Session.get")
+    def test_cache_miss_downloads_and_populates_cache(self, mock_get, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+        jpeg_bytes = _make_jpeg_bytes()
+        mock_get.return_value = _FakeResponse(jpeg_bytes, headers={"Content-Length": str(len(jpeg_bytes))})
+
+        cache: dict[str, str] = {}
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://example.com/a.jpg"}}]}]
+        }
+        result = resolve_image_urls(payload, cache=cache)
+        resolved_url = result["messages"][0]["content"][0]["image_url"]["url"]
+
+        self.assertEqual(mock_get.call_count, 1)
+        self.assertIn("https://example.com/a.jpg", cache)
+        self.assertEqual(cache["https://example.com/a.jpg"], resolved_url)
+
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    @mock.patch("bridge.core.requests.Session.get")
+    def test_cache_hit_skips_download(self, mock_get, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+
+        cache = {"https://example.com/a.jpg": "data:image/jpeg;base64,cached=="}
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://example.com/a.jpg"}}]}]
+        }
+        result = resolve_image_urls(payload, cache=cache)
+        resolved_url = result["messages"][0]["content"][0]["image_url"]["url"]
+
+        mock_get.assert_not_called()
+        self.assertEqual(resolved_url, "data:image/jpeg;base64,cached==")
+
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    @mock.patch("bridge.core.requests.Session.get")
+    def test_second_call_with_same_cache_reuses_result(self, mock_get, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+        jpeg_bytes = _make_jpeg_bytes()
+        mock_get.return_value = _FakeResponse(jpeg_bytes, headers={"Content-Length": str(len(jpeg_bytes))})
+
+        cache: dict[str, str] = {}
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://example.com/a.jpg"}}]}]
+        }
+        first = resolve_image_urls(payload, cache=cache)
+        second = resolve_image_urls(payload, cache=cache)
+
+        # Only the first call should have actually downloaded.
+        self.assertEqual(mock_get.call_count, 1)
+        self.assertEqual(
+            first["messages"][0]["content"][0]["image_url"]["url"],
+            second["messages"][0]["content"][0]["image_url"]["url"],
+        )
+
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    @mock.patch("bridge.core.requests.Session.get")
+    def test_no_cache_by_default_downloads_every_call(self, mock_get, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+        jpeg_bytes = _make_jpeg_bytes()
+        mock_get.return_value = _FakeResponse(jpeg_bytes, headers={"Content-Length": str(len(jpeg_bytes))})
+
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://example.com/a.jpg"}}]}]
+        }
+        resolve_image_urls(payload)
+        resolve_image_urls(payload)
+
+        # No cache passed -- default behavior downloads every time, same
+        # as before this feature existed.
+        self.assertEqual(mock_get.call_count, 2)
+
+
+class SessionReuseTests(unittest.TestCase):
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    def test_default_session_is_reused_across_calls(self, mock_getaddrinfo):
+        from bridge import core
+
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+        jpeg_bytes = _make_jpeg_bytes()
+
+        with mock.patch.object(requests.Session, "get") as mock_get:
+            mock_get.return_value = _FakeResponse(jpeg_bytes, headers={"Content-Length": str(len(jpeg_bytes))})
+
+            payload = {
+                "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://example.com/a.jpg"}}]}]
+            }
+            resolve_image_urls(payload)
+            session_after_first_call = core._default_session
+
+            resolve_image_urls(payload)
+            session_after_second_call = core._default_session
+
+        # Same Session instance is reused, not recreated per call.
+        self.assertIsNotNone(session_after_first_call)
+        self.assertIs(session_after_first_call, session_after_second_call)
+
+    @mock.patch("bridge.core.socket.getaddrinfo")
+    @mock.patch("bridge.core.requests.Session.get")
+    def test_explicit_session_override_is_used_instead_of_default(self, mock_get, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+        jpeg_bytes = _make_jpeg_bytes()
+        mock_get.return_value = _FakeResponse(jpeg_bytes, headers={"Content-Length": str(len(jpeg_bytes))})
+
+        custom_session = requests.Session()
+        payload = {
+            "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://example.com/a.jpg"}}]}]
+        }
+        resolve_image_urls(payload, session=custom_session)
+
+        # mock.patch.object on the class method fires for any instance,
+        # including our custom session, so we can't distinguish which
+        # instance called it here directly -- but we can confirm no
+        # exception occurred and the call succeeded using the passed-in
+        # session object (mock_get is bound to the class, called via
+        # custom_session.get(...), which is exactly what we're testing
+        # doesn't crash / bypass the code path).
+        mock_get.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/agentic-workloads/bedrock-image-url-bridge/tests/test_lambda_handler.py
+++ b/agentic-workloads/bedrock-image-url-bridge/tests/test_lambda_handler.py
@@ -1,0 +1,50 @@
+"""Unit tests for examples.lambda_handler.handler.
+
+No network or AWS calls -- the Bedrock call is mocked.
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from unittest import mock
+
+from examples.lambda_handler import handler
+
+
+class LambdaHandlerTests(unittest.TestCase):
+    def test_missing_image_url_returns_400(self):
+        response = handler({"prompt": "hi"}, None)
+        self.assertEqual(response["statusCode"], 400)
+        self.assertIn("image_url", json.loads(response["body"])["error"])
+
+    def test_api_gateway_proxy_body_is_json_decoded(self):
+        response = handler({"body": json.dumps({"prompt": "hi"})}, None)
+        self.assertEqual(response["statusCode"], 400)
+
+    @mock.patch("examples.lambda_handler.call_mantle_chat_completions")
+    def test_happy_path_returns_answer(self, mock_call):
+        mock_call.return_value = {
+            "choices": [{"message": {"content": "A red square."}}]
+        }
+        response = handler(
+            {"image_url": "s3://bucket/key.jpg", "prompt": "Describe this."}, None
+        )
+        self.assertEqual(response["statusCode"], 200)
+        self.assertEqual(json.loads(response["body"])["answer"], "A red square.")
+        mock_call.assert_called_once()
+
+    @mock.patch("examples.lambda_handler.call_mantle_chat_completions")
+    def test_invalid_scheme_returns_400_not_500(self, mock_call):
+        response = handler({"image_url": "file:///etc/passwd"}, None)
+        self.assertEqual(response["statusCode"], 400)
+        mock_call.assert_not_called()
+
+    @mock.patch("examples.lambda_handler.call_mantle_chat_completions")
+    def test_upstream_failure_returns_502(self, mock_call):
+        mock_call.side_effect = RuntimeError("bedrock-mantle chat/completions failed (500): boom")
+        response = handler({"image_url": "s3://bucket/key.jpg"}, None)
+        self.assertEqual(response["statusCode"], 502)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agentic-workloads/bedrock-image-url-bridge/tests/test_lambda_handler.py
+++ b/agentic-workloads/bedrock-image-url-bridge/tests/test_lambda_handler.py
@@ -1,6 +1,8 @@
 """Unit tests for examples.lambda_handler.handler.
 
-No network or AWS calls -- the Bedrock call is mocked.
+Verifies the handler is schema-faithful to Chat Completions: request in,
+response out, unmodified shape -- with the only added behavior being
+http(s) image_url resolution. No network or AWS calls (Bedrock is mocked).
 """
 from __future__ import annotations
 
@@ -12,38 +14,84 @@ from examples.lambda_handler import handler
 
 
 class LambdaHandlerTests(unittest.TestCase):
-    def test_missing_image_url_returns_400(self):
-        response = handler({"prompt": "hi"}, None)
+    def test_missing_messages_returns_openai_style_400(self):
+        response = handler({"model": "some-model"}, None)
         self.assertEqual(response["statusCode"], 400)
-        self.assertIn("image_url", json.loads(response["body"])["error"])
+        body = json.loads(response["body"])
+        self.assertEqual(body["error"]["type"], "invalid_request_error")
+        self.assertIn("messages", body["error"]["message"])
 
     def test_api_gateway_proxy_body_is_json_decoded(self):
-        response = handler({"body": json.dumps({"prompt": "hi"})}, None)
+        response = handler({"body": json.dumps({"model": "m"})}, None)
         self.assertEqual(response["statusCode"], 400)
 
     @mock.patch("examples.lambda_handler.call_mantle_chat_completions")
-    def test_happy_path_returns_answer(self, mock_call):
-        mock_call.return_value = {
-            "choices": [{"message": {"content": "A red square."}}]
+    def test_happy_path_returns_exact_chat_completions_response(self, mock_call):
+        chat_completions_response = {
+            "id": "chatcmpl-abc",
+            "object": "chat.completion",
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "A red square."}}],
         }
-        response = handler(
-            {"image_url": "s3://bucket/key.jpg", "prompt": "Describe this."}, None
-        )
+        mock_call.return_value = chat_completions_response
+
+        request_body = {
+            "model": "qwen.qwen3-vl-235b-a22b-instruct",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Describe this."},
+                        {"type": "image_url", "image_url": {"url": "s3://bucket/key.jpg"}},
+                    ],
+                }
+            ],
+        }
+        response = handler(request_body, None)
+
         self.assertEqual(response["statusCode"], 200)
-        self.assertEqual(json.loads(response["body"])["answer"], "A red square.")
+        # Response body is the exact, unmodified Chat Completions JSON --
+        # not a custom wrapper -- which is the whole point of the
+        # schema-faithful design.
+        self.assertEqual(json.loads(response["body"]), chat_completions_response)
         mock_call.assert_called_once()
 
     @mock.patch("examples.lambda_handler.call_mantle_chat_completions")
-    def test_invalid_scheme_returns_400_not_500(self, mock_call):
-        response = handler({"image_url": "file:///etc/passwd"}, None)
+    def test_region_key_is_stripped_before_forwarding(self, mock_call):
+        mock_call.return_value = {"choices": []}
+        request_body = {
+            "model": "m",
+            "messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+            "region": "eu-west-1",
+        }
+        handler(request_body, None)
+
+        forwarded_payload, kwargs = mock_call.call_args
+        self.assertNotIn("region", forwarded_payload[0])
+        self.assertEqual(kwargs["region"], "eu-west-1")
+
+    @mock.patch("examples.lambda_handler.call_mantle_chat_completions")
+    def test_invalid_scheme_returns_openai_style_400_not_500(self, mock_call):
+        request_body = {
+            "model": "m",
+            "messages": [
+                {"role": "user", "content": [{"type": "image_url", "image_url": {"url": "file:///etc/passwd"}}]}
+            ],
+        }
+        response = handler(request_body, None)
         self.assertEqual(response["statusCode"], 400)
+        self.assertEqual(json.loads(response["body"])["error"]["type"], "invalid_request_error")
         mock_call.assert_not_called()
 
     @mock.patch("examples.lambda_handler.call_mantle_chat_completions")
     def test_upstream_failure_returns_502(self, mock_call):
         mock_call.side_effect = RuntimeError("bedrock-mantle chat/completions failed (500): boom")
-        response = handler({"image_url": "s3://bucket/key.jpg"}, None)
+        request_body = {
+            "model": "m",
+            "messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+        }
+        response = handler(request_body, None)
         self.assertEqual(response["statusCode"], 502)
+        self.assertEqual(json.loads(response["body"])["error"]["type"], "upstream_error")
 
 
 if __name__ == "__main__":

--- a/agentic-workloads/bedrock-image-url-bridge/tests/test_preprocess.py
+++ b/agentic-workloads/bedrock-image-url-bridge/tests/test_preprocess.py
@@ -1,0 +1,350 @@
+"""Unit tests for bridge.preprocess.
+
+No network, no AWS calls. Fixture images are generated in-memory with
+Pillow, mirroring bedrock-image-preprocessor's own test fixtures
+(tests/helpers.ts: createTestImage / createScreenshotImage) ported to
+Python equivalents.
+"""
+from __future__ import annotations
+
+import io
+import math
+import unittest
+
+from PIL import Image, ImageDraw
+
+from bridge.preprocess import (
+    ImageDimensions,
+    calculate_patch_count,
+    calculate_scaled_dimensions,
+    is_photographic,
+    preprocess_images,
+    preprocess_patch_mode,
+    preprocess_tile_mode,
+)
+
+
+def _make_test_image(width: int, height: int, fmt: str = "jpeg") -> bytes:
+    """Port of the reference repo's createTestImage(): a flat mid-gray
+    image at the given size/format. For 'jpeg' this exercises the
+    format-based is_photographic() branch (True unconditionally); it is
+    not meant to look like a real photo."""
+    img = Image.new("RGB", (width, height), color=(128, 128, 128))
+    buf = io.BytesIO()
+    if fmt == "jpeg":
+        img.save(buf, format="JPEG", quality=80)
+    else:
+        img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _make_screenshot_image(width: int, height: int) -> bytes:
+    """Port of the reference repo's createScreenshotImage(): a
+    low-variance, flat-color PNG with a couple of solid rectangles --
+    the kind of image is_photographic() should classify as False."""
+    img = Image.new("RGB", (width, height), color=(245, 245, 245))
+    draw = ImageDraw.Draw(img)
+    draw.rectangle([10, 10, 210, 40], fill=(200, 200, 200))
+    draw.rectangle([10, 50, width - 10, height - 10], fill=(250, 250, 250), outline=(220, 220, 220))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _make_noisy_png(width: int, height: int) -> bytes:
+    """A PNG (no alpha) with high per-pixel variance -- should be
+    classified as photographic (True) by the stdev heuristic even
+    though it's not literally a JPEG."""
+    import random
+
+    random.seed(42)
+    img = Image.new("RGB", (width, height))
+    pixels = [
+        (random.randint(0, 255), random.randint(0, 255), random.randint(0, 255))
+        for _ in range(width * height)
+    ]
+    img.putdata(pixels)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _make_rgba_png(width: int, height: int) -> bytes:
+    img = Image.new("RGBA", (width, height), color=(10, 20, 30, 255))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+class CalculatePatchCountTests(unittest.TestCase):
+    def test_calculates_correct_patch_count(self):
+        self.assertEqual(calculate_patch_count(512, 512), 256)  # 16 * 16
+        self.assertEqual(calculate_patch_count(1024, 1024), 1024)  # 32 * 32
+        self.assertEqual(calculate_patch_count(33, 33), 4)  # ceil(33/32)^2 = 2*2
+
+    def test_handles_non_divisible_dimensions(self):
+        self.assertEqual(calculate_patch_count(100, 100), 16)  # ceil(100/32)^2 = 4*4
+
+
+class CalculateScaledDimensionsTests(unittest.TestCase):
+    def test_scales_down_to_fit_within_bounds(self):
+        result = calculate_scaled_dimensions(ImageDimensions(4000, 3000), 2048, 2048)
+        self.assertLessEqual(result.width, 2048)
+        self.assertLessEqual(result.height, 2048)
+
+    def test_preserves_aspect_ratio(self):
+        result = calculate_scaled_dimensions(ImageDimensions(4000, 2000), 2048, 2048)
+        self.assertAlmostEqual(result.width / result.height, 2.0, places=1)
+
+    def test_does_not_upscale(self):
+        result = calculate_scaled_dimensions(ImageDimensions(800, 600), 2048, 2048)
+        self.assertEqual(result.width, 800)
+        self.assertEqual(result.height, 600)
+
+
+class IsPhotographicTests(unittest.TestCase):
+    def test_jpeg_is_always_photographic(self):
+        image = _make_test_image(200, 150, "jpeg")
+        self.assertTrue(is_photographic(image))
+
+    def test_png_with_alpha_is_not_photographic(self):
+        image = _make_rgba_png(200, 150)
+        self.assertFalse(is_photographic(image))
+
+    def test_flat_screenshot_png_is_not_photographic(self):
+        image = _make_screenshot_image(400, 300)
+        self.assertFalse(is_photographic(image))
+
+    def test_high_variance_png_is_photographic(self):
+        image = _make_noisy_png(200, 150)
+        self.assertTrue(is_photographic(image))
+
+
+class PreprocessPatchModeTests(unittest.TestCase):
+    def test_low_detail_resizes_any_image_to_512x512(self):
+        image = _make_test_image(4000, 3000)
+        result = preprocess_patch_mode(image, detail="low")
+        self.assertEqual(result.metadata.resized_dimensions.width, 512)
+        self.assertEqual(result.metadata.resized_dimensions.height, 512)
+        self.assertEqual(result.metadata.patch_count, 256)
+
+    def test_low_detail_enlarges_small_images(self):
+        # withoutEnlargement=False for 'low' in the TS source -- small
+        # images still get upscaled to the fixed 512x512 target.
+        image = _make_test_image(100, 80)
+        result = preprocess_patch_mode(image, detail="low")
+        self.assertEqual(result.metadata.resized_dimensions.width, 512)
+        self.assertEqual(result.metadata.resized_dimensions.height, 512)
+
+    def test_low_detail_produces_low_token_count(self):
+        image = _make_test_image(4000, 3000)
+        result = preprocess_patch_mode(image, detail="low")
+        self.assertLess(result.metadata.estimated_tokens, 500)
+
+    def test_high_detail_constrains_to_2048px_max_dimension(self):
+        image = _make_test_image(4000, 3000)
+        result = preprocess_patch_mode(image, detail="high")
+        dims = result.metadata.resized_dimensions
+        self.assertLessEqual(max(dims.width, dims.height), 2048)
+
+    def test_high_detail_constrains_to_2500_patches(self):
+        image = _make_test_image(4000, 3000)
+        result = preprocess_patch_mode(image, detail="high")
+        self.assertLessEqual(result.metadata.patch_count, 2500)
+
+    def test_high_detail_keeps_small_images_unchanged(self):
+        image = _make_test_image(800, 600)
+        result = preprocess_patch_mode(image, detail="high")
+        self.assertEqual(result.metadata.resized_dimensions.width, 800)
+        self.assertEqual(result.metadata.resized_dimensions.height, 600)
+
+    def test_high_detail_reasonable_token_count(self):
+        image = _make_test_image(2000, 1500)
+        result = preprocess_patch_mode(image, detail="high")
+        self.assertLess(result.metadata.estimated_tokens, 5000)
+
+    def test_original_detail_allows_up_to_6000px(self):
+        image = _make_test_image(5000, 4000)
+        result = preprocess_patch_mode(image, detail="original")
+        dims = result.metadata.resized_dimensions
+        self.assertLessEqual(max(dims.width, dims.height), 6000)
+
+    def test_original_detail_constrains_to_10000_patches(self):
+        image = _make_test_image(5000, 4000)
+        result = preprocess_patch_mode(image, detail="original")
+        self.assertLessEqual(result.metadata.patch_count, 10000)
+
+    def test_original_detail_keeps_small_images_unchanged(self):
+        image = _make_test_image(800, 600)
+        result = preprocess_patch_mode(image, detail="original")
+        self.assertEqual(result.metadata.resized_dimensions.width, 800)
+        self.assertEqual(result.metadata.resized_dimensions.height, 600)
+
+    def test_outputs_jpeg_for_photographic_images_in_auto_mode(self):
+        image = _make_test_image(1000, 800, "jpeg")
+        result = preprocess_patch_mode(image, detail="high")
+        self.assertEqual(result.mime_type, "image/jpeg")
+
+    def test_outputs_png_for_screenshot_like_images_in_auto_mode(self):
+        image = _make_screenshot_image(1024, 768)
+        result = preprocess_patch_mode(image, detail="high")
+        self.assertEqual(result.mime_type, "image/png")
+
+    def test_respects_forced_output_format(self):
+        image = _make_test_image(1000, 800, "jpeg")
+        result = preprocess_patch_mode(image, detail="high", output_format="png")
+        self.assertEqual(result.mime_type, "image/png")
+
+    def test_returns_complete_metadata(self):
+        image = _make_test_image(3000, 2000)
+        result = preprocess_patch_mode(image, detail="high")
+        self.assertEqual(result.metadata.original_dimensions.width, 3000)
+        self.assertEqual(result.metadata.original_dimensions.height, 2000)
+        self.assertGreater(result.metadata.resized_dimensions.width, 0)
+        self.assertGreater(result.metadata.resized_dimensions.height, 0)
+        self.assertGreater(result.metadata.patch_count, 0)
+        self.assertGreater(result.metadata.estimated_tokens, 0)
+
+    def test_base64_roundtrips_to_valid_image(self):
+        image = _make_test_image(1000, 800)
+        result = preprocess_patch_mode(image, detail="high")
+        decoded = result.to_bytes()
+        with Image.open(io.BytesIO(decoded)) as img:
+            img.verify()
+
+
+class PreprocessTileModeTests(unittest.TestCase):
+    def test_constrains_longest_edge_to_1568px(self):
+        image = _make_test_image(4000, 3000)
+        result = preprocess_tile_mode(image)
+        dims = result.metadata.resized_dimensions
+        self.assertLessEqual(max(dims.width, dims.height), 1568)
+
+    def test_preserves_aspect_ratio(self):
+        image = _make_test_image(4000, 2000)
+        result = preprocess_tile_mode(image)
+        dims = result.metadata.resized_dimensions
+        self.assertAlmostEqual(dims.width / dims.height, 2.0, places=0)
+
+    def test_keeps_small_images_unchanged(self):
+        image = _make_test_image(400, 300)
+        result = preprocess_tile_mode(image)
+        self.assertEqual(result.metadata.resized_dimensions.width, 400)
+        self.assertEqual(result.metadata.resized_dimensions.height, 300)
+
+    def test_calculates_tile_count_correctly(self):
+        image = _make_test_image(1024, 1024)
+        result = preprocess_tile_mode(image)
+        dims = result.metadata.resized_dimensions
+        expected_tiles = math.ceil(dims.width / 512) * math.ceil(dims.height / 512)
+        self.assertEqual(result.metadata.tile_count, expected_tiles)
+
+    def test_calculates_estimated_tokens_using_anthropic_formula(self):
+        image = _make_test_image(1000, 750)
+        result = preprocess_tile_mode(image)
+        dims = result.metadata.resized_dimensions
+        expected_tokens = round((dims.width * dims.height) / 750)
+        self.assertEqual(result.metadata.estimated_tokens, expected_tokens)
+
+    def test_three_stage_cascade_all_stages_engage(self):
+        # Very large, very wide image: 10000x1000 (ratio 10:1).
+        # Stage 1 (fit within 2048x2048): scale = 2048/10000 = 0.2048
+        #   -> 2048 x 205 (round)
+        # Stage 2 (long edge <= 1568): long edge is already 2048 > 1568
+        #   -> scale = 1568/2048 = 0.765625 -> 1568 x 157
+        # Stage 3 (short edge <= 768): short edge 157 < 768, no-op.
+        image = _make_test_image(10000, 1000)
+        result = preprocess_tile_mode(image)
+        dims = result.metadata.resized_dimensions
+        self.assertEqual(dims.width, 1568)
+        self.assertLessEqual(dims.height, 768)
+        self.assertLessEqual(max(dims.width, dims.height), 1568)
+
+    def test_three_stage_cascade_short_edge_engages(self):
+        # A large near-square image should get clipped by stage 1 (2048
+        # cap) but since it's square, long/short edges are equal and
+        # under 1568/768 after stage 1 scaling down further via short
+        # edge is only relevant for non-square; use a moderately wide
+        # image where stage 3 actually applies after stage 1+2.
+        # 3000x2500: stage1 scale=2048/3000=0.6827 -> 2048x1707
+        # stage2: long edge 2048>1568 -> scale=1568/2048=0.765625 -> 1568x1307
+        # stage3: short edge 1307 > 768 -> scale=768/1307=0.5877 -> 921x768
+        image = _make_test_image(3000, 2500)
+        result = preprocess_tile_mode(image)
+        dims = result.metadata.resized_dimensions
+        self.assertEqual(min(dims.width, dims.height), 768)
+        self.assertLessEqual(max(dims.width, dims.height), 1568)
+
+    def test_respects_max_token_budget(self):
+        image = _make_test_image(3000, 2000)
+        result = preprocess_tile_mode(image, max_token_budget=1000)
+        self.assertLessEqual(result.metadata.estimated_tokens, 1000)
+
+    def test_does_not_upscale_when_under_budget(self):
+        image = _make_test_image(400, 300)
+        result = preprocess_tile_mode(image, max_token_budget=10000)
+        self.assertEqual(result.metadata.resized_dimensions.width, 400)
+        self.assertEqual(result.metadata.resized_dimensions.height, 300)
+
+    def test_achieves_target_token_count_with_budget(self):
+        image = _make_test_image(4000, 3000)
+        result = preprocess_tile_mode(image, max_token_budget=2000)
+        self.assertLessEqual(result.metadata.estimated_tokens, 2000)
+
+
+class PreprocessImagesBatchTests(unittest.TestCase):
+    def test_processes_multiple_images_in_patch_mode(self):
+        images = [_make_test_image(2000, 1500) for _ in range(5)]
+        results = preprocess_images(images, mode="patch", detail="high")
+        self.assertEqual(len(results), 5)
+        for r in results:
+            self.assertTrue(r.base64)
+            self.assertLessEqual(r.metadata.patch_count, 2500)
+
+    def test_processes_multiple_images_in_tile_mode(self):
+        images = [_make_test_image(3000, 2000) for _ in range(5)]
+        results = preprocess_images(images, mode="tile")
+        self.assertEqual(len(results), 5)
+        for r in results:
+            dims = r.metadata.resized_dimensions
+            self.assertLessEqual(max(dims.width, dims.height), 1568)
+
+    def test_under_budget_returns_unmodified_results(self):
+        images = [_make_test_image(200, 150) for _ in range(3)]
+        results = preprocess_images(images, mode="tile", max_total_tokens=1_000_000)
+        for r in results:
+            self.assertEqual(r.metadata.resized_dimensions.width, 200)
+            self.assertEqual(r.metadata.resized_dimensions.height, 150)
+
+    def test_over_budget_triggers_redistribution(self):
+        images = [_make_test_image(3000, 2000) for _ in range(10)]
+        max_total_tokens = 20000
+        results = preprocess_images(images, mode="tile", max_total_tokens=max_total_tokens)
+        total_tokens = sum(r.metadata.estimated_tokens for r in results)
+        self.assertLessEqual(total_tokens, max_total_tokens * 1.1)  # 10% tolerance
+
+    def test_handles_many_images_within_token_budget(self):
+        images = [_make_test_image(4000, 3000) for _ in range(15)]
+        results = preprocess_images(images, mode="tile", max_total_tokens=30000)
+        self.assertEqual(len(results), 15)
+        total_tokens = sum(r.metadata.estimated_tokens for r in results)
+        self.assertLessEqual(total_tokens, 33000)
+        for r in results:
+            self.assertLessEqual(r.metadata.estimated_tokens, 3000)
+
+    def test_empty_input_returns_empty_list(self):
+        results = preprocess_images([], mode="patch", detail="high")
+        self.assertEqual(results, [])
+
+    def test_downgrades_patch_detail_when_budget_is_tight(self):
+        images = [_make_test_image(3000, 2000) for _ in range(10)]
+        results = preprocess_images(
+            images, mode="patch", detail="high", max_total_tokens=5000
+        )
+        self.assertEqual(len(results), 10)
+        for r in results:
+            self.assertLess(r.metadata.estimated_tokens, 1000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Amazon Bedrock's OpenAI-compatible `bedrock-mantle` endpoint (Chat Completions + Responses APIs) rejects a plain `https://` `image_url`:
```
"Only inline image data URLs and S3 URLs are supported."
```
It does accept `s3://` and `data:` URIs natively. The native `bedrock-runtime` Converse API is stricter still — it has no URL concept at all, only raw bytes. Any application built against the OpenAI `image_url` convention (or migrating from OpenAI) hits this immediately when pointed at Bedrock.

Separately, Bedrock does not preprocess images server-side the way OpenAI/Anthropic's own APIs do — a raw 4000x3000 photo costs ~30,000 tokens through Bedrock vs ~1,600-2,000 tokens through those providers after their built-in resize/tile step. 10-15 images per request can overflow a 128K context window without this.

## Solution

A dependency-light `bridge/core.py::resolve_image_urls()` that rewrites only `http(s)://` URLs into inline `data:` URIs, leaving `s3://` and `data:` untouched. Meant to be read and copied into your own code, not installed as a library.

```python
from bridge.core import resolve_image_urls

payload = resolve_image_urls(payload)  # http(s) urls -> inline data: URIs
# ... send payload to bedrock-mantle or bedrock-runtime as before
```

`bridge/preprocess.py` adds an optional client-side resize step (`preprocess=` kwarg) that shrinks images to a token budget before encoding, using the same patch/tile math OpenAI and Anthropic document for their own APIs — reimplemented from their public docs, not third-party code. See `docs/PREPROCESSING.md`.

Every example — including the Lambda handler — mimics the exact request/response schema of the API it fronts. Migration is a base-URL swap, not a client rewrite. See `docs/MIGRATION.md`.

## Structure

```
agentic-workloads/bedrock-image-url-bridge/
├── bridge/
│   ├── core.py                    # resolve_image_urls() + SSRF guard + pooling/caching
│   └── preprocess.py              # optional token-budget resize (patch/tile modes)
├── examples/
│   ├── mantle_chat_completions.py # bedrock-mantle /v1/chat/completions, CLI script
│   ├── mantle_responses_api.py    # bedrock-mantle /v1/responses, CLI script
│   ├── runtime_converse.py        # native bedrock-runtime Converse (bytes-only, contrast case)
│   ├── lambda_handler.py          # AWS Lambda handler, schema-faithful to Chat Completions
│   └── preprocess_demo.py         # before/after token comparison, no AWS credentials required
├── tests/
│   ├── test_bridge_unit.py        # mocked, no network/AWS calls
│   ├── test_lambda_handler.py     # mocked, verifies exact schema passthrough
│   ├── test_preprocess.py         # patch/tile mode + batch redistribution
│   └── test_bridge_live.py        # opt-in (BRIDGE_LIVE_TEST=1) real endpoint calls
└── docs/                          # security, caching, hosting, scaling+cost, migration, preprocessing, alternatives
```

| Example | Endpoint / hosting shape | Before the bridge |
|---|---|---|
| `mantle_chat_completions.py` | `bedrock-mantle` `/v1/chat/completions`, CLI script | rejects `https`, verified end to end with a real vision model |
| `mantle_responses_api.py` | `bedrock-mantle` `/v1/responses`, CLI script | rejects `https`; schema-correct, but see `docs/MIGRATION.md` for a live-discovered model-availability gap |
| `runtime_converse.py` | native `bedrock-runtime` Converse, CLI script | no URL support at all, bytes only |
| `lambda_handler.py` | AWS Lambda handler | accepts/returns the exact Chat Completions request/response JSON |

## Also included

- **Connection pooling and caching** (`session=`/`cache=`), both opt-in, no-ops when unused. Default behavior (no args) is byte-identical to before.
- **Security guards** in `bridge/core.py`: SSRF guard, size cap, bounded re-validated redirects, Pillow-based format verification. See `docs/SECURITY.md`, including an AWS Shared Responsibility Model disclosure.
- **ASH v3 security scan**: 0 actionable findings across bandit/checkov/detect-secrets/npm-audit/semgrep (other ASH scanners need Docker/separate binaries not applicable to a pure-Python sample). No code changes required.
- **Docs**: `docs/CACHING.md`, `docs/HOSTING.md`, `docs/SCALING.md` (concurrency + real cost breakdown), `docs/MIGRATION.md`, `docs/PREPROCESSING.md`, `docs/ALTERNATIVES.md`.

## Testing

```
pytest tests/test_bridge_unit.py tests/test_lambda_handler.py tests/test_preprocess.py -v
============================== 80 passed, 3 skipped in ~15s ==============================
```
(3 skipped are pre-existing opt-in live tests, gated behind `BRIDGE_LIVE_TEST=1`.)

CI now runs this suite automatically on PRs touching this directory (`.github/workflows/ci.yml`), rather than relying on self-reported numbers in the PR description.

All examples, including the Lambda handler, have also been run live against a real AWS account (region `us-east-1`) and return real model output. Preprocessing was live-verified on a real 4000x5338 photo: tile mode 28,469→1,050 tokens (96.3% reduction), patch mode (high detail) 33,818→4,040 tokens (88.1% reduction) — both preprocessed images were correctly described by the model in a live `bedrock-mantle` call, confirming the shrunk image stays visually usable.

## Notes for reviewers

- `bridge/preprocess.py`'s token formulas were originally ported from a third-party MIT-licensed project with no discoverable repo URL. That provenance couldn't be verified for an `aws-samples` repo, so the implementation was rewritten directly from OpenAI's and Anthropic's public API documentation instead (cited in `docs/PREPROCESSING.md`).
- Automated review caught and fixed two real issues pre-merge: an unhandled `ValueError` on non-numeric `Content-Length`, and a relative-redirect `Location` header that could have bypassed the SSRF hostname check on a redirect hop. Both have test coverage.