### PR TITLE
Add the AWS Content disclaimer to the per-model Bedrock samples

### DIFF
--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/00-foundations/01-endpoints-auth-and-the-three-paths.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/00-foundations/01-endpoints-auth-and-the-three-paths.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Foundations 1 — Endpoints, auth, and the three URL paths\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "**Start here.** Every other notebook in this collection assumes what this one\n",
     "establishes. The three things worth knowing before you write a line of code:\n",
     "\n",
@@ -41,6 +46,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1329416a",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/00-foundations/02-governance-projects-and-retention.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/00-foundations/02-governance-projects-and-retention.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Foundations 2 — Projects, data retention, and observability\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "Governance for `bedrock-mantle`: how to isolate workloads, attribute cost,\n",
     "control whether AWS retains your prompts, and find your metrics.\n",
     "\n",
@@ -26,6 +31,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "499eb268",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/00-foundations/03-scaling-tiers-and-latency.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/00-foundations/03-scaling-tiers-and-latency.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Foundations 3 — Quotas, retries, service tiers, and latency\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "Making mantle calls survive production. Mantle's throughput model is genuinely\n",
     "different from `bedrock-runtime`, and the differences bite if you assume they're\n",
     "the same.\n",
@@ -23,6 +28,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3a69825f",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/00-foundations/04-bedrock-runtime-converse-and-profiles.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/00-foundations/04-bedrock-runtime-converse-and-profiles.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Foundations 4 — `bedrock-runtime`: Converse, inference profiles, and the catalogue\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "Notebook 01 covered `bedrock-mantle`: bearer tokens, the three URL path families,\n",
     "and the OpenAI- and Anthropic-shaped APIs. This one covers the other endpoint.\n",
     "\n",
@@ -24,6 +29,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7a2da917",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/01-openai-gpt/01-responses-api-core.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/01-openai-gpt/01-responses-api-core.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# OpenAI GPT on Amazon Bedrock Mantle — Responses API core\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "OpenAI's models on the `bedrock-mantle` endpoint. This family is the only one\n",
     "with **Web Search**, **server-side tools**, and **explicit prompt-cache\n",
     "breakpoints**, so it needs more coverage than the others — five notebooks\n",
@@ -64,6 +69,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5cc1a21b",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/01-openai-gpt/02-web-search-and-grounding.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/01-openai-gpt/02-web-search-and-grounding.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Web Search on Amazon Bedrock Mantle — grounding OpenAI GPT models\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "**Web Search** is a built-in, server-side tool on `bedrock-mantle`. Add one\n",
     "parameter and the model can retrieve current information mid-request and cite its\n",
     "sources. AWS builds and hosts the index — there is no third-party search provider\n",
@@ -62,6 +67,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8f6b958c",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/01-openai-gpt/03-tools-and-structured-output.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/01-openai-gpt/03-tools-and-structured-output.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Tools and structured output — OpenAI GPT on Amazon Bedrock Mantle\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "Client-side tool calling and strict JSON on the Responses API. This is the\n",
     "machinery behind most agent loops: define tools, let the model choose, execute,\n",
     "feed results back, repeat.\n",
@@ -42,6 +47,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "993f3461",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/01-openai-gpt/04-prompt-caching-and-cost.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/01-openai-gpt/04-prompt-caching-and-cost.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Prompt caching on Amazon Bedrock Mantle — OpenAI GPT models\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "Prompt caching cuts both latency and cost when a long, stable prefix repeats\n",
     "across requests — system instructions, tool definitions, a reference document.\n",
     "The cached prefix skips *prefill*, which is the part of inference that dominates\n",
@@ -54,6 +59,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "168080d5",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/01-openai-gpt/05-server-side-tools-and-fine-tuning.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/01-openai-gpt/05-server-side-tools-and-fine-tuning.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Server-side tools, batch, and fine-tuning — OpenAI GPT on Bedrock Mantle\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "Everything in this family that Bedrock runs **for** you, rather than in your\n",
     "client loop:\n",
     "\n",
@@ -46,6 +51,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1c986dbc",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/02-anthropic-claude/01-messages-api-core.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/02-anthropic-claude/01-messages-api-core.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Anthropic Claude on Amazon Bedrock Mantle — Messages API core\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "Claude on the `bedrock-mantle` endpoint speaks the **Anthropic-native Messages\n",
     "API**. This notebook covers the fundamentals; `02-thinking-tools-and-caching.ipynb`\n",
     "covers extended thinking, tool use, and prompt caching, and\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/02-anthropic-claude/02-thinking-tools-and-caching.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/02-anthropic-claude/02-thinking-tools-and-caching.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Claude on Amazon Bedrock Mantle — thinking, tools, and prompt caching\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "The three capabilities that make Claude worth its price on `bedrock-mantle`:\n",
     "extended/adaptive thinking, tool use with forced schemas, and prompt caching with\n",
     "a one-hour TTL option.\n",
@@ -44,6 +49,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "27d79390",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/02-anthropic-claude/03-agentic-computer-use-and-memory.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/02-anthropic-claude/03-agentic-computer-use-and-memory.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Claude agentic tools on Amazon Bedrock Mantle — computer use, memory, compaction\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "The Anthropic-defined tool families: **computer use** (GUI automation), **bash**\n",
     "and **text editor**, the **memory** tool, and **context management** (compaction).\n",
     "These are what let a Claude agent run for a long time without drowning in its own\n",
@@ -51,6 +56,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4eb31f30",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/03-google-gemma/01-gemma4-end-to-end.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/03-google-gemma/01-gemma4-end-to-end.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Gemma 4 on Amazon Bedrock Mantle — end to end\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "Google DeepMind's Gemma 4 family (Apache 2.0) on the `bedrock-mantle` endpoint:\n",
     "simple inference → streaming → reasoning → stateful chat → tool use →\n",
     "structured JSON → multimodal → production hardening.\n",
@@ -49,6 +54,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6ded1a1d",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/03-google-gemma/02-gemma3-on-both-endpoints.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/03-google-gemma/02-gemma3-on-both-endpoints.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Gemma 3 on Amazon Bedrock — and why it is nothing like Gemma 4\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "Gemma 3 and Gemma 4 come from the same provider, one generation apart. Almost\n",
     "nothing about calling them is the same.\n",
     "\n",
@@ -35,6 +40,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "07e4fee6",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/04-qwen/01-qwen3-core-and-tools.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/04-qwen/01-qwen3-core-and-tools.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Qwen3 on Amazon Bedrock Mantle\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "Alibaba's Qwen3 family on the `bedrock-mantle` endpoint — a wide range of sizes plus\n",
     "dedicated coder and vision-language variants. This notebook covers the general-purpose\n",
     "models end to end; `02-qwen3-coder-and-vision.ipynb` covers the specialists.\n",
@@ -50,6 +55,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "847ecc61",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/04-qwen/02-qwen3-coder-and-vision.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/04-qwen/02-qwen3-coder-and-vision.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Qwen3 Coder and Vision on Amazon Bedrock Mantle\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "The specialist members of the Qwen3 family: three coding models and a\n",
     "vision-language model. `01-qwen3-core-and-tools.ipynb` covers the general-purpose\n",
     "models and the shared API mechanics.\n",
@@ -48,6 +53,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "43dd8047",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/05-deepseek/01-deepseek-v3-reasoning.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/05-deepseek/01-deepseek-v3-reasoning.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# DeepSeek V3 on Amazon Bedrock Mantle\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "DeepSeek's V3 family on the `bedrock-mantle` endpoint — strong reasoning and\n",
     "mathematics at open-weight pricing. Two generations are available, and this notebook\n",
     "interleaves them so you can see what changed.\n",
@@ -49,6 +54,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "dfc9aaab",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/06-zai-glm/01-glm-family.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/06-zai-glm/01-glm-family.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Z.AI GLM on Amazon Bedrock Mantle\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "Z.AI's GLM family on the `bedrock-mantle` endpoint, spanning a flagship model and a\n",
     "low-latency Flash variant. The size spread makes this a good family for demonstrating\n",
     "a cost-aware escalation pattern.\n",
@@ -51,6 +56,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a9c1ddf8",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/07-mistral/01-mistral-text-and-sizes.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/07-mistral/01-mistral-text-and-sizes.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Mistral AI on Amazon Bedrock Mantle — text models and the size ladder\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "Mistral has the widest size range of any family on `bedrock-mantle`: from a 3B\n",
     "Ministral up to a 675B Mistral Large 3. That size spread makes it a good family\n",
     "for demonstrating **cost-aware model routing** — send each request to the\n",
@@ -53,6 +58,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d69d500e",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/07-mistral/02-devstral-and-voxtral.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/07-mistral/02-devstral-and-voxtral.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Devstral and Voxtral on Amazon Bedrock Mantle — Mistral's specialists\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "The two specialised branches of the Mistral family: **Devstral 2** for agentic\n",
     "coding, and the **Voxtral** models, which are audio-capable elsewhere in the\n",
     "Mistral ecosystem. This notebook shows what each actually does on\n",
@@ -48,6 +53,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a7843d7c",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/08-moonshot-kimi/01-kimi-k2.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/08-moonshot-kimi/01-kimi-k2.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Moonshot AI Kimi K2 on Amazon Bedrock Mantle\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "Moonshot AI's Kimi K2 models on the `bedrock-mantle` endpoint. Both variants are built\n",
     "for long-context and agentic work, and one is explicitly a thinking model.\n",
     "\n",
@@ -48,6 +53,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a055b450",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/09-minimax/01-minimax-m2.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/09-minimax/01-minimax-m2.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# MiniMax M2 on Amazon Bedrock Mantle\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "MiniMax's M2 line on the `bedrock-mantle` endpoint. Three generations are live\n",
     "simultaneously — more than any other family here — which makes it a good fit\n",
     "for demonstrating a version-migration test.\n",
@@ -50,6 +55,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a4c94505",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/10-nvidia-nemotron/01-nemotron-nano-and-super.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/10-nvidia-nemotron/01-nemotron-nano-and-super.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# NVIDIA Nemotron on Amazon Bedrock Mantle\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "NVIDIA's Nemotron family on the `bedrock-mantle` endpoint — a set of small 'Nano'\n",
     "models plus a large 'Super', which together give a clean cost/quality curve to reason\n",
     "about. One Nano variant is also vision-language capable.\n",
@@ -51,6 +56,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3050a24f",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/11-xai-grok/01-grok-4-3.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/11-xai-grok/01-grok-4-3.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# xAI Grok 4.3 on Amazon Bedrock Mantle\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "Grok 4.3 on the `bedrock-mantle` endpoint — a reasoning-first model with\n",
     "always-on thinking, strong tool use, and a large context window. It is aimed at\n",
     "document-heavy enterprise work: contract review, case-law research, credit\n",
@@ -55,6 +60,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "db602f33",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/12-writer-palmyra/01-palmyra-vision.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/12-writer-palmyra/01-palmyra-vision.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Writer Palmyra Vision on Amazon Bedrock Mantle\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "Writer's Palmyra Vision model on the `bedrock-mantle` endpoint. This is a deliberately\n",
     "instructive case: it is vision-capable but **does not support tool calling**, so it\n",
     "shows both a specialised strength and how to work around a real limitation.\n",
@@ -48,6 +53,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "812d6317",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/12-writer-palmyra/02-palmyra-x4-x5-on-runtime.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/12-writer-palmyra/02-palmyra-x4-x5-on-runtime.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Palmyra X4 and X5 — a family where every model answers differently\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "Writer has three models on Amazon Bedrock, and they disagree on almost every\n",
     "operational question. This is the clearest example in the collection of why\n",
     "\"which provider\" is the wrong unit of decision.\n",
@@ -28,6 +33,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "68730690",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/13-amazon-nova/01-nova-ladder-and-vision.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/13-amazon-nova/01-nova-ladder-and-vision.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Amazon Nova — picking a tier, and proving the small one is enough\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "Nova is Amazon's own model family and the clearest size ladder on Bedrock. It is\n",
     "`bedrock-runtime` only: there is no `bedrock-mantle` path, so Converse is the\n",
     "API.\n",
@@ -28,6 +33,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "57b2b2bd",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/14-openai-gpt-oss/01-gpt-oss-on-both-endpoints.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/14-openai-gpt-oss/01-gpt-oss-on-both-endpoints.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# gpt-oss — the same model, two endpoints, and the reasoning hides in different places\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "`gpt-oss` is OpenAI's open-weight family. Unlike GPT-5.x, which is\n",
     "`bedrock-mantle` only, gpt-oss is on **both** endpoints.\n",
     "\n",
@@ -32,6 +37,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f4b71a77",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/14-openai-gpt-oss/02-gpt-oss-safeguard-classification.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/14-openai-gpt-oss/02-gpt-oss-safeguard-classification.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# gpt-oss-safeguard — a model for judging content against *your* policy\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "`gpt-oss-safeguard` is not a general chat model. It is tuned to take a policy you\n",
     "write and decide whether a piece of content violates it. That makes it a different\n",
     "tool from `gpt-oss`, which is why it gets its own notebook rather than a section.\n",
@@ -25,6 +30,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "88583541",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/15-meta-llama/01-llama4-moe-and-vision.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/15-meta-llama/01-llama4-moe-and-vision.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Llama 4 — mixture-of-experts, vision, and profile-only access\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "Meta's Llama 4 models are `bedrock-runtime` only and **`INFERENCE_PROFILE` only**:\n",
     "they reject their bare model ID, so every call goes through the `us.` prefixed\n",
     "profile. Llama 3.x is still in the catalogue but superseded, so this notebook\n",
@@ -25,6 +30,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e717f2e3",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/99-cross-cutting/01-choosing-a-model-and-api.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/99-cross-cutting/01-choosing-a-model-and-api.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Choosing a model and API on Amazon Bedrock Mantle\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "A live capability survey across every family on `bedrock-mantle`. Rather than\n",
     "trusting a table someone wrote months ago, this notebook **probes the endpoint**\n",
     "and builds the table from what the API actually does today.\n",
@@ -38,6 +43,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "55d7d501",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/99-cross-cutting/02-migrating-from-openai.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/99-cross-cutting/02-migrating-from-openai.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Migrating to Amazon Bedrock Mantle from OpenAI or Anthropic\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "The headline promise is real: point your existing SDK at a new base URL and key,\n",
     "and it works. This notebook shows that — and then shows the four places where a\n",
     "naive port breaks, so you find them here rather than in production.\n",
@@ -37,6 +42,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8611c85f",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/99-cross-cutting/03-production-hardening.ipynb
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/99-cross-cutting/03-production-hardening.ipynb
@@ -7,6 +7,11 @@
    "source": [
     "# Production hardening for Amazon Bedrock Mantle\n",
     "\n",
+    "> **Sample code — not for production.** Provided as AWS Content under the AWS\n",
+    "> Customer Agreement; do not use it in production accounts or on production or other\n",
+    "> critical data. Running these cells calls Amazon Bedrock and incurs charges. Full\n",
+    "> disclaimer in the [README](../README.md#disclaimer).\n",
+    "\n",
     "Everything to get right before a mantle workload carries real traffic. Each\n",
     "section is a control you can verify, not advice you have to take on trust.\n",
     "\n",
@@ -41,6 +46,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7fbdd47a",
    "metadata": {},
    "source": [
     "### Where the helpers come from\n",

--- a/agentic-workloads/sample-per-model-for-amazon-bedrock/README.md
+++ b/agentic-workloads/sample-per-model-for-amazon-bedrock/README.md
@@ -193,6 +193,19 @@ today can be rejected tomorrow, as happened to Gemma 4 on 12 August 2026. Where 
 notebook states a parameter matrix it also shows the probe that produced it, so you
 can re-derive today's answer instead of trusting a committed table.
 
+## Disclaimer
+
+The sample code; software libraries; command line tools; proofs of concept;
+templates; or other related technology (including any of the foregoing that are
+provided by our personnel) is provided to you as AWS Content under the AWS Customer
+Agreement, or the relevant written agreement between you and AWS (whichever applies).
+You should not use this AWS Content in your production accounts, or on production or
+other critical data. You are responsible for testing, securing, and optimizing the
+AWS Content, such as sample code, as appropriate for production grade use based on
+your specific quality control practices and standards. Deploying AWS Content may
+incur AWS charges for creating or using AWS chargeable resources, such as running
+Amazon EC2 instances or using Amazon S3 storage.
+
 ## Security
 
 See [CONTRIBUTING](../../CONTRIBUTING.md#security-issue-notifications) for how to


### PR DESCRIPTION
Adds the standard AWS Content disclaimer to `agentic-workloads/sample-per-model-for-amazon-bedrock/`.

Requested by **`isaacibr@`**, the Guardian on PCSR [P490902911](https://t.corp.amazon.com/P490902911), after he passed the review of the artefact. His text is used verbatim.

## Two placements

| Where | What |
|---|---|
| Folder `README.md` | Full text in its own `## Disclaimer` section |
| All 33 notebooks | Short blockquote under the H1, linking to the README section |

Both, not just the README. This collection is built so a reader opens the one folder for the model they are using — that is why it exists as 16 per-family folders rather than a single tour. Someone arriving at `03-google-gemma/01-gemma4-end-to-end.ipynb` from a search result never sees the README, so a README-only disclaimer would miss most of the audience. The notebook line stays short and points at the canonical text rather than repeating a legal paragraph 33 times.

## Markdown only — proven, not asserted

**34 files changed, 210 insertions, 0 deletions.** Against the reviewed commit, for all 33 notebooks:

- 543 code cell sources — byte-identical
- Cell outputs — byte-identical
- `execution_count` values — byte-identical, and sequential in all 33
- Only markdown cell that differs — `cell[0]`, in every notebook
- `requirements.txt` — untouched

That is what lets this skip the full 33-notebook re-execution: the committed output still matches the code that produced it.

## Rescanned on these exact bytes

| Gate | Result | vs reviewed commit |
|---|---|---|
| Bandit 1.8.6 | 0 across 15,069 LOC | identical |
| Semgrep 1.140.0 | 0, 290 rules over 34 files | identical |
| detect-secrets 1.5.0 | 0 | identical |
| Checkov 3.2.484 (secrets, per-file) | 0 | identical |
| Repolinter, Amazon OSPO ruleset | 13 pass · 2 benign · 0 fail | identical |
| Holmes, CSR rubric v3 + AppSec baseline | **0 findings** | identical |

Mirrors `sample-per-model-for-amazon-bedrock@b3d9bdb`, the artefact under review in P490902911. The two copies stay byte-identical apart from the two relative link paths in the README.