### PR TITLE
Restore a clean single-pass run of the Claude notebook

### DIFF
--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/02-anthropic-claude/01-messages-api-core.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/02-anthropic-claude/01-messages-api-core.ipynb
@@ -57,6 +57,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8cd68b64",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",
@@ -103,9 +104,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 1,
    "id": "339400be",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T12:09:57.281572Z",
+     "iopub.status.busy": "2026-08-14T12:09:57.281427Z",
+     "iopub.status.idle": "2026-08-14T12:09:57.296114Z",
+     "shell.execute_reply": "2026-08-14T12:09:57.295215Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -166,18 +174,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 2,
    "id": "4b0b39a9",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T12:09:57.300048Z",
+     "iopub.status.busy": "2026-08-14T12:09:57.299894Z",
+     "iopub.status.idle": "2026-08-14T12:10:00.596585Z",
+     "shell.execute_reply": "2026-08-14T12:10:00.596215Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "HTTP 200\n",
-      "Idempotency is a property where performing the same operation multiple times produces the same result as performing it once, without unintended side effects from repetition. This is especially important in APIs and distributed systems, where requests might be retried due to network issues—an idempotent operation (like setting a value or DELETE) ensures repeated attempts don't cause errors or duplicate effects, unlike non-idempotent operations (like incrementing a counter or POST creating new resources).\n",
+      "Idempotency means that performing an operation multiple times produces the same result as performing it once, regardless of how many times it's repeated. This property is especially important in computing and API design, where it ensures that repeated requests (like retries due to network errors) don't cause unintended side effects, such as duplicate transactions or data corruption.\n",
       "\n",
-      "usage: {\"input_tokens\": 19, \"cache_creation_input_tokens\": 0, \"cache_read_input_tokens\": 0, \"cache_creation\": {\"ephemeral_5m_input_tokens\": 0, \"ephemeral_1h_input_tokens\": 0}, \"output_tokens\": 144, \"output_tokens_details\": {\"thinking_tokens\": 0}, \"service_tier\": \"standard\"}\n",
+      "usage: {\"input_tokens\": 19, \"cache_creation_input_tokens\": 0, \"cache_read_input_tokens\": 0, \"cache_creation\": {\"ephemeral_5m_input_tokens\": 0, \"ephemeral_1h_input_tokens\": 0}, \"output_tokens\": 102, \"output_tokens_details\": {\"thinking_tokens\": 0}, \"service_tier\": \"standard\"}\n",
       "stop_reason: end_turn\n"
      ]
     }
@@ -215,9 +230,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 3,
    "id": "43703bce",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T12:10:00.598490Z",
+     "iopub.status.busy": "2026-08-14T12:10:00.598398Z",
+     "iopub.status.idle": "2026-08-14T12:10:01.340714Z",
+     "shell.execute_reply": "2026-08-14T12:10:01.340308Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -253,10 +275,10 @@
    "id": "d87f375f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-14T09:53:07.412108Z",
-     "iopub.status.busy": "2026-08-14T09:53:07.412027Z",
-     "iopub.status.idle": "2026-08-14T09:53:11.680185Z",
-     "shell.execute_reply": "2026-08-14T09:53:11.679658Z"
+     "iopub.execute_input": "2026-08-14T12:10:01.343025Z",
+     "iopub.status.busy": "2026-08-14T12:10:01.342897Z",
+     "iopub.status.idle": "2026-08-14T12:10:05.799280Z",
+     "shell.execute_reply": "2026-08-14T12:10:05.798341Z"
     }
    },
    "outputs": [
@@ -354,10 +376,10 @@
    "id": "0eb4c7bf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-14T09:53:11.681811Z",
-     "iopub.status.busy": "2026-08-14T09:53:11.681718Z",
-     "iopub.status.idle": "2026-08-14T09:53:20.515646Z",
-     "shell.execute_reply": "2026-08-14T09:53:20.514646Z"
+     "iopub.execute_input": "2026-08-14T12:10:05.802574Z",
+     "iopub.status.busy": "2026-08-14T12:10:05.802386Z",
+     "iopub.status.idle": "2026-08-14T12:10:16.072590Z",
+     "shell.execute_reply": "2026-08-14T12:10:16.071269Z"
     }
    },
    "outputs": [
@@ -366,7 +388,7 @@
      "output_type": "stream",
      "text": [
       "anthropic.claude-sonnet-5      blocks=['text']\n",
-      "    text via helper: '# Write-Ahead Logging (WAL)\\n\\nA write-ahead log solves the fundamental problem of'\n",
+      "    text via helper: '# Write-Ahead Log (WAL)\\n\\nA write-ahead log solves the fundamental problem of **e'\n",
       "    content[0]['type'] = 'text' -> naive content[0]['text'] would work\n"
      ]
     },
@@ -425,10 +447,10 @@
    "id": "452c5d5e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-14T09:53:20.519558Z",
-     "iopub.status.busy": "2026-08-14T09:53:20.519359Z",
-     "iopub.status.idle": "2026-08-14T09:53:26.165007Z",
-     "shell.execute_reply": "2026-08-14T09:53:26.164458Z"
+     "iopub.execute_input": "2026-08-14T12:10:16.076430Z",
+     "iopub.status.busy": "2026-08-14T12:10:16.076201Z",
+     "iopub.status.idle": "2026-08-14T12:10:22.887619Z",
+     "shell.execute_reply": "2026-08-14T12:10:22.886898Z"
     }
    },
    "outputs": [
@@ -436,21 +458,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "# Write-Ahead Log (WAL)\n",
+      "# The Write-Ahead Log (WAL) Problem\n",
       "\n",
-      "**Problem it solves:** Ensuring durability and crash recovery without sacrificing performance.\n",
+      "**Core problem:** How do you ensure durability and atomicity of changes when a system might crash mid-operation?\n",
       "\n",
-      "## The Core Issue\n",
+      "## The specific issue\n",
       "\n",
-      "Databases need to persist changes durably, but writing directly to disk data structures (like B-trees) on every transaction is:\n",
-      "- **Slow** — random I/O to update pages scattered across disk\n",
-      "- **Dangerous** — a crash mid-write can leave data structures corrupted (partial writes)\n",
+      "If you modify data structures (like a database's B-tree pages) directly on disk, a crash during that write can leave you with:\n",
+      "- **Partial writes** — half-updated pages, corrupted structures\n",
+      "- **No way to recover** — you can't tell what the operation was trying to do, or roll it back\n",
       "\n",
-      "## How WAL Solves It\n",
+      "## The WAL solution\n",
       "\n",
-      "1. **Append-only log first**: Before modifying actual data, write the intended change as a log entry (sequential I/O — fast)\n",
-      "2. **Apply later**: Data pages are updated afterward, possibly batched or deferred\n",
-      "3. **Crash recovery**: On restart, replay the log\n",
+      "Before modifying the actual data, you first write a log entry describing the intended change, and ensure that log entry is durably on disk. Only *then* do you apply the change to the actual data structures.\n",
+      "\n",
+      "This gives you:\n",
+      "\n",
+      "1. **Crash recovery** — On restart, replay the log to redo any\n",
       "\n",
       "model echoed: claude-sonnet-5 | stop: max_tokens\n"
      ]
@@ -499,10 +523,10 @@
    "id": "c50ddd97",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-14T09:53:26.168421Z",
-     "iopub.status.busy": "2026-08-14T09:53:26.168291Z",
-     "iopub.status.idle": "2026-08-14T09:53:30.641200Z",
-     "shell.execute_reply": "2026-08-14T09:53:30.640217Z"
+     "iopub.execute_input": "2026-08-14T12:10:22.890420Z",
+     "iopub.status.busy": "2026-08-14T12:10:22.890304Z",
+     "iopub.status.idle": "2026-08-14T12:10:27.060001Z",
+     "shell.execute_reply": "2026-08-14T12:10:27.059450Z"
     }
    },
    "outputs": [
@@ -584,10 +608,10 @@
    "id": "3690d10c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-14T09:53:30.644443Z",
-     "iopub.status.busy": "2026-08-14T09:53:30.644241Z",
-     "iopub.status.idle": "2026-08-14T09:53:33.409473Z",
-     "shell.execute_reply": "2026-08-14T09:53:33.408532Z"
+     "iopub.execute_input": "2026-08-14T12:10:27.061866Z",
+     "iopub.status.busy": "2026-08-14T12:10:27.061767Z",
+     "iopub.status.idle": "2026-08-14T12:10:29.981614Z",
+     "shell.execute_reply": "2026-08-14T12:10:29.981077Z"
     }
    },
    "outputs": [
@@ -640,10 +664,10 @@
    "id": "9580fbb1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-14T09:53:33.413995Z",
-     "iopub.status.busy": "2026-08-14T09:53:33.413770Z",
-     "iopub.status.idle": "2026-08-14T09:53:35.618656Z",
-     "shell.execute_reply": "2026-08-14T09:53:35.617919Z"
+     "iopub.execute_input": "2026-08-14T12:10:29.983058Z",
+     "iopub.status.busy": "2026-08-14T12:10:29.982967Z",
+     "iopub.status.idle": "2026-08-14T12:10:32.180882Z",
+     "shell.execute_reply": "2026-08-14T12:10:32.180447Z"
     }
    },
    "outputs": [
@@ -661,7 +685,7 @@
       "\n",
       "anthropic.claude-sonnet-5\n",
       "   status       : available\n",
-      "   allowed_modes: ['none', 'provider_data_share', 'default']\n"
+      "   allowed_modes: ['provider_data_share', 'default', 'none']\n"
      ]
     },
     {
@@ -719,10 +743,10 @@
    "id": "864fc12e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-14T09:53:35.621556Z",
-     "iopub.status.busy": "2026-08-14T09:53:35.621405Z",
-     "iopub.status.idle": "2026-08-14T09:53:40.494930Z",
-     "shell.execute_reply": "2026-08-14T09:53:40.494296Z"
+     "iopub.execute_input": "2026-08-14T12:10:32.183181Z",
+     "iopub.status.busy": "2026-08-14T12:10:32.183071Z",
+     "iopub.status.idle": "2026-08-14T12:10:37.512206Z",
+     "shell.execute_reply": "2026-08-14T12:10:37.510616Z"
     }
    },
    "outputs": [
@@ -737,14 +761,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "# Three Properties of a"
+      "#"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " Good API\n",
+      " Three Proper"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ties of a Good API\n",
       "\n",
       "1"
      ]
@@ -753,21 +784,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      ". **Consistency** –"
+      ". **Consistency** —"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " The API foll"
+      " The API should foll"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ows pred"
+      "ow pred"
      ]
     },
     {
@@ -788,93 +819,163 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " "
+      " ordering, and behavior"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ordering, and response formats across"
+      " patterns across all"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " all end"
+      " its"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "points/"
+      " meth"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "methods."
+      "ods/"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " Once a"
+      "endpoints. If"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " developer learns one"
+      " one"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " part of"
+      " function"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " the API, they can re"
+      " is"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "asonably gu"
+      " named `get"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ess how other"
+      "User()`, you"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " parts work.\n",
+      " shouldn't have"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " another"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " named"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " `fetch"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "_order"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "()`."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " Consistency reduces the"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " learning curve and"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " min"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "imizes sur"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "prises for developers.\n",
       "\n",
-      "2. **"
+      "2"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Cl"
+      ". **Cl"
      ]
     },
     {
@@ -902,56 +1003,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "** – Good"
+      "** — A"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " APIs include well"
+      " good API should be"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-explained desc"
+      " well"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "riptions of"
+      "-documented,"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " end"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "points, parameters,"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " exp"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "ected in"
+      " including expected in"
      ]
     },
     {
@@ -965,86 +1045,191 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " codes, and pract"
+      " cod"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ical examples. This reduces"
+      "es, us"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " the learning curve and min"
+      "age examples, and ed"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "imizes support requests."
+      "ge cases."
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      " Even"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " a"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " well-designed API bec"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "omes hard to use if develop"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ers can"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'t understand how to inter"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "act with it.\n",
       "\n",
-      "\n",
-      "3. **Rob"
+      "3. **"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ust Error Handling** –"
+      "Rob"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " The API returns meaningful"
+      "ust"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      ", desc"
+      " Error Handling** — The"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "riptive error messages with"
+      " API should prov"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " appropriate status codes,"
+      "ide meaningful, act"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " hel"
+      "ionable error messages and app"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ping developers qu"
+      "ropriate status codes (e"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ".g., H"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TTP "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "400 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "v"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "s."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 500) rather than gener"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ic or sil"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ent failures. This hel"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ps developers qu"
      ]
     },
     {
@@ -1058,102 +1243,44 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ix issues rather than gu"
+      "ix issues when"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "essing what"
+      " something"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " went wrong.\n",
+      " goes wrong.\n",
       "\n",
-      "**"
+      "*"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Bonus properties wor"
+      "("
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "th considering:**\n",
-      "- **"
+      "Bonus proper"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Simplicity/"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Ease of Use** – Min"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "imal compl"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "exity to acc"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "omplish common"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " tasks\n",
-      "- **Back"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "ward"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " Compatibility** –"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " Changes don't break existing integ"
+      "ties"
      ]
     },
     {
@@ -1163,8 +1290,8 @@
       "\n",
       "\n",
       "--- event types ---\n",
-      "    59  content_block_delta\n",
-      "    59  text\n",
+      "    74  content_block_delta\n",
+      "    74  text\n",
       "     1  message_start\n",
       "     1  content_block_start\n",
       "     1  content_block_stop\n",
@@ -1205,10 +1332,10 @@
    "id": "4574636c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-14T09:53:40.496676Z",
-     "iopub.status.busy": "2026-08-14T09:53:40.496573Z",
-     "iopub.status.idle": "2026-08-14T09:53:41.617871Z",
-     "shell.execute_reply": "2026-08-14T09:53:41.617145Z"
+     "iopub.execute_input": "2026-08-14T12:10:37.514458Z",
+     "iopub.status.busy": "2026-08-14T12:10:37.514362Z",
+     "iopub.status.idle": "2026-08-14T12:10:38.583447Z",
+     "shell.execute_reply": "2026-08-14T12:10:38.582898Z"
     }
    },
    "outputs": [
@@ -1217,7 +1344,7 @@
      "output_type": "stream",
      "text": [
       "event: message_start\n",
-      "data: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_bdrk_mummrkctfm5i6augr7\n",
+      "data: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_bdrk_nxs7z75gv6wcfpbylk\n",
       "event: content_block_start\n",
       "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n",
       "event: content_block_delta\n",
@@ -1273,10 +1400,10 @@
    "id": "763a837d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-14T09:53:41.620519Z",
-     "iopub.status.busy": "2026-08-14T09:53:41.620352Z",
-     "iopub.status.idle": "2026-08-14T09:53:43.195514Z",
-     "shell.execute_reply": "2026-08-14T09:53:43.194683Z"
+     "iopub.execute_input": "2026-08-14T12:10:38.585081Z",
+     "iopub.status.busy": "2026-08-14T12:10:38.584994Z",
+     "iopub.status.idle": "2026-08-14T12:10:40.131514Z",
+     "shell.execute_reply": "2026-08-14T12:10:40.130847Z"
     }
    },
    "outputs": [
@@ -1291,7 +1418,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "assistant: MongoDB trades immediate consistency for availability and partition tolerance, as it uses eventual consistency by default across replica sets.\n",
+      "assistant: MongoDB trades strong consistency for availability and partition tolerance, as it doesn't guarantee immediate consistency across all replicas by default.\n",
       "\n",
       "input tokens grew: 23 -> 32\n"
      ]
@@ -1326,10 +1453,10 @@
    "id": "4ce15aae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-14T09:53:43.197967Z",
-     "iopub.status.busy": "2026-08-14T09:53:43.197801Z",
-     "iopub.status.idle": "2026-08-14T09:53:43.903491Z",
-     "shell.execute_reply": "2026-08-14T09:53:43.902086Z"
+     "iopub.execute_input": "2026-08-14T12:10:40.133616Z",
+     "iopub.status.busy": "2026-08-14T12:10:40.133459Z",
+     "iopub.status.idle": "2026-08-14T12:10:40.868797Z",
+     "shell.execute_reply": "2026-08-14T12:10:40.868198Z"
     }
    },
    "outputs": [
@@ -1339,7 +1466,7 @@
      "text": [
       "continuation:  (N. Virginia)\n",
       "2. us-west-2 (Oregon)\n",
-      "3. us-east-2 (Ohio)\n"
+      "3. us-west-1 (N. California)\n"
      ]
     }
    ],
@@ -1381,10 +1508,10 @@
    "id": "a21718ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-14T09:53:43.905879Z",
-     "iopub.status.busy": "2026-08-14T09:53:43.905709Z",
-     "iopub.status.idle": "2026-08-14T09:53:44.989553Z",
-     "shell.execute_reply": "2026-08-14T09:53:44.988717Z"
+     "iopub.execute_input": "2026-08-14T12:10:40.870789Z",
+     "iopub.status.busy": "2026-08-14T12:10:40.870682Z",
+     "iopub.status.idle": "2026-08-14T12:10:41.661439Z",
+     "shell.execute_reply": "2026-08-14T12:10:41.660983Z"
     }
    },
    "outputs": [
@@ -1430,10 +1557,10 @@
    "id": "bc179cfc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-14T09:53:44.991807Z",
-     "iopub.status.busy": "2026-08-14T09:53:44.991660Z",
-     "iopub.status.idle": "2026-08-14T09:53:46.998362Z",
-     "shell.execute_reply": "2026-08-14T09:53:46.997699Z"
+     "iopub.execute_input": "2026-08-14T12:10:41.663198Z",
+     "iopub.status.busy": "2026-08-14T12:10:41.663109Z",
+     "iopub.status.idle": "2026-08-14T12:10:44.976300Z",
+     "shell.execute_reply": "2026-08-14T12:10:44.975236Z"
     }
    },
    "outputs": [
@@ -1505,10 +1632,10 @@
    "id": "4ade5734",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-14T09:53:47.001391Z",
-     "iopub.status.busy": "2026-08-14T09:53:47.001240Z",
-     "iopub.status.idle": "2026-08-14T09:53:49.263879Z",
-     "shell.execute_reply": "2026-08-14T09:53:49.263046Z"
+     "iopub.execute_input": "2026-08-14T12:10:44.979580Z",
+     "iopub.status.busy": "2026-08-14T12:10:44.979421Z",
+     "iopub.status.idle": "2026-08-14T12:10:47.323832Z",
+     "shell.execute_reply": "2026-08-14T12:10:47.323357Z"
     }
    },
    "outputs": [
@@ -1555,10 +1682,10 @@
    "id": "407f3eed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-14T09:53:49.266428Z",
-     "iopub.status.busy": "2026-08-14T09:53:49.266296Z",
-     "iopub.status.idle": "2026-08-14T09:53:51.027198Z",
-     "shell.execute_reply": "2026-08-14T09:53:51.025820Z"
+     "iopub.execute_input": "2026-08-14T12:10:47.325343Z",
+     "iopub.status.busy": "2026-08-14T12:10:47.325256Z",
+     "iopub.status.idle": "2026-08-14T12:10:48.883125Z",
+     "shell.execute_reply": "2026-08-14T12:10:48.882586Z"
     }
    },
    "outputs": [
@@ -1616,10 +1743,10 @@
    "id": "33103114",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-14T09:53:51.030800Z",
-     "iopub.status.busy": "2026-08-14T09:53:51.030590Z",
-     "iopub.status.idle": "2026-08-14T09:53:52.929236Z",
-     "shell.execute_reply": "2026-08-14T09:53:52.928467Z"
+     "iopub.execute_input": "2026-08-14T12:10:48.885091Z",
+     "iopub.status.busy": "2026-08-14T12:10:48.884995Z",
+     "iopub.status.idle": "2026-08-14T12:10:50.443356Z",
+     "shell.execute_reply": "2026-08-14T12:10:50.442803Z"
     }
    },
    "outputs": [
@@ -1702,10 +1829,10 @@
    "id": "80ba99cd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-14T09:53:52.933905Z",
-     "iopub.status.busy": "2026-08-14T09:53:52.933665Z",
-     "iopub.status.idle": "2026-08-14T09:54:09.510328Z",
-     "shell.execute_reply": "2026-08-14T09:54:09.509783Z"
+     "iopub.execute_input": "2026-08-14T12:10:50.445301Z",
+     "iopub.status.busy": "2026-08-14T12:10:50.445178Z",
+     "iopub.status.idle": "2026-08-14T12:11:06.173016Z",
+     "shell.execute_reply": "2026-08-14T12:11:06.167632Z"
     }
    },
    "outputs": [
@@ -1721,35 +1848,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "anthropic.claude-haiku-4-5             3.32s    22    45  'Exactly-once delivery is hard because you must'\n"
+      "anthropic.claude-haiku-4-5             1.64s    22    54  'Exactly-once delivery is hard because you must'\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "anthropic.claude-opus-4-7              2.72s    36    92  'Exactly-once delivery is hard because network '\n"
+      "anthropic.claude-opus-4-7              3.65s    36   146  'Exactly-once delivery is hard because network '\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "anthropic.claude-opus-4-8              3.00s    31   113  'Exactly-once delivery is hard because network '\n"
+      "anthropic.claude-opus-4-8              2.99s    31   113  'Exactly-once delivery is hard because network '\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "anthropic.claude-sonnet-5              3.66s    31   154  'Exactly-once delivery is hard because networks'\n"
+      "anthropic.claude-sonnet-5              3.70s    31   160  'Exactly-once delivery is hard because in a dis'\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "anthropic.claude-opus-5                3.86s    31   160  'Because networks'\n"
+      "anthropic.claude-opus-5                3.72s    31   160  'Because a sender can'\n"
      ]
     }
    ],
@@ -1800,10 +1927,10 @@
    "id": "48c86d33",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-14T09:54:09.512877Z",
-     "iopub.status.busy": "2026-08-14T09:54:09.512765Z",
-     "iopub.status.idle": "2026-08-14T09:54:13.396202Z",
-     "shell.execute_reply": "2026-08-14T09:54:13.393683Z"
+     "iopub.execute_input": "2026-08-14T12:11:06.177873Z",
+     "iopub.status.busy": "2026-08-14T12:11:06.177698Z",
+     "iopub.status.idle": "2026-08-14T12:11:09.896056Z",
+     "shell.execute_reply": "2026-08-14T12:11:09.895411Z"
     }
    },
    "outputs": [
@@ -1876,10 +2003,10 @@
    "id": "8b84d2fa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-14T09:54:13.399627Z",
-     "iopub.status.busy": "2026-08-14T09:54:13.399364Z",
-     "iopub.status.idle": "2026-08-14T09:54:16.072528Z",
-     "shell.execute_reply": "2026-08-14T09:54:16.071910Z"
+     "iopub.execute_input": "2026-08-14T12:11:09.898647Z",
+     "iopub.status.busy": "2026-08-14T12:11:09.898493Z",
+     "iopub.status.idle": "2026-08-14T12:11:13.578850Z",
+     "shell.execute_reply": "2026-08-14T12:11:13.578031Z"
     }
    },
    "outputs": [
@@ -1887,7 +2014,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "workspace: 200 proj_gyckilkc...\n"
+      "workspace: 200 proj_ipjpkhv3...\n"
      ]
     },
     {
@@ -1984,10 +2111,10 @@
    "id": "f7bca2a6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-14T09:54:16.075694Z",
-     "iopub.status.busy": "2026-08-14T09:54:16.075544Z",
-     "iopub.status.idle": "2026-08-14T09:54:22.933032Z",
-     "shell.execute_reply": "2026-08-14T09:54:22.932079Z"
+     "iopub.execute_input": "2026-08-14T12:11:13.582681Z",
+     "iopub.status.busy": "2026-08-14T12:11:13.582530Z",
+     "iopub.status.idle": "2026-08-14T12:11:20.283410Z",
+     "shell.execute_reply": "2026-08-14T12:11:20.282691Z"
     }
    },
    "outputs": [
@@ -2014,8 +2141,8 @@
      "text": [
       "\n",
       "stop reason: end_turn\n",
-      "tokens     : 89\n",
-      "answer     : Idempotency lets you safely retry an operation (e.g., after a network failure or timeout) without risking duplicate side effects, since repeated executions produce the same result as a single executio\n"
+      "tokens     : 76\n",
+      "answer     : Idempotency lets you safely retry a failed or repeated request without risking duplicate side effects (e.g., double charges or duplicate records).\n"
      ]
     }
    ],
@@ -2098,10 +2225,10 @@
    "id": "de6c0f59",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-14T09:54:22.936619Z",
-     "iopub.status.busy": "2026-08-14T09:54:22.936428Z",
-     "iopub.status.idle": "2026-08-14T09:54:27.487450Z",
-     "shell.execute_reply": "2026-08-14T09:54:27.486863Z"
+     "iopub.execute_input": "2026-08-14T12:11:20.286154Z",
+     "iopub.status.busy": "2026-08-14T12:11:20.285997Z",
+     "iopub.status.idle": "2026-08-14T12:11:24.686255Z",
+     "shell.execute_reply": "2026-08-14T12:11:24.685575Z"
     }
    },
    "outputs": [
@@ -2110,7 +2237,7 @@
      "output_type": "stream",
      "text": [
       "turn 1 stop reason: tool_use\n",
-      "turn 1 blocks     : ['toolUse']\n",
+      "turn 1 blocks     : ['reasoningContent', 'toolUse']\n",
       "tool call         : get_weather({'city': 'Singapore'})\n",
       "arguments valid   : yes\n"
      ]
@@ -2120,7 +2247,7 @@
      "output_type": "stream",
      "text": [
       "turn 2 stop reason: end_turn\n",
-      "final answer      : The current weather in Singapore is **31°C** and **humid**.\n"
+      "final answer      : The current weather in Singapore is **humid** with a temperature of **31°C**.\n"
      ]
     }
    ],
@@ -2202,10 +2329,10 @@
    "id": "828f3f71",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-14T09:54:27.489037Z",
-     "iopub.status.busy": "2026-08-14T09:54:27.488948Z",
-     "iopub.status.idle": "2026-08-14T09:54:37.529608Z",
-     "shell.execute_reply": "2026-08-14T09:54:37.528810Z"
+     "iopub.execute_input": "2026-08-14T12:11:24.689905Z",
+     "iopub.status.busy": "2026-08-14T12:11:24.689757Z",
+     "iopub.status.idle": "2026-08-14T12:11:33.441961Z",
+     "shell.execute_reply": "2026-08-14T12:11:33.440569Z"
     }
    },
    "outputs": [
@@ -2213,16 +2340,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "no extra fields  out= 319 blocks=['text']\n",
-      "                 reasoning=0 chars | # Bat and Ball Problem  **The ball costs $0.05 (5 cents)**  ## The Mat\n"
+      "no extra fields  out= 326 blocks=['text']\n",
+      "                 reasoning=0 chars | # Bat and Ball Problem  **The ball costs $0.05 (5 cents)**  ## Working\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "provider fields  out= 258 blocks=['text']\n",
-      "                 reasoning=0 chars | # Bat and Ball Problem  **Setting up the equations:** - Let ball = $x \n",
+      "provider fields  out= 337 blocks=['text']\n",
+      "                 reasoning=0 chars | # Bat and Ball Problem  **The ball costs $0.05 (5 cents)**  ## Solutio\n",
       "\n",
       "Note whether a reasoningContent block appears above. Some models return the\n",
       "trace as a typed block on Converse and some do not, so read the blocks\n",
@@ -2275,10 +2402,10 @@
    "id": "8c4e907c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-14T09:54:37.532103Z",
-     "iopub.status.busy": "2026-08-14T09:54:37.531955Z",
-     "iopub.status.idle": "2026-08-14T09:54:41.741012Z",
-     "shell.execute_reply": "2026-08-14T09:54:41.740255Z"
+     "iopub.execute_input": "2026-08-14T12:11:33.449013Z",
+     "iopub.status.busy": "2026-08-14T12:11:33.448810Z",
+     "iopub.status.idle": "2026-08-14T12:11:37.239327Z",
+     "shell.execute_reply": "2026-08-14T12:11:37.238843Z"
     }
    },
    "outputs": [


### PR DESCRIPTION
One file. `02-anthropic-claude/01-messages-api-core.ipynb` carried execution counts `[4,5,6,4,5,6,7,…]` — the first three cells were re-run interactively in a live Jupyter session while the notebook was being reviewed, and that state got committed along with unrelated work.

It matters because "executed cleanly top to bottom" is part of what this collection claims. Interleaved counts show the committed output came from more than one pass, so a reader can't assume the outputs are mutually consistent with each other.

**Every cell source is identical to what's already on `main`** — verified by hashing each of the 50 cells. This changes only outputs and execution counts. The notebook was re-executed end to end in one pass; counts are now `[1,2,3,…,25]`.

## State of the collection

| | |
|---|---|
| Notebooks | 33 |
| Cells | 1120 (543 code) |
| Unexecuted | 0 |
| Error outputs | 0 |
| Execution counts sequential | **all 33** |
| Unredacted account-scoped IDs in output | 0 |

## Scanners, re-run against this exact state

| Scanner | Result |
|---|---|
| Bandit 1.8.6 | 0 across 15,069 LOC |
| Semgrep 1.140.0 | 0 across 34 files |
| detect-secrets · Checkov (per-file) | 0 · 0 |
| pip-audit | no known vulnerabilities |
| Licence review | 0 copyleft / unknown |
| AWS ASH 3.5.8 | 7/7 available scanners PASSED, 0 at every severity |
| pyflakes · black · Repolinter | clean · clean · 13 pass, 2 benign, 0 fail |
| Holmes CSR rubric v3 | **0 findings** |

Nothing was edited between the final execution and the final scans.

PCSR: P490902911.