### PR TITLE
feat(skills): add sagemaker-marketplace-onboarding Claude Code skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,6 +11,12 @@
       "source": "./ai-coding-assistants/skills/aws-bento-deck",
       "description": "Build AWS-branded BENTO presentations (self-contained .bento.html) from a plan file, with a three-phase PLAN -> BUILD -> QA workflow.",
       "keywords": ["aws", "presentation", "bento", "slides", "deck", "branding"]
+    },
+    {
+      "name": "sagemaker-marketplace-onboarding",
+      "source": "./ai-infra/sagemaker-marketplace-onboarding",
+      "description": "Interactive walkthrough that onboards a model provider's container onto the AWS SageMaker Marketplace container contract: /ping + /invocations, optional bidirectional WebSocket, optional per-inference metering, weights packaging, local testing, ECR push, and CreateModelPackage hand-off.",
+      "keywords": ["aws", "sagemaker", "marketplace", "ml", "container", "onboarding"]
     }
   ]
 }

--- a/ai-infra/sagemaker-marketplace-onboarding/.claude-plugin/plugin.json
+++ b/ai-infra/sagemaker-marketplace-onboarding/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin.json",
+  "name": "sagemaker-marketplace-onboarding",
+  "displayName": "SageMaker Marketplace Onboarding",
+  "version": "1.0.0",
+  "description": "Interactive walkthrough that onboards a model provider's container onto the AWS SageMaker Marketplace container contract: /ping + /invocations, optional bidirectional WebSocket, optional per-inference metering, weights packaging, local testing, ECR push, and CreateModelPackage hand-off.",
+  "author": {
+    "name": "AWS Samples"
+  },
+  "homepage": "https://github.com/aws-samples/sample-apj-sup-sa/tree/main/ai-infra/sagemaker-marketplace-onboarding",
+  "repository": "https://github.com/aws-samples/sample-apj-sup-sa",
+  "keywords": ["aws", "sagemaker", "marketplace", "ml", "container", "onboarding"]
+}

--- a/ai-infra/sagemaker-marketplace-onboarding/README.md
+++ b/ai-infra/sagemaker-marketplace-onboarding/README.md
@@ -1,0 +1,165 @@
+# sagemaker-marketplace-onboarding
+
+An [Agent Skill](https://docs.claude.com/en/docs/claude-code/skills) that walks a model provider
+through making their container compatible with the AWS SageMaker Marketplace container contract —
+`/ping` + `/invocations` (Real-Time, Streaming, Async, Batch Transform), optional bidirectional
+WebSocket, optional per-inference metering, weights packaging, local testing, ECR push, and an
+optional `CreateModelPackage` hand-off for sellers who also want to publish.
+
+## What it does
+
+An 11-phase interactive walkthrough, one phase at a time with confirmation before advancing:
+
+| Phase | What happens |
+|-------|--------------|
+| 0 | Goal (container-only vs. also-list) + project state (existing vs. greenfield) |
+| 1 | Inventory an existing project (framework, HTTP routes, weights) — read-only |
+| 2 | Discovery interview (invocation modes, modality, billing model) via structured questions |
+| 3 | Gap analysis vs. the container contract — report only, never edits the original project |
+| 4 | Scaffold a sibling directory from this skill's templates |
+| 5 | Walk through `/ping`, `/invocations`, streaming, `/execution-parameters`, WebSocket |
+| 6 | Dockerfile contract — exec-form ENTRYPOINT, no baked weights, no NVIDIA drivers, no `tini` |
+| 7 | Model weights packaging (`model.tar`, uncompressed, `.safetensors` preferred) |
+| 8 | Local testing gate — must pass before ECR push |
+| 9 | ECR push + vulnerability scan |
+| 10 | Pre-submission checklist |
+| 11 | `CreateModelPackage` hand-off (only if the seller also wants to publish) |
+| 12 | *(optional, ask-only)* Operating a live listing — observability + IAM temporary delegation pointers |
+
+Never edits a provider's existing project files — it always scaffolds alongside into a sibling
+directory (e.g. `<project>/sagemaker/`).
+
+## What's in this skill
+
+```
+sagemaker-marketplace-onboarding/
+├── SKILL.md                              ← Skill instructions (the agent reads this)
+├── README.md                             ← This file
+├── reference/
+│   ├── contract.md                       ← One-page endpoint/header/timing cheat sheet
+│   ├── timing.md                         ← Every hard timing constraint
+│   ├── checklist.md                      ← Full pre-submission checklist template
+│   ├── gap-checks.md                     ← Gap-analysis checklist for Phase 3
+│   ├── websocket.md                      ← Bidirectional streaming protocol, Ping/Pong, metadata channel
+│   ├── billing.md                        ← Hourly vs. per-inference, dimensions, freeze rule
+│   ├── logging.md                        ← CloudWatch log groups, structured JSON logging
+│   ├── marketplace-listing.md            ← CreateModelPackage API skeleton + validation job
+│   ├── observability.md                  ← CloudWatch metrics catalog + EMF business-metric emission
+│   └── iam-temporary-delegation.md       ← Buyer-approved temporary support access for a live listing
+└── templates/
+    ├── Dockerfile, app.py, model_loader.py, inference.py, metering.py, websocket_handler.py
+    ├── package_model.sh, requirements.txt, supervisord.conf, PRE_SUBMISSION_CHECKLIST.md
+    └── test/  (test_input.json, test_local.sh, test_streaming.py, test_websocket.py)
+```
+
+## Requirements
+
+- No build step — this skill is Markdown instructions plus copy-and-fill Python/shell templates.
+- The agent needs Write/Read/shell access to scaffold the sibling directory and run local Docker
+  tests (Phase 8) — no npm/Node dependency, unlike some other skills in this repo.
+- Docker (for Phase 8 local testing) and the AWS CLI + an AWS account (for Phase 9 ECR push and
+  Phase 11 `CreateModelPackage`) are the provider's own prerequisites, not the skill's.
+
+---
+
+## Installation
+
+### Claude Code
+
+**Option A — Plugin marketplace (recommended).** This repo ships a Claude Code plugin
+marketplace, so you can install the skill (and get automatic updates) with two commands inside
+Claude Code:
+
+```
+/plugin marketplace add aws-samples/sample-apj-sup-sa
+/plugin install sagemaker-marketplace-onboarding@apj-sup-sa
+```
+
+See [`../../README.md`](../../README.md) for marketplace details.
+
+**Option B — Copy into your skills directory.** Copy this folder into either scope:
+
+```bash
+# Personal (all projects)
+cp -R ai-infra/sagemaker-marketplace-onboarding ~/.claude/skills/sagemaker-marketplace-onboarding
+
+# Project-scoped (checked in for your team)
+mkdir -p .claude/skills
+cp -R ai-infra/sagemaker-marketplace-onboarding .claude/skills/sagemaker-marketplace-onboarding
+```
+
+Restart Claude Code (or run `/doctor`) and confirm the skill is listed. It activates automatically
+when you ask to onboard a model onto SageMaker Marketplace.
+
+### Codex
+
+Codex CLI discovers Agent Skills from a `skills/` directory. Place this folder where your Codex
+setup looks for skills:
+
+```bash
+# Personal scope
+mkdir -p ~/.codex/skills
+cp -R ai-infra/sagemaker-marketplace-onboarding ~/.codex/skills/sagemaker-marketplace-onboarding
+
+# Or project scope, checked into your repo
+mkdir -p .codex/skills
+cp -R ai-infra/sagemaker-marketplace-onboarding .codex/skills/sagemaker-marketplace-onboarding
+```
+
+The `SKILL.md` frontmatter (`name` + `description`) is what Codex matches on to decide when to
+load the skill. Confirm your Codex version's skills path in its docs — some builds read
+`AGENTS.md`/skill references from the working directory instead.
+
+### Kiro
+
+Kiro loads skill-style guidance from its steering/rules configuration. Vendor the skill into your
+Kiro workspace and point steering at it:
+
+```bash
+mkdir -p .kiro/skills
+cp -R ai-infra/sagemaker-marketplace-onboarding .kiro/skills/sagemaker-marketplace-onboarding
+```
+
+Then add a steering rule (e.g. in `.kiro/steering/`) that tells Kiro to read
+`.kiro/skills/sagemaker-marketplace-onboarding/SKILL.md` when the user wants to onboard a model
+container onto SageMaker Marketplace, and to follow its phase-by-phase workflow. Because the skill
+is plain Markdown plus templates, no Kiro-specific packaging is required.
+
+---
+
+## Usage
+
+Once installed, ask for it in plain language:
+
+```
+Help me onboard my model to SageMaker Marketplace.
+```
+
+or:
+
+```
+Review my container against the SageMaker Marketplace spec.
+```
+
+Trigger phrases the skill recognizes include: "onboard my model to SageMaker Marketplace", "list
+my model on SageMaker Marketplace", "help me build a SageMaker Marketplace container", "package my
+model for SageMaker Marketplace" — or attaching the SageMaker Marketplace Model Listing Guide.
+
+### What to expect
+
+1. **Two up-front questions** — container-only vs. also-list, and existing project vs. greenfield.
+2. **If you have an existing project**, it inventories your code (read-only) and reports back
+   framework, HTTP routes, and where weights live for you to confirm or correct.
+3. **A structured discovery interview** — invocation modes, modality, framework, billing model —
+   using multiple-choice questions, not free text, because the answers change what gets generated.
+4. **A gap-analysis punch list** (existing projects only) before anything is written.
+5. **A scaffolded sibling directory** — never your existing files — with a Dockerfile, server,
+   model loader, inference stub, tests, and a pre-submission checklist tailored to your answers.
+6. **A local-testing gate** that must pass (container start, `/ping`, `/invocations`, network
+   isolation, SIGTERM handling) before it lets you push to ECR.
+7. **Optionally**, help running `CreateModelPackage` with a validation job if you're also listing.
+
+Everything outside the container contract — FDP enrollment, IAM roles, pricing, EULA, regions, the
+customer-facing notebook, and publishing — is manual work you handle via your AWS account team and
+the Marketplace Management Portal; the skill points you at the right docs rather than walking you
+through those steps.

--- a/ai-infra/sagemaker-marketplace-onboarding/SKILL.md
+++ b/ai-infra/sagemaker-marketplace-onboarding/SKILL.md
@@ -349,6 +349,18 @@ The walkthrough ends here.
 
 ---
 
+## Phase 12 — Operating a live listing (optional, only if asked)
+
+Only relevant after Phase 11 is complete and the listing is published. Do not raise this unprompted — surface it if the user asks about monitoring a live endpoint, reconciling Marketplace billing, or giving customer support teams account access.
+
+**Observability.** SageMaker publishes request/latency/error metrics and instance resource metrics to CloudWatch automatically — no container code needed for those. For streaming/WebSocket models, point the user at `ConcurrentRequestsPerModel` (10s-resolution, includes queued requests — the real load signal for long-lived connections) and `FirstChunkLatency`, not `InvocationsPerInstance`. For GPU capacity planning, SageMaker's detailed observability (on by default) exposes per-GPU Prometheus metrics via PromQL with zero container changes. If the seller wants their own business/billing metrics in CloudWatch (e.g. to reconcile Marketplace metered billing against actual traffic), recommend CloudWatch Embedded Metric Format (EMF) — a stdout JSON line CloudWatch auto-extracts into a real metric, no outbound call, works under network isolation. See `reference/observability.md` for the full metric catalog and an EMF emission snippet that mirrors the existing `metering.py` `ConsumedUnits` value.
+
+**Customer support access.** If the seller asks how to support a buyer's endpoint without a standing cross-account IAM role, point them at AWS IAM Temporary Delegation — buyer-approved, time-limited (≤12h) STS credentials, CloudTrail-logged, no wildcards. This requires separate AWS Partner qualification to initiate requests; it is account/product-level enablement, not something this skill's container or `CreateModelPackage` call sets up. See `reference/iam-temporary-delegation.md`.
+
+Both of these are pointers, not implementation phases — this skill does not build the CloudWatch dashboards, alarms, or delegation integration for the user.
+
+---
+
 ## Reference material (in this skill's directory)
 
 Read these when you need to quote a specific constraint:
@@ -361,6 +373,8 @@ Read these when you need to quote a specific constraint:
 - `reference/billing.md` — hourly vs per-inference, dimensions, freeze rule
 - `reference/logging.md` — CloudWatch log groups, structured JSON logging, key events to log, multi-process pitfalls
 - `reference/marketplace-listing.md` — CreateModelPackage API skeleton + validation job (Phase 11 only)
+- `reference/observability.md` — CloudWatch metrics catalog (invocation/instance/detailed-observability) + EMF business-metric emission (Phase 12 only)
+- `reference/iam-temporary-delegation.md` — buyer-approved temporary support access for a live listing (Phase 12 only)
 
 ## Interaction style
 

--- a/ai-infra/sagemaker-marketplace-onboarding/SKILL.md
+++ b/ai-infra/sagemaker-marketplace-onboarding/SKILL.md
@@ -1,0 +1,373 @@
+---
+name: sagemaker-marketplace-onboarding
+description: "Interactive walkthrough that onboards a model provider onto SageMaker Marketplace by making their model container spec-compliant. Handles existing projects (inventory + gap analysis + scaffold alongside without editing their files) and greenfield builds. Covers the /ping and /invocations contract (Real-Time, Streaming, Async, Batch Transform), optional bidirectional WebSocket, optional per-inference metering, model weights packaging, local testing, and ECR push. Optionally guides CreateModelPackage with the validation job for users who also want to publish. Use when the user says things like 'onboard my model to SageMaker Marketplace', 'list my model on SageMaker Marketplace', 'help me build a SageMaker Marketplace container', 'package my model for SageMaker Marketplace', 'review my container against the SageMaker Marketplace spec', or attaches the SageMaker Marketplace Model Listing Guide."
+---
+
+# SageMaker Marketplace — Container Builder (Interactive Walkthrough)
+
+You are guiding a model provider (the seller) through the process of making their model container compatible with the AWS SageMaker Marketplace container contract. The provider may already have a project or may be starting from scratch, and they may want to stop at the container or continue on to publish a Marketplace listing. Adapt accordingly.
+
+The container contract you are enforcing supports four sync invocation modes with **one identical `/invocations` implementation**: Real-Time (`InvokeEndpoint`), Streaming response (`InvokeEndpointWithResponseStream`), Async Inference (`InvokeEndpointAsync`), and Batch Transform. The container code is mode-agnostic — SageMaker handles routing. Bidirectional WebSocket streaming and per-inference metering are **opt-in** — only generate them if the user says they need them.
+
+## Move phase by phase
+
+Do not dump the whole plan on the user up front. One phase at a time, confirm before moving to the next. When you write files, use the Write tool; don't paste them into chat. Save what you learn about the project to memory (`project` type) so future sessions don't ask twice.
+
+---
+
+## Phase 0 — Goal + project state
+
+Ask two questions up front, in a single AskUserQuestion call. These branch the rest of the walkthrough.
+
+**Question A — Goal (what does "done" look like for you?):**
+
+- **Just build a SageMaker-compatible container** — the provider wants a working container they can deploy however they like. Skip the marketplace-listing phase at the end.
+- **Build the container AND list on Marketplace** — after the container is ready, walk them through FDP enrollment, IAM roles, `CreateModelPackage`, pricing, EULA, regions, notebook, and publishing (Limited → Public).
+
+Route the "container only" answer through Phases 1–10 as usual, but skip Phase 11 (Marketplace listing hand-off). Route the "also list" answer through the full sequence including Phase 11.
+
+**Question B — Project state:**
+
+- **Existing project** (they have code they want to make marketplace-ready) → Phase 1 (Inventory)
+- **Greenfield** (starting from scratch) → skip to Phase 2 (Discovery interview), then Phase 4 (Scaffold from templates)
+
+If existing, ask for the project path. If no folder is mounted, offer `mcp__cowork__request_cowork_directory`. Do not proceed without seeing the code.
+
+**Save both answers to memory** as `project` type so a later session picks up where you left off. Use these two flags — `goal` (container-only vs also-list) and `project_state` (existing vs greenfield) — to gate the rest of the walkthrough.
+
+---
+
+## Phase 1 — Inventory the existing project (existing projects only)
+
+Do a **shallow** read. You are trying to answer three questions: what framework is this, what HTTP interface (if any) does it already expose, and where do the weights live. Do not read every source file.
+
+Inventory targets (Read/Glob these; skip if not present):
+
+1. **Dependency manifests**: `requirements.txt`, `pyproject.toml`, `Pipfile`, `poetry.lock`, `setup.py`, `environment.yml`. Framework detection: `torch`, `transformers`, `tensorflow`, `onnxruntime`, `tritonclient`, `vllm`, `fastapi`, `flask`, `bentoml`, `torchserve`.
+2. **Dockerfile** (any of `Dockerfile`, `Dockerfile.*`, `docker/Dockerfile`). Extract: base image, ENTRYPOINT (exec vs shell form), CMD, exposed ports, `USER` directive, any `LABEL` for SageMaker.
+3. **Entry points**: files named `app.py`, `server.py`, `main.py`, `serve.py`, `inference.py`, `handler.py`, `predictor.py`. Read them once. Note: framework (Flask/FastAPI/aiohttp/Starlette/torchserve/BentoML), listen port, existing route paths (`/ping`, `/health`, `/predict`, `/invocations`, `/v1/completions`, etc.), how model weights are loaded.
+4. **Weights**: look for `*.pt`, `*.bin`, `*.safetensors`, `*.onnx`, `*.pb`, `model.tar`, `checkpoints/`, `weights/`, `models/`. Are they baked into the repo? Downloaded on startup from HuggingFace Hub or S3?
+5. **README / docs**: skim the first ~100 lines of `README.md` to catch stated inputs, outputs, and invocation examples.
+
+**Report back** to the user in a short block:
+
+```
+Framework:           <detected>
+Existing HTTP server: <file>:<line> on port <N>, routes: <list>
+Model weights:        <where they are, whether baked-in>
+Dockerfile:           <present + summary, or absent>
+```
+
+Then confirm your read with the user before moving to Phase 2. Ask them to correct anything you got wrong.
+
+---
+
+## Phase 2 — Discovery interview
+
+Use **AskUserQuestion** — not free-text — grouped into at most two calls to avoid overwhelming the user. Cover:
+
+**Group 1 — Invocation modes (multiSelect):**
+- Real-Time `/invocations` (baseline — required for any listing)
+- Streaming response (`InvokeEndpointWithResponseStream` — chunked HTTP response, for LLMs/generation)
+- **Async Inference** (`InvokeEndpointAsync` — auto-supported by the same `/invocations` with **no container code change**. But the container-side implications matter: **1 GB payload** (via S3) and **60-minute** processing budget vs. the 60-second sync timeout. Ask if the model has invocations that can run >60s or process >25 MB — if yes, note this for the customer-facing notebook so buyers know Async is an option. This is informational for the container walkthrough; no scaffold changes.)
+- Batch Transform (auto-supported by the same `/invocations`, but ask if they'll actually use it — affects whether we scaffold `/execution-parameters`)
+- **Bidirectional WebSocket** (`InvokeEndpointWithBidirectionalStream` — full-duplex real-time streaming; typical use cases include STT/TTS/voice, live translation, agent-to-agent flows. Requires `/invocations-bidirectional-stream` endpoint + Docker label + Ping/Pong handling. Skip unless the model genuinely needs simultaneous input and output.)
+
+**Group 2 — Model shape:**
+- **Modality** — LLM (text-in / text-out) / STT (audio-in / text-out) / TTS (text-in / audio-out) / Image classification or detection / Image generation / Text embedding / Vision-language (multimodal) / Other. This drives which modality-specific patterns (if any) apply — for example, pronunciation overrides only apply to TTS; audio streaming protocols only apply to STT/TTS. Do not ask about pronunciation, audio streaming, or other modality-specific patterns unless the modality warrants it.
+- Framework (confirm from inventory or ask fresh for greenfield): PyTorch / HuggingFace Transformers / TensorFlow / ONNX Runtime / Triton / vLLM / Other
+- Model size on disk: <5 GB / 5–20 GB / 20–50 GB / >50 GB (drives cold-start budget conversation)
+- Target instance family: ml.g5.* / ml.g6.* / ml.g6e.* / ml.p4d.* / CPU (ml.m5/ml.c5)
+- Primary input `Content-Type`: application/json / audio (wav/mp3) / image / text/plain / multipart / other
+- Response shape: single JSON / single binary / multi-file (needs zip) / streaming chunks
+
+**Group 3 — Billing:**
+- Billing model: **Hourly** (customer pays $/hour per instance) or **Per-inference / usage-based** (customer pays per unit consumed — you must emit metering; harder to change later, 90-day freeze after any price update)
+- If per-inference: what's the billable dimension? The right choice depends on modality — pick from the list below or supply a custom name. This is a naming decision — it must match between the container's metering emission and the Marketplace listing configuration.
+
+  | Modality | Typical dimensions |
+  |---|---|
+  | LLM | `tokens`, `inference.count` |
+  | STT | `audio_seconds`, `inference.count` |
+  | TTS | `characters_synthesized`, `audio_seconds`, `inference.count` |
+  | Image classification / detection | `images`, `inference.count` |
+  | Image generation | `images`, `pixels`, `inference.count` |
+  | Text embedding | `characters_processed`, `tokens`, `inference.count` |
+  | Vision-language | `tokens`, `images`, `inference.count` |
+  | Other / catch-all | `inference.count` |
+
+**Modality-specific follow-ups** — only ask if the answer above triggers them:
+
+- **TTS only**: do customers need per-request pronunciation overrides? Because the container runs in network isolation and cannot load pronunciation dictionaries from S3 at runtime, the standard pattern is to accept `pronunciations` in the request body. If yes, document this convention in the customer-facing notebook and have the container's TTS handler read the field and apply overrides during synthesis. Skip this entirely for non-TTS models.
+- **STT / TTS only** (and only if bidirectional WebSocket was picked in Group 1): confirm the audio streaming protocol shape. Skip for other modalities.
+- **LLM only** (and only if streaming response or WebSocket was picked in Group 1): confirm token-level streaming vs sentence-level chunks.
+
+Also confirm the **target directory** for scaffolding. For existing projects, propose a sibling dir like `<project>/sagemaker/` so nothing overwrites their code.
+
+Record everything to memory (`project` type). If the user has already answered a subset in prior conversations, don't ask again.
+
+---
+
+## Phase 3 — Gap analysis (existing projects only)
+
+Before writing any code, produce a punch list comparing the existing project against the container contract. For each gap, name the specific file/line, the spec constraint, and the fix. Do **not** edit the existing files — just report.
+
+Reference `reference/gap-checks.md` for the full list of things to check. The common gaps are:
+
+1. **Wrong port** — anything not listening on 8080 must be moved.
+2. **Wrong health-check path** — SageMaker only pings `/ping`. Rename or add.
+3. **`/ping` always returns 200** — must return 503 while loading; spec warns this causes routing to dead instances.
+4. **Non-standard inference path** — `/predict`, `/v1/chat/completions`, etc. must become `/invocations`. Add a shim, don't just rename (keeps the original working for other clients).
+5. **Weights baked into the image** — must be extracted into `model.tar` and loaded from `/opt/ml/model/`.
+6. **Weights downloaded at startup** — HuggingFace Hub, S3, git-lfs pulls: all fail. Container runs with zero outbound network.
+7. **Shell-form ENTRYPOINT** — breaks SIGTERM. Convert to exec form.
+8. **Missing `CMD ["serve"]`** — SageMaker runs `docker run <image> serve`.
+9. **Non-root `USER`** — causes permission issues with the `/opt/ml/model/` mount.
+10. **NVIDIA drivers bundled** — remove; SageMaker provides them.
+11. **`tini` used as init** — remove; it gets confused by the `serve` arg.
+12. **Startup > 8 minutes** — spec hard limit. If load is close, recommend uncompressed tar + safetensors.
+13. **Reliance on custom HTTP headers** — SageMaker strips everything except the five documented headers.
+14. **Custom pricing hooks needed** — if per-inference billing was picked in Phase 2, metering emission is currently missing.
+15. **WebSocket missing** — if bidirectional was picked in Phase 2, `/invocations-bidirectional-stream` + Docker label + Ping/Pong all need to be added.
+
+Present the punch list, get user confirmation, then move to Phase 4.
+
+---
+
+## Phase 4 — Scaffold alongside (both paths)
+
+Create the following layout in the target directory. For existing projects this is a sibling directory (e.g., `<project>/sagemaker/`) — do not touch the existing project's files.
+
+```
+<target>/
+├── Dockerfile
+├── requirements.txt
+├── app.py                      # FastAPI server — /ping, /invocations, /execution-parameters
+├── model_loader.py             # Loads weights from /opt/ml/model/
+├── inference.py                # predict() and (if streaming) predict_stream() — provider fills in
+├── package_model.sh            # Builds model.tar from a weights dir + uploads to S3
+├── test/
+│   ├── test_input.json
+│   ├── test_local.sh           # docker run + curl smoke tests + SIGTERM + --network none
+│   └── test_streaming.py       # Streaming response chunk-arrival check
+├── PRE_SUBMISSION_CHECKLIST.md
+└── (if WebSocket opted in:)
+    ├── websocket_handler.py    # /invocations-bidirectional-stream + Ping/Pong + framing + metadata channel
+    └── test/test_websocket.py  # Local WebSocket smoke test
+└── (if per-inference billing opted in:)
+    └── metering.py             # emits X-Amzn-Inference-Metering JSON header on 2XX responses
+```
+
+Populate from the templates in this skill's `templates/` directory. Read the templates via Read and pass their contents to Write:
+
+- Always: `Dockerfile`, `requirements.txt`, `app.py`, `model_loader.py`, `inference.py`, `package_model.sh`, `test/test_input.json`, `test/test_local.sh`, `PRE_SUBMISSION_CHECKLIST.md`
+- If streaming response was chosen: also `test/test_streaming.py`, and uncomment the streaming block in the copy of `app.py`
+- If Bidirectional WebSocket was chosen: also `websocket_handler.py`, `test/test_websocket.py`, uncomment the Docker `LABEL` in the copy of `Dockerfile`, wire the WebSocket route into the copy of `app.py`
+- If per-inference billing was chosen: also `metering.py`, wire it into the invocations handler and (if WebSocket) the metadata channel
+
+For `inference.py`, generate a framework-specific stub based on Phase 2 answers. HuggingFace users get a `transformers.pipeline` skeleton; plain PyTorch gets `torch.load`; ONNX gets `onnxruntime.InferenceSession`; etc.
+
+After scaffolding, show the user the file tree and confirm before Phase 5.
+
+---
+
+## Phase 5 — Container code walkthrough
+
+Walk the user through each endpoint's contract. For each one, show the relevant snippet from `app.py`, explain the constraint from the spec, and offer to customize. Do not skip the "why" — the spec has non-obvious gotchas.
+
+**`/ping` — GET, port 8080**
+- Must respond within 2 seconds; socket accept within 250 ms.
+- Return 200 only when the model is actually loaded and a lightweight inference path works. Static 200 during model failure keeps SageMaker routing to the dead instance.
+- Return 503 while loading and on failure.
+- 8-minute total budget from `docker run` to `/ping` = 200 (includes S3 download of `model.tar` + extraction + weight load).
+
+**`/invocations` — POST, port 8080**
+- The **same** endpoint serves Real-Time, Streaming response, **Async**, and Batch Transform. The container gets zero indication of the mode. Do not branch on invocation mode.
+- Max payload: 25 MB Real-Time / streaming; **1 GB** Async (SageMaker downloads from S3 and hands the container a normal POST); 100 MB per record Batch Transform.
+- Timeout: 60 s sync / 8 min streaming / **60 min Async** / unlimited Batch Transform.
+- Async is fully transparent to the container — customer uploads to S3, SageMaker downloads and calls `/invocations`, container returns as normal, SageMaker uploads response to a customer S3 path. No code changes needed to support it beyond keeping your sync `/invocations` correct.
+- SageMaker forwards only these headers: `Content-Type`, `Accept`, `X-Amzn-SageMaker-Custom-Attributes`, `X-Amzn-SageMaker-Inference-Id`, `X-Amzn-SageMaker-Session-Id`.
+- If multiple output files, zip inside the container and return `Content-Type: application/zip`.
+- **If per-inference billing**: every 2XX response must include the `X-Amzn-Inference-Metering` response header. Its value is a JSON string: `{"Dimension": "inference.count", "ConsumedUnits": N}`. For mini-batch invocations (multiple inferences in one request), set `ConsumedUnits` to the number processed. Metering is ignored on non-2XX responses — do not return 200 with a silent error body. See `metering.py`.
+
+**Streaming response** (only if selected in Phase 2)
+- Return `Transfer-Encoding: chunked`. Each chunk becomes a `PayloadPart` event client-side.
+- Same `/invocations` endpoint. No new route.
+
+**`/execution-parameters` — GET, port 8080** (recommended for Batch Transform)
+- Returns `{"MaxConcurrentTransforms": N, "BatchStrategy": "SINGLE_RECORD"|"MULTI_RECORD", "MaxPayloadInMB": M}`. SageMaker calls this before starting a batch job.
+
+**`/invocations-bidirectional-stream` — WebSocket** (only if selected in Phase 2)
+- Requires Docker label `com.amazonaws.sagemaker.capabilities.bidirectional-streaming=true`. Without it, SageMaker will not route WebSocket traffic.
+- Handshake, then WebSocket frames both ways. Client PayloadParts map to Text/Binary frames.
+- Must respond to WebSocket Ping frames (60s interval; 5 missed Pongs → connection closed).
+- Max connection duration: 30 minutes. Client must reconnect for longer sessions. Design the container stateless per-connection.
+- Errors: send Text frame with `{"ModelStreamError": {"ErrorCode": "...", "Message": "..."}}` or a Close frame.
+- **If per-inference billing on WebSocket**: metering goes on a **companion metadata WebSocket** at `/invocations-bidirectional-stream-metadata`, not on the main data stream. Signal support with `X-Amzn-SageMaker-Metadata-Stream-Supported: true` in the upgrade response. See `websocket_handler.py` and `reference/websocket.md`.
+
+**Model loading — `model_loader.py`**
+- Weights at `/opt/ml/model/` (read-only), read via `SM_MODEL_DIR` env var.
+- `/tmp` is the only writable path. Zero outbound network.
+
+**Environment variables in Batch mode** (informational — don't branch on them):
+`SAGEMAKER_BATCH=true`, `SAGEMAKER_MAX_PAYLOAD_IN_MB`, `SAGEMAKER_BATCH_STRATEGY`, `SAGEMAKER_MAX_CONCURRENT_TRANSFORMS`. Real-Time invocations do not set these.
+
+Ask the user to review the generated `app.py` (and `websocket_handler.py` / `metering.py` if applicable) before moving on. Offer to fill in `inference.py` with a working stub for their framework.
+
+---
+
+## Phase 6 — Dockerfile
+
+**One image, one Dockerfile, one endpoint.** Marketplace expects exactly one Docker image per model listing. Multi-stage builds are fine (and often smaller final images), but only the final stage gets pushed to ECR. There is no "loader image + server image" split — everything runs in the same container.
+
+**How SageMaker starts your container.** It literally runs `docker run <image> serve`. That maps to `ENTRYPOINT + "serve"` at runtime. Two supported patterns:
+
+- **Single-process** (default):
+  ```
+  ENTRYPOINT ["python3", "app.py"]
+  CMD ["serve"]
+  ```
+  Result: `python3 app.py serve`. "serve" lands in `sys.argv[1]`. Local `docker run <image>` (no args) also works — CMD supplies the default.
+
+- **Multi-process** (only if you have >1 internal process — see `templates/supervisord.conf`):
+  ```
+  ENTRYPOINT ["/usr/bin/supervisord"]
+  CMD ["-c", "/etc/supervisord.conf"]
+  ```
+  Supervisord ignores the "serve" arg, but the `[program:api-gateway]` block in the conf runs `python3 app.py serve` explicitly, so the effect is identical.
+
+**Exec form is non-negotiable.** `ENTRYPOINT ["python3", "app.py"]` — JSON array, no shell. If you write `ENTRYPOINT python3 app.py` (shell form), Docker wraps it in `/bin/sh -c "..."` and SIGTERM goes to sh instead of Python. Your model never gets 30s to shut down cleanly, gets SIGKILL'd, and Marketplace validation fails. This is the single most common failure mode — check your ENTRYPOINT form before anything else.
+
+**Other rules the spec enforces** (each of these fails Marketplace validation if violated):
+- **Base image** matching target instance's CUDA version. Default `nvidia/cuda:12.1.0-runtime-ubuntu22.04` for g5/g6. Do **not** bundle NVIDIA drivers.
+- **Run as root** — no `USER` directive. Non-root causes permission issues with the `/opt/ml/model/` mount.
+- **No tini** — gets confused by the `serve` argument.
+- **No baked weights** — never `COPY weights/` into the image.
+- **Port 8080 only.** If multi-process, use supervisord; other processes on localhost.
+- **Docker label** `com.amazonaws.sagemaker.capabilities.bidirectional-streaming=true` **only** if the WebSocket endpoint is implemented — otherwise omit.
+- **No outbound network at runtime.** Bundle every dependency; no `pip install`, no HuggingFace Hub, no external license servers.
+
+---
+
+## Phase 7 — Model weights packaging
+
+Guide the user through `package_model.sh`.
+
+- Organize weights in a directory (`model_weights/`, `config/`, etc.).
+- Use **uncompressed** `tar -cf` (not `tar -czf`). Saves 1–3 min cold start for large models.
+- Prefer `.safetensors` over `.pt`/`.bin` (~2× faster load).
+- Upload to a seller S3 bucket. After `CreateModelPackage`, weights transfer to a Marketplace-managed bucket with a Marketplace KMS key — **seller loses direct access to that version**. Keep a source backup.
+- To ship an update: new `model.tar` → new `ModelPackageVersion`. Existing customer endpoints stay on the old version until they redeploy. Docker image does not change unless code changes.
+
+8-minute cold-start budget: S3 download ~30–120 s, extraction ~10–30 s, weight load 60–180 s.
+
+---
+
+## Phase 8 — Local testing (the validation gate)
+
+**This is the primary validation. If it passes locally, it will work on SageMaker.** Do not let the user push to ECR until every test below is green.
+
+1. **Container starts** — `docker run --gpus all --rm -p 8080:8080/tcp -v $(pwd)/model_artifacts:/opt/ml/model:ro --name test-model <image>:latest serve`
+2. **/ping returns 200 within 2 s** — after the model has actually loaded. Watch logs to confirm.
+3. **/invocations** — POST with `test/test_input.json`; valid response with correct `Content-Type`.
+4. **/execution-parameters** — returns valid batch config.
+5. **Streaming** (if enabled) — `test/test_streaming.py` shows chunks arriving progressively.
+6. **WebSocket** (if enabled) — `test/test_websocket.py`: connect, exchange frames, verify Ping/Pong, verify graceful close.
+7. **Metering** (if per-inference) — inspect `/invocations` response headers; confirm `X-Amzn-Inference-Metering: {"Dimension":"...","ConsumedUnits":N}` present on every 2XX response and absent on error responses.
+8. **Network isolation** — `docker run --network none ...`. Container must still start and respond to `/ping`. If it fails, there's a runtime dependency on external services.
+9. **SIGTERM** — `docker stop test-model` completes in <30 s. If it doesn't, ENTRYPOINT is probably shell form.
+
+Only after all applicable tests pass, proceed to Phase 9.
+
+---
+
+## Phase 9 — ECR push and vulnerability scan
+
+Walk the user through pushing to ECR **in each region they plan to list in**.
+
+```bash
+aws ecr get-login-password --region <region> | \
+  docker login --username AWS --password-stdin <account>.dkr.ecr.<region>.amazonaws.com
+aws ecr create-repository --repository-name <model-name> --region <region>   # first time
+docker tag <model-name>:latest <account>.dkr.ecr.<region>.amazonaws.com/<model-name>:v1
+docker push <account>.dkr.ecr.<region>.amazonaws.com/<model-name>:v1
+aws ecr describe-image-scan-findings --repository-name <model-name> \
+  --image-id imageTag=v1 --region <region>
+```
+
+Recommend Trivy locally first: `trivy image --severity CRITICAL,HIGH <image>:latest`. Common fixes: base-image upgrade, `apt-get upgrade` in Dockerfile, pin `requirements.txt` to non-vulnerable versions.
+
+---
+
+## Phase 10 — Pre-submission checklist
+
+Read `PRE_SUBMISSION_CHECKLIST.md` back to the user, item by item. Confirm each. Do not declare "marketplace-ready" until every applicable item is checked. Items conditional on Phase 2 answers:
+- WebSocket-related items apply only if WebSocket was implemented.
+- Metering items apply only if per-inference billing was chosen.
+
+---
+
+## Phase 11 — CreateModelPackage hand-off (only if `goal = also-list`)
+
+**Skip this phase entirely if the user chose "container only" in Phase 0.**
+
+For "also list" users, the skill helps with exactly two things: they already packaged `model.tar` in Phase 7, and here you help them run `CreateModelPackage` with a validation job. Everything else in the listing workflow — FDP enrollment, IAM roles, pricing, EULA, regions, the customer-facing notebook, publishing — the user handles manually via their AWS account team and the Marketplace Management Portal. Do not walk them through those steps.
+
+### Step 1 — Prep sample validation input in S3
+
+`CreateModelPackage` with `CertifyForMarketplace=True` triggers a SageMaker validation transform job that runs the container against sample input. If validation fails, the listing request fails. Before calling the API, the user must:
+
+1. Choose a small, realistic sample of what customers will send to `/invocations`. A handful of records is fine.
+2. Upload them to a seller-owned S3 bucket under a prefix like `s3://<bucket>/validation-input/`. The format must match one of the `SupportedContentTypes` declared in the API call.
+3. Have a separate S3 prefix ready for validation output: `s3://<bucket>/validation-output/`.
+
+### Step 2 — CreateModelPackage API call
+
+Walk through the API structure with the user. See `reference/marketplace-listing.md` for the full skeleton. The fields that matter:
+
+- `InferenceSpecification.Containers[0].Image` → the ECR image URI pushed in Phase 9.
+- `InferenceSpecification.Containers[0].ModelDataUrl` → `s3://…/model.tar` from Phase 7.
+- `SupportedRealtimeInferenceInstanceTypes` / `SupportedTransformInstanceTypes` → the instance families tested during Phase 8. Match what the container actually runs on.
+- `SupportedContentTypes` / `SupportedResponseMIMETypes` → what `/invocations` accepts and returns. Must match reality.
+- `ValidationSpecification.ValidationRole` → an IAM role with permission to run the transform job (typically the user's existing SageMaker execution role).
+- `ValidationSpecification.ValidationProfiles[0].TransformJobDefinition` → points at the S3 input from Step 1 and the S3 output prefix.
+- `CertifyForMarketplace=True` → triggers the Marketplace review workflow. Without it, you get a private ModelPackage instead.
+
+What SageMaker validates: container starts, `/ping` returns 200 within 8 minutes, `/invocations` processes the sample input, valid output is produced, no security vulnerabilities. This is a **contract check**, not an accuracy evaluation.
+
+### Step 3 — After CreateModelPackage passes
+
+Everything from here is manual work the user handles via AWS account team + Marketplace Management Portal, not this skill. That includes: FDP enrollment (start it early — takes 1–2 weeks), the second IAM role for `assets.marketplace.amazonaws.com`, pricing (hourly vs per-inference — big commitment, hard to change), EULA, supported regions, the customer-facing notebook, and publishing (Limited → Public).
+
+Point them at:
+
+- **AWS docs for the Marketplace listing steps:** https://docs.aws.amazon.com/marketplace/latest/userguide/machine-learning-products.html
+- **ML publishing prerequisites (including FDP):** https://docs.aws.amazon.com/marketplace/latest/userguide/ml-publishing-prerequisites.html
+- **Marketplace Management Portal (where all UI configuration happens):** https://aws.amazon.com/marketplace/management/
+
+The walkthrough ends here.
+
+---
+
+## Reference material (in this skill's directory)
+
+Read these when you need to quote a specific constraint:
+
+- `reference/contract.md` — one-page endpoint/header/timing cheat sheet
+- `reference/timing.md` — every hard timing constraint
+- `reference/checklist.md` — full pre-submission checklist template
+- `reference/gap-checks.md` — the gap-analysis checklist for Phase 3
+- `reference/websocket.md` — bidirectional streaming protocol, framing, Ping/Pong, metadata channel
+- `reference/billing.md` — hourly vs per-inference, dimensions, freeze rule
+- `reference/logging.md` — CloudWatch log groups, structured JSON logging, key events to log, multi-process pitfalls
+- `reference/marketplace-listing.md` — CreateModelPackage API skeleton + validation job (Phase 11 only)
+
+## Interaction style
+
+- One phase at a time. Confirm before advancing.
+- Use AskUserQuestion for decisions that change what gets generated. Never free-text those.
+- Never edit the user's existing project files. Always scaffold alongside.
+- When you write, use the Write tool — don't paste files into chat.
+- Show the file tree after scaffolding.
+- When a test fails, cite the spec constraint, propose a specific fix, and offer to apply it (to the scaffolded copy — still not the original).
+- Don't recite the whole spec. Cite the relevant constraint only when the user hits it or asks.

--- a/ai-infra/sagemaker-marketplace-onboarding/SKILL.md
+++ b/ai-infra/sagemaker-marketplace-onboarding/SKILL.md
@@ -206,6 +206,10 @@ Walk the user through each endpoint's contract. For each one, show the relevant 
 - **If per-inference billing on WebSocket**: metering goes on a **companion metadata WebSocket** at `/invocations-bidirectional-stream-metadata`, not on the main data stream. Signal support with `X-Amzn-SageMaker-Metadata-Stream-Supported: true` in the upgrade response. See `websocket_handler.py` and `reference/websocket.md`.
 - **If modality is STT/TTS**: if the user wants this container easily consumable from a voice-orchestration framework like Pipecat, mention the control-message-vocabulary pattern (Speak/Flush/Clear/KeepAlive/Finalize) in `reference/pipecat-integration.md` while designing the container's WebSocket protocol — cheaper to build in now than retrofit later. Do not implement it unasked; just flag that the option exists at this point in the walkthrough.
 
+**Optional: mirroring metering into your own CloudWatch (EMF)** (only if per-inference billing was selected in Phase 2)
+- The `X-Amzn-Inference-Metering` header / metadata-channel frame is what actually gets the seller paid — nothing else is required for billing to work. Separately, mention that `reference/observability.md` documents an **optional** pattern (CloudWatch Embedded Metric Format) for mirroring the same `ConsumedUnits` value into the seller's own CloudWatch, as a self-serve way to reconcile the Marketplace bill against actual traffic without needing buyer-side CloudWatch access.
+- This is a nice-to-have, not a spec requirement. Ask before adding anything: if the user wants it, add the `emit_emf_metric()` call (from `reference/observability.md`) to their `metering.py`, generated at that point for their specific file — do not scaffold it into `templates/metering.py` by default. If they don't want it, don't mention it again.
+
 **Model loading — `model_loader.py`**
 - Weights at `/opt/ml/model/` (read-only), read via `SM_MODEL_DIR` env var.
 - `/tmp` is the only writable path. Zero outbound network.

--- a/ai-infra/sagemaker-marketplace-onboarding/SKILL.md
+++ b/ai-infra/sagemaker-marketplace-onboarding/SKILL.md
@@ -204,6 +204,7 @@ Walk the user through each endpoint's contract. For each one, show the relevant 
 - Max connection duration: 30 minutes. Client must reconnect for longer sessions. Design the container stateless per-connection.
 - Errors: send Text frame with `{"ModelStreamError": {"ErrorCode": "...", "Message": "..."}}` or a Close frame.
 - **If per-inference billing on WebSocket**: metering goes on a **companion metadata WebSocket** at `/invocations-bidirectional-stream-metadata`, not on the main data stream. Signal support with `X-Amzn-SageMaker-Metadata-Stream-Supported: true` in the upgrade response. See `websocket_handler.py` and `reference/websocket.md`.
+- **If modality is STT/TTS**: if the user wants this container easily consumable from a voice-orchestration framework like Pipecat, mention the control-message-vocabulary pattern (Speak/Flush/Clear/KeepAlive/Finalize) in `reference/pipecat-integration.md` while designing the container's WebSocket protocol — cheaper to build in now than retrofit later. Do not implement it unasked; just flag that the option exists at this point in the walkthrough.
 
 **Model loading — `model_loader.py`**
 - Weights at `/opt/ml/model/` (read-only), read via `SM_MODEL_DIR` env var.
@@ -361,6 +362,33 @@ Both of these are pointers, not implementation phases — this skill does not bu
 
 ---
 
+## Phase 13 — Pipecat ecosystem hand-off (optional, only if applicable)
+
+**Trigger condition** — independent of Phase 0's `goal` flag (relevant whether or not the user is listing on Marketplace): modality is STT or TTS, Bidirectional WebSocket was implemented (Phase 2), and Phase 8's local testing gate has passed. If any of those don't hold, skip this phase silently — don't mention it.
+
+If the trigger condition holds, ask once whether the user wants help getting the model consumable from [Pipecat](https://github.com/pipecat-ai/pipecat), an open-source voice-agent orchestration framework with first-class support for SageMaker bidirectional-streaming endpoints. Use AskUserQuestion, not free text, with these options:
+
+- **Skip** — no Pipecat work. Default if the user hasn't heard of Pipecat or doesn't have a voice-agent use case in mind.
+- **Community-maintained integration** — the user hosts and maintains the integration in their own separate repository; Pipecat lists it for discoverability. Lower barrier, the realistic default for most providers.
+- **Contribute to Pipecat core** — a PR into `pipecat-ai/pipecat` itself, only appropriate if the model is broadly relevant enough that Pipecat's maintainers would want to own and maintain it. Flag this as the Pipecat maintainers' call, not something to promise will be accepted.
+
+Read `reference/pipecat-integration.md` before proceeding — it has the full architecture explanation, the control-message-vocabulary table, both paths' concrete requirements, and an illustrative (not scaffolded) service-wrapper code appendix.
+
+If **Community-maintained integration**:
+1. Confirm with the user: which GitHub account/org will host the repo, what license (BSD-2 like Pipecat, or another permissive OSS license), and whether they want **company attribution** in the README (Pipecat's own guide recommends this when the provider works for the company behind the model — it builds confidence the integration will be maintained). Do not default or assume any of these — ask explicitly, the same way Phase 0 asks rather than assumes the user's goal.
+2. Walk through the requirements checklist from `reference/pipecat-integration.md`'s "Path A" section: source implementation (subclass `STTService`/`TTSService`, using the illustrative appendix as a starting point adapted to the container's own WebSocket control-message vocabulary from Phase 5/6 — not copy-pasted verbatim), a foundational single-file usage example, README (intro, install, usage, tested Pipecat version, attribution per step 1), LICENSE, docstrings, changelog.
+3. Mention the separate docs-site submission (`pipecat-ai/docs`, Supported Services page + a dedicated service page with a demo video) as a follow-up step once the integration repo itself is working — don't try to do both in one pass.
+4. Do not scaffold a `templates/pipecat_service_stub.py` file automatically. The service wrapper needs to be adapted to whatever control-message vocabulary this specific container's WebSocket protocol implements (see Phase 5's note) — there is no generic version that would be more than the illustrative appendix already provides. Help the user adapt the appendix's code to their container's actual protocol, in their own repository.
+
+If **Contribute to Pipecat core**:
+1. Confirm the user understands this is a judgment call for Pipecat's maintainers, not guaranteed acceptance.
+2. Walk through the mechanics from `reference/pipecat-integration.md`'s "Path B" section: fork `pipecat-ai/pipecat`, branch, implement the service wrapper under `src/pipecat/services/<provider>/sagemaker/` following the real `deepgram/sagemaker/{stt,tts}.py` files as structural reference, add a changelog fragment (`changelog/<PR_number>.added.md`), commit, push to fork, open the PR against `main` with a clear description.
+3. Same caution as above on not auto-generating the service wrapper — help adapt the illustrative appendix, in the user's fork, to their container's real protocol.
+
+This phase never writes to the user's model container project — any files it produces belong in a separate Pipecat-integration repository or fork, matching this skill's existing rule of never editing the user's own project outside the scaffolded sibling directory.
+
+---
+
 ## Reference material (in this skill's directory)
 
 Read these when you need to quote a specific constraint:
@@ -375,6 +403,7 @@ Read these when you need to quote a specific constraint:
 - `reference/marketplace-listing.md` — CreateModelPackage API skeleton + validation job (Phase 11 only)
 - `reference/observability.md` — CloudWatch metrics catalog (invocation/instance/detailed-observability) + EMF business-metric emission (Phase 12 only)
 - `reference/iam-temporary-delegation.md` — buyer-approved temporary support access for a live listing (Phase 12 only)
+- `reference/pipecat-integration.md` — Pipecat voice-agent orchestration architecture, control-message-vocabulary design guidance, and both ecosystem contribution paths (Phase 5 pointer + Phase 13 only)
 
 ## Interaction style
 

--- a/ai-infra/sagemaker-marketplace-onboarding/reference/billing.md
+++ b/ai-infra/sagemaker-marketplace-onboarding/reference/billing.md
@@ -1,0 +1,94 @@
+# Billing — Hourly vs Per-Inference Reference
+
+The container-side implications of the two Marketplace billing models. This skill covers only the container hooks — the actual Marketplace listing configuration (pricing values, dimensions, EULA) happens in the Marketplace Management Portal and is outside this skill's scope.
+
+## The customer pays two things
+
+Regardless of which billing model you choose:
+
+1. **Instance usage price** — set by AWS, always per hour per instance.
+2. **Model usage price** — set by you, either hourly or per-inference.
+
+## Hourly pricing
+
+- Customer pays $/hour for every instance running your model.
+- No container-side code required. `/invocations` returns its result as usual.
+- Different prices per instance type are supported.
+- Example: $2/hr × 3 instances × 2 hours = $12.
+
+## Per-inference (usage-based) pricing
+
+- Customer pays for units consumed per invocation. **The container must report metering on every invocation.** Fail to report = fail to be paid for that invocation.
+- Metering emission depends on the endpoint:
+
+### Standard `/invocations` (Real-Time, Streaming response, Batch Transform)
+
+Emit metering as an HTTP response header. The value is a JSON string.
+
+```
+X-Amzn-Inference-Metering: {"Dimension": "inference.count", "ConsumedUnits": 3}
+```
+
+**Mini-batch semantics.** If a single `/invocations` call processes multiple inferences (e.g. batching several inputs), set `ConsumedUnits` to the number of inferences processed. For a single-inference call, use `1`.
+
+**Only 2XX responses are billed.** AWS Marketplace charges the buyer only for responses with HTTP status codes in the 2XX range. Metering on 4XX/5XX responses is ignored. Conversely, do not return 200 with a silent error body — you would be paid for a failed inference. Make error paths return proper non-2XX codes.
+
+Reference: https://docs.aws.amazon.com/marketplace/latest/userguide/machine-learning-pricing.html
+
+### Bidirectional WebSocket (`/invocations-bidirectional-stream`)
+
+Metering goes on a **companion metadata WebSocket** — never on the main data stream. See `reference/websocket.md` for the full protocol.
+
+## Choosing a dimension
+
+The dimension name is a naming decision that must match between the container and the Marketplace listing configuration. Common patterns:
+
+| Dimension | When to use |
+|---|---|
+| `inference.count` | One unit per invocation. Simplest. |
+| `audio_seconds` | STT/TTS/audio models. Bill by audio duration processed. |
+| `characters_synthesized` | TTS. Bill by characters spoken. |
+| `characters_processed` | Text embedding/classification. Bill by input length. |
+| `tokens` | LLM generation. Bill by tokens produced (or consumed). |
+| `pixels` | Image models. Bill by pixels processed. |
+
+Whatever you pick becomes part of the customer contract — you cannot change it later without creating a new listing.
+
+## Critical pricing rules
+
+- **You cannot switch models.** Hourly ↔ per-inference is a new listing.
+- **Once a price is set** and the product reaches limited state, you cannot change it on your own. Changes go through AWS support.
+- **90-day freeze** after any price update. During the freeze:
+  - You cannot add or remove supported instance types.
+  - Existing subscribers stay on the old price for 90 days.
+  - New subscribers get the new price immediately.
+- **Workaround for the freeze:** create a new product and unpublish the old one.
+- **Do not choose "Free"** if you plan to charge later. Use "$0/hour" instead — a Free listing cannot be converted to paid.
+
+## Currency
+
+- Public pricing: **USD only**.
+- Private offers: USD or INR (useful for India-based listings).
+
+## Private offers
+
+Enterprise-specific pricing with a custom EULA and duration. Contract-based (fixed payment, unlimited access for the duration). Cannot mix pricing types — a hourly public listing cannot have a per-inference private offer.
+
+Required inputs for a private offer:
+- ProductId
+- Targeted Buyer AWS Account(s)
+- Offer acceptance deadline
+- Offer duration (in days)
+- Custom EULA file (optional)
+- Prices per instance type
+
+Configuration happens in the Marketplace Management Portal — outside this skill's scope.
+
+## Container-side implication summary
+
+| Setup | What the container must do |
+|---|---|
+| Hourly pricing, no WebSocket | Nothing special. Return inference results. |
+| Hourly pricing, WebSocket | Nothing special beyond the WebSocket contract. |
+| Per-inference, `/invocations` only | Emit `X-Amzn-Inference-Metering: {"Dimension": "...", "ConsumedUnits": N}` on every 2XX response. |
+| Per-inference, WebSocket | Advertise metadata support in upgrade response, emit metering frames on companion channel. |

--- a/ai-infra/sagemaker-marketplace-onboarding/reference/billing.md
+++ b/ai-infra/sagemaker-marketplace-onboarding/reference/billing.md
@@ -37,7 +37,14 @@ Reference: https://docs.aws.amazon.com/marketplace/latest/userguide/machine-lear
 
 ### Bidirectional WebSocket (`/invocations-bidirectional-stream`)
 
-Metering goes on a **companion metadata WebSocket** — never on the main data stream. See `reference/websocket.md` for the full protocol.
+Metering goes on a **companion metadata WebSocket** — never on the main data stream. This is a GA
+capability (Deepgram is the launch partner) that exists specifically because a bidi session's total
+usage isn't known until the stream ends, so the header-based mechanism below can't apply. See
+`reference/websocket.md` for the full protocol: opt-in headers, message schema, size/rate limits
+(512 bytes, 1 msg/sec), and failure-mode behavior (`X-Amzn-SageMaker-Metadata-Stream-Required`).
+
+Source: ["Introducing usage-based pricing for Amazon SageMaker bidirectional
+streaming"](https://aws.amazon.com/blogs/machine-learning/introducing-usage-based-pricing-for-amazon-sagemaker-bidirectional-streaming/)
 
 ## Choosing a dimension
 

--- a/ai-infra/sagemaker-marketplace-onboarding/reference/checklist.md
+++ b/ai-infra/sagemaker-marketplace-onboarding/reference/checklist.md
@@ -56,6 +56,8 @@ Copy this file into the project as `PRE_SUBMISSION_CHECKLIST.md`. Walk through e
 - [ ] Every 2XX `/invocations` response emits the `X-Amzn-Inference-Metering` header with a JSON value: `{"Dimension": "...", "ConsumedUnits": N}`. Mini-batch requests set `ConsumedUnits` to the number of inferences processed. No metering on non-2XX responses.
 - [ ] The `dimension` name in the emission matches what is configured on the Marketplace listing.
 - [ ] For bidirectional streaming: the WebSocket upgrade response includes `X-Amzn-SageMaker-Metadata-Stream-Supported: true` and `/invocations-bidirectional-stream-metadata` is implemented.
+- [ ] Metadata channel messages are one record per frame, text-only, ≤512 bytes, sent at ≤1/sec, with `ConsumedUnits > 0` and `Dimension` ≤128 chars.
+- [ ] `X-Amzn-SageMaker-Metadata-Stream-Required` is deliberately set `true` or `false` (not left to default) based on whether the model can tolerate unmetered usage if the metadata channel drops.
 
 ## Contract compliance (spot-check)
 

--- a/ai-infra/sagemaker-marketplace-onboarding/reference/checklist.md
+++ b/ai-infra/sagemaker-marketplace-onboarding/reference/checklist.md
@@ -1,0 +1,64 @@
+# Pre-Submission Checklist
+
+Copy this file into the project as `PRE_SUBMISSION_CHECKLIST.md`. Walk through every item with the model provider before declaring the container marketplace-ready. Do not skip items — most of these are the exact conditions the SageMaker validation transform job will fail on.
+
+## Endpoints
+
+- [ ] `GET /ping` responds within 2 seconds once the model is loaded.
+- [ ] `/ping` actually **exercises the inference path** (a lightweight smoke prediction) — not a static 200 based on object presence. The spec explicitly warns that static 200 during model failure keeps SageMaker routing to the dead instance.
+- [ ] `/ping` returns **503** (not 200) while the model is still loading or if inference is broken.
+- [ ] `POST /invocations` handles the test payload from `test/test_input.json` and returns a valid response with a sensible `Content-Type`.
+- [ ] `/invocations` returns non-2xx on error (do not return 200 with an error body — errors must surface to the caller).
+- [ ] `GET /execution-parameters` returns valid `MaxConcurrentTransforms`, `BatchStrategy`, `MaxPayloadInMB` (optional but recommended for Batch Transform).
+- [ ] If streaming response was enabled: `/invocations` returns `Transfer-Encoding: chunked` and chunks arrive progressively (verified with `test/test_streaming.py`).
+
+## Startup and shutdown
+
+- [ ] Container starts and `/ping` returns 200 within **8 minutes** of `docker run` — including S3 download, extraction, and weight loading.
+- [ ] Container shuts down gracefully within 30 seconds of SIGTERM (`docker stop` completes without SIGKILL).
+- [ ] `ENTRYPOINT` is in **exec form** (`["python3", "app.py"]`), not shell form.
+- [ ] `CMD` is `["serve"]` (SageMaker invokes `docker run <image> serve`).
+
+## Runtime environment
+
+- [ ] Container runs as **root** (no `USER` directive in the Dockerfile).
+- [ ] Container works under `docker run --network none ...`. No runtime dependency on external services (S3, HuggingFace Hub, license servers, pip install at startup).
+- [ ] Model weights are loaded from `/opt/ml/model/` (or `SM_MODEL_DIR` env var), not from a baked-in path.
+- [ ] No NVIDIA drivers bundled in the image.
+- [ ] No `tini` used as init.
+- [ ] Only port 8080 is exposed. Any internal processes bind to localhost.
+
+## Model artifacts
+
+- [ ] Model weights are NOT baked into the Docker image.
+- [ ] `model.tar` is uncompressed (`tar -cf`, not `tar -czf`).
+- [ ] Weights are in `.safetensors` (or another fast-load format) where possible.
+- [ ] Weights uploaded to a seller-owned S3 bucket.
+
+## Security
+
+- [ ] ECR image passes `trivy image --severity CRITICAL,HIGH` (no CRITICAL or HIGH findings).
+- [ ] ECR automatic vulnerability scan passes (`aws ecr describe-image-scan-findings`).
+
+## Docker label
+
+- [ ] If (and only if) implementing the WebSocket bidirectional-streaming endpoint, the Dockerfile has `LABEL com.amazonaws.sagemaker.capabilities.bidirectional-streaming=true`. Otherwise this label is absent.
+
+## Bidirectional WebSocket (only if implemented)
+
+- [ ] `/invocations-bidirectional-stream` endpoint responds to a WebSocket upgrade on port 8080.
+- [ ] Container responds to WebSocket Ping frames with Pong within the required window.
+- [ ] Container is stateless per-connection — sessions >30 min reconnect at the application layer.
+- [ ] Errors are surfaced as `{"ModelStreamError": {...}}` Text frames or WebSocket Close frames.
+
+## Per-inference billing (only if selected)
+
+- [ ] Every 2XX `/invocations` response emits the `X-Amzn-Inference-Metering` header with a JSON value: `{"Dimension": "...", "ConsumedUnits": N}`. Mini-batch requests set `ConsumedUnits` to the number of inferences processed. No metering on non-2XX responses.
+- [ ] The `dimension` name in the emission matches what is configured on the Marketplace listing.
+- [ ] For bidirectional streaming: the WebSocket upgrade response includes `X-Amzn-SageMaker-Metadata-Stream-Supported: true` and `/invocations-bidirectional-stream-metadata` is implemented.
+
+## Contract compliance (spot-check)
+
+- [ ] Code does **not** branch on invocation mode. The same `/invocations` handler works for Real-Time, Streaming response, and Batch Transform without needing to know which one is calling.
+- [ ] Code does **not** depend on any HTTP header outside the five SageMaker forwards (`Content-Type`, `Accept`, `X-Amzn-SageMaker-Custom-Attributes`, `X-Amzn-SageMaker-Inference-Id`, `X-Amzn-SageMaker-Session-Id`).
+- [ ] Container only writes to `/tmp` — never to `/opt/ml/model/` or arbitrary paths.

--- a/ai-infra/sagemaker-marketplace-onboarding/reference/contract.md
+++ b/ai-infra/sagemaker-marketplace-onboarding/reference/contract.md
@@ -1,0 +1,59 @@
+# SageMaker Marketplace Container Contract — One-Page Reference
+
+## Endpoints (all on port 8080)
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET  | `/ping` | Health check. 200 = ready. 503 = loading/broken. |
+| POST | `/invocations` | Inference. Same code serves Real-Time, Streaming response, Batch Transform. |
+| GET  | `/execution-parameters` | Optional. Batch Transform tuning hint. |
+
+## Headers SageMaker forwards to `/invocations`
+
+Only these five. Any other header is stripped.
+
+- `Content-Type` — buyer's payload MIME type
+- `Accept` — buyer's desired response MIME type
+- `X-Amzn-SageMaker-Custom-Attributes` — opaque, max 1024 chars
+- `X-Amzn-SageMaker-Inference-Id` — request tracking
+- `X-Amzn-SageMaker-Session-Id` — for streaming sessions
+
+## Timing constraints (hard limits)
+
+| Constraint | Value | On failure |
+|---|---|---|
+| Socket connection accept | ≤ 250 ms | Request rejected |
+| /ping response | ≤ 2 s | Health check fails |
+| Container startup (until /ping = 200) | ≤ 8 min | CreateEndpoint fails |
+| /invocations sync | ≤ 60 s | 504 timeout |
+| InvokeEndpointWithResponseStream | ≤ 8 min | Connection closed |
+| SIGKILL after SIGTERM | 30 s | Process killed |
+
+## Payload limits
+
+| Mode | Max |
+|---|---|
+| Real-Time /invocations | 25 MB |
+| Streaming response | 25 MB request |
+| Async Inference | 1 GB (via S3) |
+| Batch Transform (per record) | 100 MB |
+
+## Filesystem
+
+- `/opt/ml/model/` — read-only mount. Weights land here at deploy time. Read via `SM_MODEL_DIR` env var.
+- `/tmp` — writable scratch. Only writable path.
+- No S3, no internet, no VPC endpoints, no outbound network at runtime.
+
+## Dockerfile must-haves
+
+**One Dockerfile / one image per listing.** Multi-stage builds are OK; only the final image is pushed. There is no separate "loader" image.
+
+**How SageMaker launches it:** `docker run <image> serve`. That maps to `ENTRYPOINT + "serve"` at runtime.
+
+- `ENTRYPOINT ["python3", "app.py"]` — **exec form** (JSON array). Shell form (`ENTRYPOINT python3 app.py`) makes Docker wrap in `/bin/sh -c`, which does not forward SIGTERM to Python — SageMaker's graceful shutdown breaks.
+- `CMD ["serve"]` — provides the "serve" argument. Local `docker run <image>` (no args) also works because CMD supplies the default.
+- Multi-process alternative: `ENTRYPOINT ["/usr/bin/supervisord"]` + `CMD ["-c", "/etc/supervisord.conf"]` — the supervisord config runs `python3 app.py serve` inside a program block.
+- Run as root. No `USER` directive.
+- Do not bundle NVIDIA drivers, tini, or model weights.
+- Only port 8080 exposed.
+- `LABEL com.amazonaws.sagemaker.capabilities.bidirectional-streaming=true` **only** if implementing WebSocket.

--- a/ai-infra/sagemaker-marketplace-onboarding/reference/gap-checks.md
+++ b/ai-infra/sagemaker-marketplace-onboarding/reference/gap-checks.md
@@ -66,6 +66,8 @@ The full list of things to compare between an existing model project and the Sag
 - [ ] Every 2XX `/invocations` response emits the `X-Amzn-Inference-Metering` header. Value is a JSON string: `{"Dimension": "...", "ConsumedUnits": N}`. Mini-batch requests set `ConsumedUnits` to the batch size. Metering is not emitted on non-2XX responses (which are not billed).
 - [ ] Dimension name matches what will be configured on the Marketplace listing.
 - [ ] For WebSocket: upgrade response includes `X-Amzn-SageMaker-Metadata-Stream-Supported: true` and the container implements `/invocations-bidirectional-stream-metadata`.
+- [ ] Metadata frames: one record per frame, text-only, ≤512 bytes, ≤1 msg/sec, `Dimension` ≤128 chars, `ConsumedUnits > 0`, `ClientToken` ≤64 chars.
+- [ ] `X-Amzn-SageMaker-Metadata-Stream-Required` set explicitly (true = fail the data stream with HTTP 424 if metering drops; false/default = keep serving unmetered).
 
 ## Multi-process containers (only if applicable)
 

--- a/ai-infra/sagemaker-marketplace-onboarding/reference/gap-checks.md
+++ b/ai-infra/sagemaker-marketplace-onboarding/reference/gap-checks.md
@@ -1,0 +1,81 @@
+# Gap Analysis Checklist (Phase 3)
+
+The full list of things to compare between an existing model project and the SageMaker Marketplace container contract. For each item, if the project is out of spec, note the file/line, cite the constraint, and propose the fix. **Do not edit the existing project's files** — the fix goes into the scaffolded sibling directory only.
+
+## Networking
+
+- [ ] HTTP server listens on port **8080**. Anything else (5000, 8000, 8888, etc.) must move.
+- [ ] Only port 8080 is exposed to the outside. Multi-process containers bind everything else to localhost via supervisord.
+- [ ] No reliance on outbound network at inference time (no S3, no HuggingFace Hub, no license servers, no pip install at startup, no VPC endpoints).
+
+## Endpoints
+
+- [ ] `GET /ping` exists, returns 200 when the model is loaded and functional, 503 while loading or if broken.
+- [ ] `/ping` does **not** return static 200 — the spec explicitly warns against this because it prevents SageMaker from replacing dead instances.
+- [ ] `/ping` responds within 2 seconds.
+- [ ] `POST /invocations` exists and is the single inference entry point.
+- [ ] Any existing prediction path (`/predict`, `/v1/chat/completions`, `/generate`, etc.) is either renamed to `/invocations` or gets a `/invocations` alias that forwards to it — do not break the original.
+- [ ] `/invocations` does **not** branch on invocation mode. The container cannot distinguish Real-Time from Async from Batch and should not try.
+- [ ] `/invocations` does **not** depend on any HTTP header outside the five SageMaker forwards: `Content-Type`, `Accept`, `X-Amzn-SageMaker-Custom-Attributes`, `X-Amzn-SageMaker-Inference-Id`, `X-Amzn-SageMaker-Session-Id`.
+- [ ] `GET /execution-parameters` present if Batch Transform will be used (recommended).
+
+## Response contract
+
+- [ ] Success responses use HTTP 200 with a sensible `Content-Type`.
+- [ ] Error responses use non-2xx status codes. No 200-with-error-body.
+- [ ] Multi-file outputs are zipped in-container and returned as `application/zip` (cannot write to S3 at runtime).
+- [ ] Streaming response (if enabled): uses `Transfer-Encoding: chunked`. Same `/invocations` endpoint, not a separate route.
+
+## Model weights
+
+- [ ] Weights are **not** baked into the Docker image.
+- [ ] Weights are **not** downloaded at startup (HuggingFace Hub, S3, git-lfs — all fail under network isolation).
+- [ ] Loading code reads from `/opt/ml/model/` (or `SM_MODEL_DIR` env var). No hardcoded paths like `/app/models/`.
+- [ ] Total load time (S3 download + extraction + weight load) fits in the 8-minute startup window. If tight, recommend uncompressed tar and safetensors.
+- [ ] Weights packaged as **uncompressed** tar (`tar -cf`, not `tar -czf`).
+
+## Filesystem
+
+- [ ] Container writes only to `/tmp`. Nothing else is writable.
+- [ ] No `USER` directive in the Dockerfile (must run as root).
+
+## Dockerfile
+
+- [ ] `ENTRYPOINT` is **exec form** (`ENTRYPOINT ["python3", "app.py"]`). Shell form breaks SIGTERM.
+- [ ] `CMD ["serve"]` is present.
+- [ ] Base image matches the target instance's CUDA version.
+- [ ] No NVIDIA drivers bundled in the image.
+- [ ] No `tini` used as init.
+- [ ] `EXPOSE 8080` only.
+- [ ] `LABEL com.amazonaws.sagemaker.capabilities.bidirectional-streaming=true` **if and only if** WebSocket bidirectional streaming is implemented.
+
+## Signal handling
+
+- [ ] Container exits gracefully within 30 seconds of SIGTERM. If not, exec-form ENTRYPOINT is missing.
+
+## Advanced modes (opt-in)
+
+**Bidirectional WebSocket** (only if selected in Phase 2):
+- [ ] `/invocations-bidirectional-stream` endpoint exists on port 8080.
+- [ ] Container responds to WebSocket Ping with Pong (usually automatic in modern WebSocket libraries).
+- [ ] Container stateless per-connection (no session state persisted across reconnects).
+- [ ] Errors return either a `{"ModelStreamError": {...}}` text frame or a WebSocket Close frame.
+- [ ] Aware of the 30-minute max connection duration.
+
+**Per-inference billing** (only if selected in Phase 2):
+- [ ] Every 2XX `/invocations` response emits the `X-Amzn-Inference-Metering` header. Value is a JSON string: `{"Dimension": "...", "ConsumedUnits": N}`. Mini-batch requests set `ConsumedUnits` to the batch size. Metering is not emitted on non-2XX responses (which are not billed).
+- [ ] Dimension name matches what will be configured on the Marketplace listing.
+- [ ] For WebSocket: upgrade response includes `X-Amzn-SageMaker-Metadata-Stream-Supported: true` and the container implements `/invocations-bidirectional-stream-metadata`.
+
+## Multi-process containers (only if applicable)
+
+- [ ] Only port 8080 is exposed to SageMaker; every other process binds to localhost.
+- [ ] `supervisord` runs as PID 1 with `nodaemon=true` so SIGTERM propagates to child processes.
+- [ ] **Every** program in `supervisord.conf` has `stdout_logfile=/dev/stdout` and `stdout_logfile_maxbytes=0` (same for stderr). Without this, program logs never reach CloudWatch — SageMaker only captures the container's own stdout.
+- [ ] `stopwaitsecs` for each program is ≤ 25s (SageMaker sends SIGKILL 30s after SIGTERM; leave buffer for supervisord itself to exit).
+
+## Miscellaneous
+
+- [ ] Logs go to stdout/stderr (SageMaker captures automatically to CloudWatch). Structured JSON logging recommended.
+- [ ] Container does not try to write logs to a file inside `/opt/ml/model/` (read-only) or any path other than `/tmp`.
+- [ ] No dependency on a database, cache, or external service running alongside the container.

--- a/ai-infra/sagemaker-marketplace-onboarding/reference/iam-temporary-delegation.md
+++ b/ai-infra/sagemaker-marketplace-onboarding/reference/iam-temporary-delegation.md
@@ -5,7 +5,8 @@ after the model is published. Included here as a pointer for sellers who ask "ho
 customer's endpoint without a long-lived cross-account role."
 
 Source: AWS IAM User Guide — [IAM temporary delegation](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies-temporary-delegation.html),
-and the AWS ML blog "Deepgram enhances Amazon SageMaker AI support with AWS IAM Temporary Delegation"
+and the AWS ML blog ["Deepgram enhances Amazon SageMaker AI support with AWS IAM Temporary
+Delegation"](https://aws.amazon.com/blogs/machine-learning/deepgram-enhances-amazon-sagemaker-ai-support-with-aws-iam-temporary-delegation/)
 (2026-07-27), which documents a reference integration for exactly this seller use case.
 
 ## The problem it solves

--- a/ai-infra/sagemaker-marketplace-onboarding/reference/iam-temporary-delegation.md
+++ b/ai-infra/sagemaker-marketplace-onboarding/reference/iam-temporary-delegation.md
@@ -1,0 +1,85 @@
+# IAM Temporary Delegation — Reference (post-launch support access)
+
+Out of scope for the container build itself — this is an **operating-the-listing** capability for
+after the model is published. Included here as a pointer for sellers who ask "how do I support a
+customer's endpoint without a long-lived cross-account role."
+
+Source: AWS IAM User Guide — [IAM temporary delegation](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies-temporary-delegation.html),
+and the AWS ML blog "Deepgram enhances Amazon SageMaker AI support with AWS IAM Temporary Delegation"
+(2026-07-27), which documents a reference integration for exactly this seller use case.
+
+## The problem it solves
+
+A buyer's SageMaker endpoint misbehaves (bad output, stuck loading, 5XX spike). The seller's support
+team needs enough account access to investigate — but standing cross-account IAM roles or shared
+credentials are a compliance liability the buyer's security team will push back on, and per-incident
+screen-shares don't scale.
+
+## How it works
+
+1. The buyer logs into the seller's product/support flow and starts an integration or support action.
+2. The seller (product provider) **initiates a delegation request** naming the specific AWS services
+   and actions needed, and redirects the buyer to the AWS Management Console.
+3. The buyer reviews the exact, fully-resolved permissions (no wildcards) and approves, denies, or
+   forwards the request to their own administrator.
+4. Once approved, the seller obtains **short-lived STS credentials** scoped to the approved
+   permissions — up to **12 hours** maximum. (Root-user approvers are capped at 4 hours; longer
+   durations require a non-root approver.)
+5. Access expires automatically. No manual cleanup, no standing cross-account role left behind —
+   unless the request explicitly provisioned one for ongoing operations (see below).
+6. Every delegated action is tagged and logged in the buyer's **AWS CloudTrail** for audit.
+
+```
+Buyer's product/support console → delegation request → Buyer approves in IAM console
+        → seller receives scoped STS creds (≤12h) → CloudTrail-logged activity → auto-expiry
+```
+
+## Ongoing access (optional)
+
+If the seller needs persistent access (e.g., continuously reading a CloudWatch log group rather than
+one-off investigation), the delegation request can include **creating an IAM role** that survives
+past the temporary window. That role **must** carry a permission boundary — a cap on its maximum
+permissions that the buyer reviews and approves as part of the same request. The boundary limits
+blast radius even if the role's attached policy is later widened.
+
+## Relevant IAM permissions (buyer side)
+
+| Permission | What it does |
+|---|---|
+| `iam:AssociateDelegationRequest` | Associate an unassigned request with the account |
+| `iam:GetDelegationRequest` | View request details |
+| `iam:UpdateDelegationRequest` | Forward a request to an administrator |
+| `iam:AcceptDelegationRequest` | Approve a request |
+| `iam:SendDelegationToken` | Release the exchange token to the provider after approval |
+| `iam:RejectDelegationRequest` | Reject a request |
+| `iam:ListDelegationRequests` | List requests for the account |
+
+Administrators can grant these selectively to delegate approval authority to specific teams rather
+than requiring root/admin for every approval.
+
+## Constraints that matter for a seller evaluating this
+
+- **Only qualified AWS Partners and Amazon products can initiate requests.** This requires completing
+  a separate AWS Partner onboarding process for the temporary-delegation feature — it is not something
+  a seller's container or `CreateModelPackage` call gets for free. Buyers can only *approve*, never
+  initiate.
+- **12-hour hard cap** per delegation window. Not a substitute for a persistent support role if the
+  investigation genuinely spans days — plan for re-requesting or the IAM-role-with-boundary path above.
+- **Buyer must already hold the permissions being delegated.** If the buyer's own account lacks a
+  requested permission, the provider does not receive it even after approval — the check fails silently
+  from the provider's side, not the buyer's.
+- This replaces the older pattern of asking buyers to create a long-lived cross-account IAM role
+  trusting the seller's account ID + external ID. If a seller is currently asking Marketplace buyers to
+  do that, temporary delegation is the direction AWS is pushing partners toward instead.
+
+## Where this fits in the SageMaker Marketplace onboarding flow
+
+Not a Phase in this skill's container walkthrough — it has no effect on `/ping`, `/invocations`,
+weights packaging, or `CreateModelPackage`. Surface it only when a seller who has already published a
+listing (Phase 11 complete) asks about **customer support access** post-launch. Point them at:
+
+- Partner Integration Guide: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies-temporary-delegation-partner-guide.html
+- AWS Partner Central, to start the qualification process for initiating delegation requests.
+
+This skill does not implement the integration — it is account/product-level AWS Partner enablement,
+not container code.

--- a/ai-infra/sagemaker-marketplace-onboarding/reference/logging.md
+++ b/ai-infra/sagemaker-marketplace-onboarding/reference/logging.md
@@ -1,0 +1,93 @@
+# Logging & Monitoring — Reference
+
+SageMaker captures container `stdout` and `stderr` automatically and ships them to CloudWatch Logs. You do not need to install a CloudWatch agent or configure log shipping.
+
+## Log group
+
+```
+/aws/sagemaker/Endpoints/<endpoint-name>
+```
+
+For Batch Transform jobs:
+```
+/aws/sagemaker/TransformJobs/<transform-job-name>
+```
+
+Log stream names are per-container-per-variant.
+
+## Emit structured JSON
+
+Plain-text logs work but are painful to query in CloudWatch Logs Insights. Emit structured JSON so you can filter by `msg`, `level`, `inference_id`, etc.:
+
+```python
+import json, logging, sys
+
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(logging.Formatter(
+    json.dumps({
+        "time":  "%(asctime)s",
+        "level": "%(levelname)s",
+        "msg":   "%(message)s",
+    })
+))
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+logger.addHandler(handler)
+```
+
+## Key events to log
+
+At minimum, log these — they are the events you'll need when a customer opens a support ticket:
+
+- **Startup complete** — model loaded successfully, time taken, weights source path
+- **Startup failure** — full stack trace; useful when /ping times out during CreateEndpoint
+- **Request received** — `X-Amzn-SageMaker-Inference-Id`, content-type, body size
+- **Request completed** — inference-id, latency in ms, output size
+- **Error** — inference-id, full stack trace, request metadata (not the full request body — could be PII)
+- **Ping check failed** — inference path is broken; SageMaker will start replacing the instance shortly
+
+Optional but useful:
+
+- **GPU memory** — periodic (every ~30s) allocated + reserved MB
+- **Batch mode signals** — log the `SAGEMAKER_BATCH`, `SAGEMAKER_MAX_PAYLOAD_IN_MB` env vars once at startup
+
+## Multi-process containers
+
+If you use supervisord, every program in `supervisord.conf` must pipe its own stdout/stderr:
+
+```ini
+[program:model-server]
+command=python3 model_server.py
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+```
+
+Without `stdout_logfile=/dev/stdout` on each program, supervisord captures to disk and SageMaker never sees those logs.
+
+## What to NOT log
+
+- **Full inference bodies** — customer inputs may be PII (audio recordings, text with personal info, images). Log the size and hash if you need to correlate, not the content.
+- **Model weights or internal state**
+- **Credentials** — you shouldn't have any anyway (no outbound network), but scrub environment variables before logging them.
+- **High-frequency success events** — logging every token in a streaming response floods CloudWatch and is expensive.
+
+## Querying
+
+CloudWatch Logs Insights:
+
+```
+fields @timestamp, level, msg, inference_id, latency_ms
+| filter level = "ERROR"
+| sort @timestamp desc
+| limit 20
+```
+
+## No CloudWatch Metrics API
+
+Your container **cannot** call `cloudwatch:PutMetricData` at runtime — no outbound network. If you need custom metrics, log them as structured JSON and use CloudWatch Metric Filters to promote them into metrics.
+
+## Retention
+
+CloudWatch log retention is set by the endpoint owner (the customer), not by you. Customers can configure retention on `/aws/sagemaker/Endpoints/<their-endpoint-name>`. Do not assume logs will exist a week later — write anything you need to persist to your own system via the customer's log retention.

--- a/ai-infra/sagemaker-marketplace-onboarding/reference/marketplace-listing.md
+++ b/ai-infra/sagemaker-marketplace-onboarding/reference/marketplace-listing.md
@@ -1,0 +1,68 @@
+# CreateModelPackage — Reference
+
+The skill's marketplace scope is deliberately narrow: help the user run `CreateModelPackage` with a validation job. Everything else (FDP, IAM, pricing, EULA, regions, notebook, publishing) is manual work the user handles via their AWS account team and the Marketplace Management Portal — not this skill.
+
+## What the validation job does
+
+`CreateModelPackage` with `CertifyForMarketplace=True` triggers a SageMaker Batch Transform job that runs the container against sample input the user provides in S3. It verifies: container starts, `/ping` returns 200 within 8 minutes, `/invocations` processes the sample and produces valid output, no security vulnerabilities in the image. This is a contract check, not an accuracy evaluation.
+
+## Prerequisites (user's responsibility)
+
+- ECR image pushed to the region where `CreateModelPackage` will run.
+- `model.tar` uploaded to a seller-owned S3 bucket. Keep a local backup — after `CreateModelPackage`, weights transfer to a Marketplace-managed bucket and the seller loses direct access.
+- Sample input for the validation job uploaded to S3 (e.g. `s3://<bucket>/validation-input/`). Format must match one of the `SupportedContentTypes` in the API call.
+- An empty S3 prefix ready for validation output (`s3://<bucket>/validation-output/`).
+- An IAM role with permission to run the transform job (typically the user's existing SageMaker execution role — this is not the separate marketplace assets role).
+
+## API skeleton
+
+```python
+sm.create_model_package(
+    ModelPackageName="<your-model>-v1",
+    InferenceSpecification={
+        "Containers": [{
+            "Image": "<account>.dkr.ecr.<region>.amazonaws.com/<model>:v1",
+            "ModelDataUrl": "s3://<seller-bucket>/<model>/model.tar",
+        }],
+        "SupportedRealtimeInferenceInstanceTypes": ["ml.g5.2xlarge"],
+        "SupportedTransformInstanceTypes":         ["ml.g5.2xlarge"],
+        "SupportedContentTypes":     ["application/json"],
+        "SupportedResponseMIMETypes":["application/json"],
+    },
+    ValidationSpecification={
+        "ValidationRole": "arn:aws:iam::<account>:role/SageMakerExecutionRole",
+        "ValidationProfiles": [{
+            "ProfileName": "validation-1",
+            "TransformJobDefinition": {
+                "TransformInput": {
+                    "DataSource": {"S3DataSource": {
+                        "S3DataType": "S3Prefix",
+                        "S3Uri": "s3://<bucket>/validation-input/",
+                    }},
+                    "ContentType": "application/json",
+                },
+                "TransformOutput": {"S3OutputPath": "s3://<bucket>/validation-output/"},
+                "TransformResources": {"InstanceType": "ml.g5.xlarge", "InstanceCount": 1},
+            },
+        }],
+    },
+    CertifyForMarketplace=True,
+)
+```
+
+## Field notes
+
+- `Image` — the ECR URI from Phase 9.
+- `ModelDataUrl` — the `model.tar` S3 path from Phase 7.
+- `SupportedRealtimeInferenceInstanceTypes` / `SupportedTransformInstanceTypes` — the instance families the user tested during Phase 8. Do not list families that were not tested.
+- `SupportedContentTypes` / `SupportedResponseMIMETypes` — must match what `/invocations` actually accepts and returns.
+- `ValidationSpecification.TransformInput.ContentType` — must match one of the `SupportedContentTypes` above and must match the format of the sample files.
+- `CertifyForMarketplace=True` — without this, you get a private ModelPackage instead of triggering the Marketplace review workflow.
+
+## Everything else — user handles manually
+
+For the listing steps this skill deliberately doesn't cover — FDP enrollment, IAM roles including the `assets.marketplace.amazonaws.com` trust role, pricing configuration, EULA selection, region setup, customer-facing notebook, publishing (Limited → Public) — refer the user to AWS docs:
+
+- Machine Learning products overview: https://docs.aws.amazon.com/marketplace/latest/userguide/machine-learning-products.html
+- ML publishing prerequisites: https://docs.aws.amazon.com/marketplace/latest/userguide/ml-publishing-prerequisites.html
+- Marketplace Management Portal: https://aws.amazon.com/marketplace/management/

--- a/ai-infra/sagemaker-marketplace-onboarding/reference/observability.md
+++ b/ai-infra/sagemaker-marketplace-onboarding/reference/observability.md
@@ -1,0 +1,168 @@
+# Observability — Reference (operating a published listing)
+
+`reference/logging.md` covers the container-side logging contract every seller needs for the build
+(stdout/stderr → CloudWatch Logs, structured JSON, what not to log). This file covers **metrics** —
+mostly informational for the build phase, but directly relevant once a listing is live and buyers ask
+"how do I monitor this."
+
+Source: AWS ML blog ["Deepgram deepens Amazon SageMaker AI observability with Enhanced Metrics"](https://aws.amazon.com/blogs/machine-learning/deepgram-deepens-amazon-sagemaker-ai-observability-with-enhanced-metrics/)
+(2026-08-27) and Deepgram's own SageMaker observability docs
+([Observability for Amazon SageMaker](https://developers.deepgram.com/docs/observability-sagemaker),
+[Deepgram Enhanced Metrics](https://developers.deepgram.com/docs/enhanced-metrics-sagemaker),
+[Prometheus & OpenTelemetry Metrics](https://developers.deepgram.com/docs/prometheus-otel-sagemaker)),
+which document a reference pattern for exactly this seller use case — surfacing container-internal
+metrics without any outbound network call.
+
+## Three layers of metrics on a SageMaker endpoint
+
+| Layer | Who publishes it | Where it lives | Needs container code? |
+|---|---|---|---|
+| SageMaker invocation metrics | AWS, automatically | CloudWatch `AWS/SageMaker` namespace | No |
+| SageMaker instance metrics | AWS, automatically | CloudWatch `/aws/sagemaker/Endpoints` namespace | No |
+| Detailed observability (GPU/host/container Prometheus) | AWS-managed OTel Collector on the host | CloudWatch OTel metric store (PromQL) | Only for the container's own `/metrics`; GPU+host work with zero container changes |
+| Container-emitted business metrics (EMF) | Your container, via stdout | CloudWatch custom namespace (classic metrics API) | Yes — this is the pattern to build |
+
+## 1. SageMaker invocation metrics (`AWS/SageMaker` namespace) — free, no code
+
+Published automatically per endpoint variant. The ones that matter most for the modes this skill
+scaffolds:
+
+| Metric | Resolution | Notes |
+|---|---|---|
+| `Invocations` | 1 min | Total request count. Each streaming session or Real-Time/Batch call counts as one. |
+| `InvocationsPerInstance` | 1 min | Throughput normalized by instance count. Less useful for long-lived streaming sessions than `ConcurrentRequestsPerModel`. |
+| `ModelLatency` | per-request | Time inside your container. **Not emitted for bidirectional-streaming sessions** — use `FirstChunkLatency` there instead. Microseconds. |
+| `OverheadLatency` | per-request | SageMaker routing/serialization time, outside your container. High values point at platform overhead, not your code. |
+| `ConcurrentRequestsPerModel` | **10s** (high-resolution) | In-flight requests per instance, **including queued**. The primary load signal for anything holding a connection open (bidirectional WebSocket, long streaming responses) — each connection occupies capacity for its full duration, so this reflects real load far better than completed-invocation counts. |
+| `FirstChunkLatency` | per-session | Time from stream start to first chunk sent. Primary latency metric for streaming/WebSocket. Microseconds. |
+| `MidStreamErrors` | per-session | Failures after a streaming response has already started — otherwise invisible outside container logs. |
+| `Invocation4XXErrors` / `Invocation5XXErrors` / `InvocationModelErrors` | 1 min | Client vs. server-side failure counts. 5XX spikes often mean container crash / OOM / GPU issue. |
+
+All latency metrics are in **microseconds** — a 2-second alarm threshold is `2000000`, not `2000`.
+
+## 2. SageMaker instance metrics (`/aws/sagemaker/Endpoints` namespace) — free, no code
+
+`CPUUtilization`, `GPUUtilization`, `GPUMemoryUtilization`, `MemoryUtilization`, `DiskUtilization` —
+resource-level, per endpoint variant. For GPU-bound models (the common case for anything this skill
+scaffolds — LLM/STT/TTS/vision), `GPUUtilization` and `GPUMemoryUtilization` are the ones to alarm on:
+sustained near-max indicates the instance is at capacity and needs scaling.
+
+Enable **enhanced (per-instance) metrics** via `MetricsConfig` on the endpoint config to break these
+down per-instance rather than aggregated across the fleet — useful once you're running >1 instance
+behind a variant.
+
+## 3. Detailed observability — per-GPU + host Prometheus via managed OTel (on by default, no code for GPU/host)
+
+SageMaker runs an AWS-managed OpenTelemetry Collector on every instance backing the endpoint. It
+exports three sources to a CloudWatch OTel metric store queried with **PromQL** (not the classic
+`get-metric-statistics` API):
+
+- **GPU (DCGM exporter):** `DCGM_FI_DEV_GPU_UTIL`, `DCGM_FI_DEV_FB_USED`, etc. — **per-GPU**, not summed.
+  Critical on multi-GPU instances (e.g. `ml.g6.12xlarge`) where an aggregate/average would hide one
+  saturated device.
+- **Host (node exporter):** standard `node_*` Prometheus metrics for the instance.
+- **Container:** the collector scrapes your container's own `/metrics` endpoint on port 8080 if you
+  serve one. This is the one piece that needs container code — see below.
+
+Key facts:
+
+- **On by default for new endpoints**, publishing every 60s. Set explicitly (and choose 10–300s
+  frequency) via `MetricsConfig={"EnableDetailedObservability": True, "MetricPublishFrequencyInSeconds": N}`
+  on `create_endpoint_config` / `update_endpoint_config`. Requires botocore/boto3 ≥1.43.49 or a recent
+  CLI — older SDKs reject the parameter.
+- **Runs on the host, outside your container** — GPU and host metrics work under Marketplace's network
+  isolation requirement with zero impact, since the collector isn't part of the model container's
+  network namespace restrictions.
+- **Not in `list-metrics`** — these live in the OTel store only; query with PromQL via the CloudWatch
+  console's PromQL editor or the Prometheus-compatible HTTP API at
+  `https://monitoring.<region>.amazonaws.com/api/v1/query` (SigV4-signed, service name `monitoring`;
+  works with Grafana or any Prometheus-native tool).
+- **Label quoting gotcha:** OTel resource labels use dotted names (`aws.sagemaker.endpoint.name`) —
+  PromQL requires quoting them (`{"aws.sagemaker.endpoint.name"="..."}`). Using underscores instead of
+  dots is valid PromQL syntax that silently matches nothing — it returns an empty result, not an error,
+  and is easy to misread as "metric not published."
+
+### Optional: serve your own `/metrics` for the container layer
+
+If the container exposes a Prometheus-format `/metrics` endpoint on port 8080, the collector scrapes it
+automatically alongside GPU/host metrics — no extra opt-in needed beyond detailed observability being
+on. Useful for exposing engine-internal signals (queue depth, active-request counts, model-specific
+health) that SageMaker's own metrics can't see. This is genuinely optional — most sellers get useful
+signal from GPU+host alone.
+
+## 4. Container-emitted business metrics via CloudWatch EMF — the pattern this skill should recommend
+
+**Supersedes the "use CloudWatch Metric Filters" advice in `reference/logging.md`.** Metric Filters
+promote log values into metrics after the fact and are fragile (pattern-matching against log text).
+**CloudWatch Embedded Metric Format (EMF)** is the better mechanism for exactly the "I need custom
+metrics but have zero outbound network" problem this skill's containers face:
+
+- Write a specially-structured JSON line to stdout (the same stdout SageMaker already captures to
+  CloudWatch Logs). CloudWatch Logs recognizes the EMF schema and extracts real CloudWatch metrics
+  automatically — no `cloudwatch:PutMetricData` call, no IAM permission, no agent or sidecar.
+- Works under Marketplace's zero-outbound-network constraint because it never makes a network call —
+  it's a stdout write that CloudWatch's own log pipeline post-processes.
+- Appears in the **classic** metrics API (`aws cloudwatch list-metrics`, `get-metric-statistics`,
+  alarms, dashboards) — unlike detailed observability's PromQL-only store.
+- Spec: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html
+
+### Recommended use: mirror your metering emission into EMF
+
+If per-inference billing was selected in Phase 2, `metering.py` already computes `ConsumedUnits` per
+request for the `X-Amzn-Inference-Metering` header. Emit the **same value** as an EMF record on stdout
+at the same call site so the seller has a self-serve way to reconcile the AWS Marketplace bill against
+actual traffic, independent of buyer-side CloudWatch access:
+
+```python
+import json, time
+
+def emit_emf_metric(dimension: str, consumed_units: int, extra_dims: dict | None = None):
+    """Write a CloudWatch EMF record to stdout. SageMaker ships stdout to the
+    endpoint's CloudWatch log group; CloudWatch Logs extracts the metric —
+    no cloudwatch:PutMetricData call, no outbound network."""
+    dims = {"Dimension": dimension, **(extra_dims or {})}
+    record = {
+        "_aws": {
+            "Timestamp": int(time.time() * 1000),
+            "CloudWatchMetrics": [{
+                "Namespace": "YourModel/Inference",
+                "Dimensions": [list(dims.keys())],
+                "Metrics": [{"Name": "ConsumedUnits", "Unit": "Count"}],
+            }],
+        },
+        **dims,
+        "ConsumedUnits": consumed_units,
+    }
+    print(json.dumps(record))
+```
+
+Keep dimension cardinality low (category/model/transport-style buckets, not per-request IDs) — each
+unique metric+dimension combination is billed under standard CloudWatch metric pricing, and high
+cardinality also risks leaking request-identifying information into a metrics namespace, which is the
+wrong place for it (see "what NOT to log" in `reference/logging.md` — the same rule applies to EMF
+dimensions).
+
+### Bidirectional WebSocket metering
+
+For WebSocket, emit the EMF record at the same point the metering companion channel
+(`/invocations-bidirectional-stream-metadata`) sends its `{"Metering": {...}}` frame — same
+`ConsumedUnits` value, two destinations (buyer's billing pipeline via the metadata WebSocket, seller's
+own CloudWatch via EMF on stdout).
+
+## What to add to this skill's phases
+
+- **Phase 5 (container walkthrough):** when per-inference billing is selected, offer to add the
+  `emit_emf_metric()` call alongside the existing `X-Amzn-Inference-Metering` header / metadata-channel
+  emission in `metering.py`.
+- **Phase 8 (local testing):** EMF lines are just JSON on stdout — verify locally by grepping container
+  logs for the `_aws` key; no CloudWatch account access needed to confirm the container emits correctly
+  shaped records before pushing to ECR.
+- **Post-Phase-11 (operating a live listing):** point sellers who ask about capacity planning at
+  `ConcurrentRequestsPerModel` (streaming load) and `GPUUtilization`/detailed observability (resource
+  headroom) rather than `InvocationsPerInstance`, which undercounts long-lived streaming connections.
+
+## Related
+
+- `reference/logging.md` — stdout/CloudWatch Logs contract (this file is the metrics counterpart)
+- `reference/billing.md` — the `X-Amzn-Inference-Metering` header contract that EMF metering should mirror
+- `reference/websocket.md` — the metadata-channel metering protocol for bidirectional streaming

--- a/ai-infra/sagemaker-marketplace-onboarding/reference/pipecat-integration.md
+++ b/ai-infra/sagemaker-marketplace-onboarding/reference/pipecat-integration.md
@@ -1,0 +1,455 @@
+# Pipecat Orchestration Support — Reference
+
+Pipecat is an open-source Python framework for voice AI pipelines (VAD → STT → LLM → TTS →
+transport). It has first-class support for consuming models deployed on SageMaker bidirectional
+streaming endpoints — the exact container contract this skill scaffolds in Phase 4-6.
+
+Source: AWS ML blog ["Deploy voice agents with Pipecat and Amazon SageMaker AI bidirectional
+streaming"](https://d1im9ux8shqxn5.cloudfront.net/blog-ml-21563/) and the real Pipecat source
+(`pipecat-ai/pipecat`, `src/pipecat/services/aws/sagemaker/` and
+`src/pipecat/services/deepgram/sagemaker/`).
+
+This file covers two things: (1) how Pipecat's client-side architecture maps onto the container
+you just built, so you understand what you need to expose for it to be wrappable; and (2) how to
+get your model listed in the Pipecat ecosystem once your container works.
+
+## Scope check — is this relevant to you?
+
+Only relevant if:
+- Modality is STT or TTS (or an LLM served over bidirectional streaming), **and**
+- You selected Bidirectional WebSocket in Phase 2.
+
+Skip this entirely for Real-Time/Batch/Streaming-response-only containers — Pipecat's SageMaker
+integration is specifically for the `/invocations-bidirectional-stream` contract.
+
+## How Pipecat wraps a SageMaker bidi endpoint — three layers
+
+### Layer 1: `SageMakerBidiClient` (already built, reusable, nothing for you to do here)
+
+A generic HTTP/2 client Pipecat ships in core. Handles SigV4 auth, session lifecycle, and
+binary/text frame handling against `runtime.sagemaker.<region>.amazonaws.com:8443`. Any model on
+any SageMaker bidi endpoint uses the *same* client:
+
+```python
+from pipecat.services.aws.sagemaker.bidi_client import SageMakerBidiClient
+
+client = SageMakerBidiClient(
+    endpoint_name="my-endpoint",
+    region="us-east-2",
+    model_invocation_path="v1/speak",   # → your container's X-Amzn-SageMaker-Model-Invocation-Path
+    model_query_string="voice=my-voice&sample_rate=16000",
+)
+await client.start_session()
+await client.send_json({"type": "Speak", "text": "Hello"})
+response = await client.receive_response()
+await client.close_session()
+```
+
+This is why the routing header matters (see below) — `model_invocation_path` is how one Pipecat
+service targets a specific logical API on your container.
+
+### Layer 2: a service wrapper — this is the part you (the model provider) write
+
+A subclass of Pipecat's `STTService` or `TTSService` that translates Pipecat's generic interface
+(`run_stt(audio)` / `run_tts(text)`) into **your container's own WebSocket protocol**. This is
+the piece that doesn't exist yet for a new model — everything else (transport, VAD, LLM,
+pipeline wiring) is already generic in Pipecat.
+
+Real example — `DeepgramSageMakerTTSService` (`pipecat/services/deepgram/sagemaker/tts.py`):
+
+```python
+async def run_tts(self, text: str, context_id: str):
+    await self._client.send_json({"type": "Speak", "text": text})
+    yield None   # audio arrives asynchronously via a background response-processing task
+
+async def on_audio_context_interrupted(self, context_id: str):
+    # Barge-in: caller started speaking, discard whatever we were synthesizing
+    await self._client.send_json({"type": "Clear"})
+
+async def flush_audio(self, context_id: str | None = None):
+    # LLM turn finished — force synthesis of whatever text is buffered
+    await self._client.send_json({"type": "Flush"})
+```
+
+A background task continuously reads from the BiDi stream, tells JSON control frames
+(`Metadata`, `Flushed`, `Cleared`, `Warning`) apart from raw binary audio bytes by attempting a
+UTF-8/JSON decode first, and routes each to the right handler.
+
+The STT counterpart (`DeepgramSageMakerSTTService`, `pipecat/services/deepgram/sagemaker/stt.py`)
+follows the same shape: `run_stt(audio)` calls `client.send_audio_chunk(audio)`; a background
+task parses transcription JSON and pushes `TranscriptionFrame`/`InterimTranscriptionFrame`; a
+second background task sends `{"type": "KeepAlive"}` every 5 seconds during silence; and on
+`VADUserStoppedSpeakingFrame` it sends `{"type": "Finalize"}` to flush a final transcript.
+
+### Layer 3: pipeline integration (already generic — nothing for you to do)
+
+A factory picks your service class at runtime based on config; the rest of the Pipecat pipeline
+(VAD, LLM, transport, barge-in handling) doesn't know or care which vendor's model it's calling.
+
+## What this means for the container you just built
+
+Pipecat's service wrapper is only possible because the container implements a **control-message
+vocabulary** on top of the raw `/invocations-bidirectional-stream` contract — not just raw audio
+frames. Deepgram's containers accept JSON text frames like `{"type": "Speak", ...}`,
+`{"type": "Flush"}`, `{"type": "Clear"}`, `{"type": "Close"}`, `{"type": "KeepAlive"}`, and (STT)
+`{"type": "Finalize"}`, interleaved with binary audio frames.
+
+If you want your model to be easily wrappable by Pipecat (or any other voice-orchestration
+framework doing the same job), design your container's WebSocket protocol with equivalents for:
+
+| Need | Deepgram's pattern | Why an orchestrator needs it |
+|---|---|---|
+| Start synthesis / send input | `{"type": "Speak", "text": "..."}` (TTS) or raw binary audio frames (STT) | The one required message — everything else is optional polish |
+| Force flush of buffered output | `{"type": "Flush"}` | Called when the LLM turn ends so TTS doesn't wait for more text before speaking |
+| Cancel in-flight output (barge-in) | `{"type": "Clear"}` | Called the instant VAD detects the caller interrupting — without this, the orchestrator can't stop your model mid-sentence |
+| Keep an idle connection alive | `{"type": "KeepAlive"}` every 5s | Prevents your own container (or any intermediate proxy) from timing out during silence |
+| Force a final result on turn-end | `{"type": "Finalize"}` (STT only) | Lets the orchestrator get a clean final transcript exactly when VAD says the caller stopped talking, instead of waiting on your model's own endpointing |
+| Graceful session end | `{"type": "Close"}` / `{"type": "CloseStream"}` | Lets the client signal intent before disconnecting, vs. a hard close |
+
+None of this is a hard SageMaker Marketplace requirement — the container contract (Phase 5/6)
+doesn't mandate a specific message vocabulary. This is purely an **interoperability** design
+choice: it's what makes a Pipecat (or similar) integration one afternoon of work instead of a
+custom protocol negotiation. Mention this table if the user asks "how do I make my container
+Pipecat-compatible" during Phase 5.
+
+### Routing multiple logical APIs on one container
+
+If your container serves more than one logical model API (e.g. `/v1/listen` for STT and
+`/v1/speak` for TTS on the same endpoint, mirroring how `model_invocation_path` is used above),
+read `X-Amzn-SageMaker-Model-Invocation-Path` on the WebSocket upgrade request and route to the
+right internal handler. See `websocket.md`'s note on this header, and
+`templates/websocket_handler.py` for where to add the branch.
+
+## Getting your model into the Pipecat ecosystem
+
+Once your container passes Phase 8's local testing gate, you have two paths to make it usable by
+Pipecat users. **Ask the user which one fits** before doing anything — this is a real decision
+with different requirements, not a formality.
+
+### Path A — Community Integration (the realistic default for most providers)
+
+Pipecat's own contribution guide is explicit: *"We encourage community-maintained integrations!"*
+and *"the Pipecat team does not code review, test, or maintain community integrations."* This is
+a **separate repository you own**, listed for discoverability — not a PR into Pipecat's own
+codebase. Lower barrier, faster to ship, and the standard route unless your model is significant
+enough that the Pipecat maintainers would want it in core (that's their call, not something to
+assume).
+
+Requirements (from Pipecat's `COMMUNITY_INTEGRATIONS.md`), your own repo must contain:
+- Full source implementation following Pipecat's service patterns (subclass `STTService` or
+  `TTSService`; see Layer 2 above)
+- A foundational single-file usage example
+- `README.md` with: intro, install instructions, Pipecat pipeline usage, how to run the example,
+  tested Pipecat version, and **company attribution** if you work for the company providing the
+  model (builds confidence the integration will be maintained)
+- A permissive `LICENSE` (BSD-2 like Pipecat, or equivalent)
+- Docstrings following Pipecat's docstring conventions
+- A changelog
+
+Then, separately, **submit docs into `pipecat-ai/docs`**: a row on the Supported Services page
+with a `Community` maintainer badge, plus a dedicated service page (installation, prerequisites,
+configuration, minimal usage example, compatibility note) — copy an existing community page as a
+starting point rather than writing from scratch. Include a ~30-60s demo video link in that PR
+description showing core functionality and an interruption/barge-in handling if applicable.
+Announce it in the `#community-integrations` Discord channel after submitting: https://discord.gg/pipecat
+
+### Path B — Core PR into `pipecat-ai/pipecat`
+
+Only appropriate if the model is broadly relevant enough that Pipecat's maintainers would want to
+maintain it directly (this is their judgment call — flag it as a possibility to the user, don't
+promise it'll be accepted). Standard OSS contribution flow per `CONTRIBUTING.md`:
+
+1. Fork `pipecat-ai/pipecat`, clone your fork.
+2. Branch: `git checkout -b <feature-branch-name>`.
+3. Implement your service wrapper under `src/pipecat/services/<provider>/sagemaker/` (or
+   `<provider>/` if not SageMaker-specific), following the patterns in Layer 2 above and the real
+   `deepgram/sagemaker/{stt,tts}.py` files as a structural reference.
+4. Add a changelog fragment: `changelog/<PR_number>.added.md` (a Markdown bullet describing the
+   addition — PR number isn't known until the PR is opened, so this typically gets added/renamed
+   in the same PR).
+5. Commit, push to your fork, open a PR against `pipecat-ai/pipecat` `main`, with a clear
+   description of what the integration does.
+
+### What this skill does — and doesn't — help with
+
+This is documentation only for now — see the illustrative appendix below for what a service
+wrapper looks like structurally. This skill does **not** currently scaffold a live
+`templates/pipecat_service_stub.py` file into Phase 4's output, and does not scaffold the full
+community-integration repo (README, LICENSE, changelog, docs-site PR) or open the PR on your
+behalf — those are decisions and content only you can make (attribution, licensing terms, which
+repo to host it in, whether you want to commit to maintaining it). Treat the checklist above as
+the punch list to walk through with the user, the same way Phase 3's gap analysis is a punch
+list, not an auto-fix. If a future revision of this skill promotes the appendix into a real
+scaffolded template, it slots into Phase 4's opt-in tree the same way `websocket_handler.py` and
+`metering.py` already do.
+
+## Appendix: illustrative service-wrapper example (not a scaffolded template)
+
+The following is a **structural example**, not code this skill generates or copies anywhere. It
+shows the shape a Pipecat `TTSService`/`STTService` subclass takes when wrapping a SageMaker
+bidi endpoint, adapted from the real `DeepgramSageMakerTTSService`/`STTService` implementations
+in `pipecat-ai/pipecat` (`src/pipecat/services/deepgram/sagemaker/{tts,stt}.py`). Every `TODO`
+marks a point where the real implementation is Deepgram-specific and yours would differ. Read
+this to *decide* whether the pattern is worth adopting for your model — it is not meant to be
+copy-pasted as-is.
+
+This code lives in a **separate Pipecat-integration repository or PR**, never in your model
+container — the container only ever speaks the WebSocket protocol Phase 5/6 scaffolds; this class
+is the *client-side* translator that a Pipecat pipeline loads.
+
+```python
+"""
+Illustrative only. Requires (in the Pipecat integration's own environment,
+NOT your model container's runtime): uv add "pipecat-ai[sagemaker]"
+"""
+import asyncio
+import json
+from collections.abc import AsyncGenerator
+
+from loguru import logger
+from pipecat.frames.frames import (
+    CancelFrame, EndFrame, ErrorFrame, Frame,
+    InterimTranscriptionFrame, TranscriptionFrame, TTSAudioRawFrame,
+    VADUserStoppedSpeakingFrame,
+)
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessorSetup
+from pipecat.services.aws.sagemaker.bidi_client import SageMakerBidiClient
+from pipecat.services.stt_service import STTService
+from pipecat.services.tts_service import TTSService
+from pipecat.utils.time import time_now_iso8601
+
+# TODO: model_invocation_path resolves to X-Amzn-SageMaker-Model-Invocation-Path
+# on your container's WebSocket upgrade request (see the routing note above).
+TTS_INVOCATION_PATH = "v1/speak"
+STT_INVOCATION_PATH = "v1/listen"
+
+
+class YourModelSageMakerTTSService(TTSService):
+    def __init__(self, *, endpoint_name: str, region: str, voice: str, **kwargs):
+        super().__init__(**kwargs)
+        self._endpoint_name = endpoint_name
+        self._region = region
+        self._voice = voice
+        self._client: SageMakerBidiClient | None = None
+        self._response_task: asyncio.Task | None = None
+
+    async def setup(self, setup: FrameProcessorSetup):
+        await super().setup(setup)
+        await self._connect()
+
+    async def cleanup(self):
+        await super().cleanup()
+        await self._disconnect()
+
+    async def stop(self, frame: EndFrame):
+        await super().stop(frame)
+        await self._disconnect()
+
+    async def cancel(self, frame: CancelFrame):
+        await super().cancel(frame)
+        await self._disconnect()
+
+    async def _connect(self):
+        # TODO: build your query string from voice/sample_rate/encoding etc.
+        query_string = f"voice={self._voice}&sample_rate={self.sample_rate}"
+        self._client = SageMakerBidiClient(
+            endpoint_name=self._endpoint_name,
+            region=self._region,
+            model_invocation_path=TTS_INVOCATION_PATH,
+            model_query_string=query_string,
+        )
+        try:
+            await self._client.start_session()
+            self._response_task = self.create_task(self._process_responses())
+        except Exception as e:
+            await self.push_error(error_msg=f"Connection failed: {e}", exception=e)
+
+    async def _disconnect(self):
+        if not (self._client and self._client.is_active):
+            return
+        try:
+            # TODO: your container's graceful-close control message
+            await self._client.send_json({"type": "Close"})
+        except Exception as e:
+            logger.warning(f"close failed: {e}")
+        if self._response_task and not self._response_task.done():
+            await self.cancel_task(self._response_task)
+        await self._client.close_session()
+
+    async def run_tts(self, text: str, context_id: str) -> AsyncGenerator[Frame | None, None]:
+        # Audio arrives asynchronously via _process_responses() -- this
+        # method just kicks off the request.
+        if self._client is None:
+            yield ErrorFrame(error="client unavailable")
+            return
+        try:
+            # TODO: your container's "synthesize this text" control message
+            await self._client.send_json({"type": "Speak", "text": text})
+            yield None
+        except Exception as e:
+            yield ErrorFrame(error=f"run_tts failed: {e}")
+
+    async def flush_audio(self, context_id: str | None = None):
+        # Called when the LLM turn ends -- force synthesis of buffered text.
+        if self._client and self._client.is_active:
+            try:
+                await self._client.send_json({"type": "Flush"})  # TODO
+            except Exception as e:
+                logger.error(f"flush_audio failed: {e}")
+
+    async def on_audio_context_interrupted(self, context_id: str):
+        # Barge-in: caller started speaking, cancel in-flight synthesis.
+        if self._client and self._client.is_active:
+            try:
+                await self._client.send_json({"type": "Clear"})  # TODO
+            except Exception as e:
+                logger.error(f"interruption handling failed: {e}")
+        await super().on_audio_context_interrupted(context_id)
+
+    async def _process_responses(self):
+        try:
+            while self._client and self._client.is_active:
+                result = await self._client.receive_response()
+                if result is None:
+                    break
+                payload = getattr(getattr(result, "value", None), "bytes_", None)
+                if not payload:
+                    continue
+                try:
+                    parsed = json.loads(payload.decode("utf-8"))
+                    logger.trace(f"control message: {parsed}")  # TODO: handle types
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    context_id = self.get_active_audio_context_id()
+                    frame = TTSAudioRawFrame(payload, self.sample_rate, 1, context_id=context_id)
+                    await self.append_to_audio_context(context_id, frame)
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            await self.push_error(error_msg=f"response processing failed: {e}", exception=e)
+
+
+class YourModelSageMakerSTTService(STTService):
+    def __init__(self, *, endpoint_name: str, region: str, **kwargs):
+        super().__init__(**kwargs)
+        self._endpoint_name = endpoint_name
+        self._region = region
+        self._client: SageMakerBidiClient | None = None
+        self._response_task: asyncio.Task | None = None
+        self._keepalive_task: asyncio.Task | None = None
+        self._user_id = ""
+
+    async def setup(self, setup: FrameProcessorSetup):
+        await super().setup(setup)
+        await self._connect()
+
+    async def stop(self, frame: EndFrame):
+        await super().stop(frame)
+        await self._disconnect()
+
+    async def cancel(self, frame: CancelFrame):
+        await super().cancel(frame)
+        await self._disconnect()
+
+    async def cleanup(self):
+        await super().cleanup()
+        await self._disconnect()
+
+    async def _connect(self):
+        # TODO: build your query string from model/language/sample_rate etc.
+        query_string = f"sample_rate={self.sample_rate}"
+        self._client = SageMakerBidiClient(
+            endpoint_name=self._endpoint_name,
+            region=self._region,
+            model_invocation_path=STT_INVOCATION_PATH,
+            model_query_string=query_string,
+        )
+        try:
+            await self._client.start_session()
+            self._response_task = self.create_task(self._process_responses())
+            # Only start a keepalive loop if your container's protocol needs
+            # one -- check the control-message table above.
+            self._keepalive_task = self.create_task(self._send_keepalive())
+        except Exception as e:
+            await self.push_error(error_msg=f"Connection failed: {e}", exception=e)
+
+    async def _disconnect(self):
+        if self._client and self._client.is_active:
+            try:
+                await self._client.send_json({"type": "CloseStream"})  # TODO
+            except Exception as e:
+                logger.warning(f"close failed: {e}")
+            if self._keepalive_task and not self._keepalive_task.done():
+                await self.cancel_task(self._keepalive_task)
+            if self._response_task and not self._response_task.done():
+                await self.cancel_task(self._response_task)
+            await self._client.close_session()
+
+    async def run_stt(self, audio: bytes) -> AsyncGenerator[Frame | None, None]:
+        if self._client and self._client.is_active:
+            try:
+                await self._client.send_audio_chunk(audio)
+            except Exception as e:
+                yield ErrorFrame(error=f"run_stt failed: {e}")
+        yield None
+
+    async def _send_keepalive(self):
+        while self._client and self._client.is_active:
+            await asyncio.sleep(5)
+            if self._client and self._client.is_active:
+                try:
+                    await self._client.send_json({"type": "KeepAlive"})  # TODO
+                except Exception as e:
+                    logger.warning(f"keepalive failed: {e}")
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        await super().process_frame(frame, direction)
+        if isinstance(frame, VADUserStoppedSpeakingFrame):
+            # Caller stopped talking -- ask for a final result now rather
+            # than waiting on the model's own endpointing, if supported.
+            if self._client and self._client.is_active:
+                try:
+                    await self._client.send_json({"type": "Finalize"})  # TODO
+                except Exception as e:
+                    logger.warning(f"finalize failed: {e}")
+
+    async def _process_responses(self):
+        try:
+            while self._client and self._client.is_active:
+                result = await self._client.receive_response()
+                if result is None:
+                    break
+                payload = getattr(getattr(result, "value", None), "bytes_", None)
+                if not payload:
+                    continue
+                try:
+                    parsed = json.loads(payload.decode("utf-8"))
+                except json.JSONDecodeError:
+                    logger.warning(f"non-JSON STT response: {payload!r}")
+                    continue
+                # TODO: replace with your model's actual response shape.
+                # This example assumes {"text": "...", "is_final": bool}.
+                transcript = parsed.get("text", "")
+                if not transcript.strip():
+                    continue
+                frame_cls = TranscriptionFrame if parsed.get("is_final") else InterimTranscriptionFrame
+                await self.push_frame(
+                    frame_cls(transcript, self._user_id, time_now_iso8601(), None, result=parsed)
+                )
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            await self.push_error(error_msg=f"response processing failed: {e}", exception=e)
+```
+
+**Decision point for the user:** if this pattern looks worth adopting, the next step is to
+promote it into a real `templates/pipecat_service_stub.py` scaffolded file (wired into Phase 4's
+opt-in tree) — that is a separate, explicit follow-up, not something this doc change does
+automatically.
+
+## Reference implementation
+
+The blog's companion repository is a complete, deployable example wiring all of this together —
+useful to point a user at if they want to see a production-shaped version (CDK infra, ECS
+Fargate, session-aware auto-scaling, CloudWatch dashboard, Claude Code deploy skill) rather than
+just the Pipecat service-wrapper piece:
+https://github.com/aws-solutions-library-samples/sample-voice-agent

--- a/ai-infra/sagemaker-marketplace-onboarding/reference/timing.md
+++ b/ai-infra/sagemaker-marketplace-onboarding/reference/timing.md
@@ -1,0 +1,28 @@
+# Timing Constraints (from the SageMaker Marketplace Model Listing Guide)
+
+Every hard timing limit the spec enforces, in one place. Violate any of these and the container will misbehave in production even if local testing looks fine.
+
+| Constraint | Value | Consequence if exceeded |
+|---|---|---|
+| Socket connection acceptance | ≤ 250 ms | Request rejected before your code sees it |
+| /ping timeout per request | 2 seconds | Health check fails; SageMaker considers instance unhealthy |
+| Container startup window (from `docker run` until /ping returns 200) | 8 minutes | CreateEndpoint fails; instance replaced |
+| /invocations sync max processing | 60 seconds | 504 timeout returned to client |
+| InvokeEndpointWithResponseStream | 8 minutes | Connection closed mid-response |
+| InvokeEndpointAsync | 60 minutes | Async job fails |
+| Batch Transform (per record) | No hard timeout, but 100 MB max payload | Record fails |
+| SIGKILL delay after SIGTERM | 30 seconds | Process killed hard; connections dropped |
+| WebSocket Ping interval (SageMaker → container) | Every 60 seconds | (streaming only, out of scope for this skill) |
+
+## Cold-start budget breakdown
+
+The 8-minute window covers everything from `docker run` until `/ping` returns 200:
+
+| Phase | Typical time | Optimization |
+|---|---|---|
+| S3 download of model.tar | 30–120 s (size dependent) | Uncompressed tar |
+| Extraction to /opt/ml/model/ | 10–30 s | Uncompressed = near-instant |
+| Weight loading to GPU | 60–180 s | Use safetensors (~2× faster than .pt/.bin) |
+| **Total** | **~3–6 min** | **must be < 8 min** |
+
+If your model is above 20 GB, budget carefully. If load consistently takes over 6 minutes, split the model or use safetensors.

--- a/ai-infra/sagemaker-marketplace-onboarding/reference/websocket.md
+++ b/ai-infra/sagemaker-marketplace-onboarding/reference/websocket.md
@@ -94,21 +94,83 @@ Applies only to text-to-speech models — skip for LLMs, STT, image, embedding, 
 
 Container reads and applies. No shared state between customers.
 
-## Per-inference billing on WebSocket
+## Per-inference billing on WebSocket (companion metadata streaming)
 
-Metering does **not** go on the main data stream. It goes on a **companion metadata WebSocket** at `/invocations-bidirectional-stream-metadata`.
+GA capability (see AWS ML blog ["Introducing usage-based pricing for Amazon SageMaker bidirectional
+streaming"](https://aws.amazon.com/blogs/machine-learning/introducing-usage-based-pricing-for-amazon-sagemaker-bidirectional-streaming/),
+Deepgram launch partner). This is what makes per-inference billing possible on a long-lived
+connection where total usage is not known until the stream ends — SageMaker's header-based metering
+(`X-Amzn-Inference-Metering` on a normal `/invocations` response) only works because a request-response
+call has a bounded end. A bidi session can run 30 seconds or 30 minutes, so metering has to be reported
+incrementally on a side channel instead.
 
-1. Container advertises support in the main endpoint's upgrade response header:
-   ```
-   X-Amzn-SageMaker-Metadata-Stream-Supported: true
-   ```
-2. SageMaker opens a second WebSocket to the metadata endpoint with the same `X-Amzn-SageMaker-Request-Id`.
-3. Container emits JSON frames on the metadata channel:
-   ```json
-   {"Metering": {"Dimension": "audio_seconds", "ConsumedUnits": 150, "ClientToken": "<uuid>"}}
-   ```
+Metering does **not** go on the main data stream. It goes on a **companion metadata WebSocket** at
+`/invocations-bidirectional-stream-metadata` — a second, independent WebSocket connection SageMaker
+opens in parallel with the data connection.
 
-`Dimension` must match the value configured in your Marketplace listing. `ClientToken` is a per-frame idempotency key.
+### Step 1 — opt in via upgrade response headers on the *data* connection
+
+| Header | Required | Values | Description |
+|---|---|---|---|
+| `X-Amzn-SageMaker-Metadata-Stream-Supported` | Yes (to opt in) | `true` | Signals the model server supports the companion stream. If absent/not `true`, SageMaker never attempts the metadata connection. |
+| `X-Amzn-SageMaker-Metadata-Stream-Required` | No | `true` / `false` (default `false`) | If `true`, the **data** stream is terminated with **HTTP 424** when the metadata connection fails to establish or drops mid-session. If `false`/absent, the data stream keeps running in data-only mode and metering simply stops. |
+| `X-Amzn-SageMaker-Metadata-Invocation-Path` | No | custom path string | Overrides the default metadata path (`/invocations-bidirectional-stream-metadata`). |
+
+### Step 2 — accept the metadata connection
+
+SageMaker opens a second WebSocket to the metadata endpoint. Both connections carry the same
+`X-Amzn-SageMaker-Request-Id` header — use it to correlate the metadata connection with the matching
+data connection for the same inference session.
+
+### Step 3 — send metering messages
+
+One JSON object per Text frame, **exactly one metering record per frame** (do not batch multiple
+records into a single frame; binary frames are not supported for metering):
+
+```json
+{
+  "Metering": {
+    "Dimension": "inference.count",
+    "ConsumedUnits": 150,
+    "ClientToken": "a3f2b1c0-unique-uuid"
+  }
+}
+```
+
+| Field | Required | Type | Constraint |
+|---|---|---|---|
+| `Metering.Dimension` | Yes | string | max 128 characters |
+| `Metering.ConsumedUnits` | Yes | number | > 0 |
+| `Metering.ClientToken` | No | string | max 64 characters — idempotency key; a duplicate `ClientToken` on the same connection is recorded only once |
+
+`Dimension` must match the value configured on the Marketplace listing.
+
+### Constraints and limits
+
+- **Max message size:** 512 bytes (total size of the JSON text frame).
+- **Max send rate:** 1 message per second per connection. Exceeding this may drop messages.
+- **Frame type:** text frames only.
+- **Transport:** TCP — ordered, reliable delivery at the transport layer.
+
+### Send incrementally, not just at session end
+
+Recommended: emit metering records incrementally as usage accrues (e.g. per N seconds of audio
+processed), not only once at session close. **If the session drops mid-stream, billing is only
+captured for usage reported up to that point** — a single end-of-session record loses everything if
+the connection dies first.
+
+### Failure modes
+
+| Scenario | `Required=true` | `Required=false` (default) |
+|---|---|---|
+| Metadata WebSocket fails to connect | Data stream terminated (HTTP 424) | Data stream continues normally (data-only mode) |
+| Metadata WebSocket drops mid-session | Data stream terminated (HTTP 424) | Data stream continues; metering stops |
+| Malformed metering message | Message dropped; connection stays open | Message dropped; connection stays open |
+| Data connection breaks mid-stream | Metadata stream closed | Metadata stream closed |
+
+Set `Required=true` only if the model's business model cannot tolerate unmetered usage (e.g. the
+provider would rather fail the request than serve it unbilled). Default (`false`) favors availability
+over billing completeness.
 
 ## Testing locally
 

--- a/ai-infra/sagemaker-marketplace-onboarding/reference/websocket.md
+++ b/ai-infra/sagemaker-marketplace-onboarding/reference/websocket.md
@@ -1,0 +1,181 @@
+# Bidirectional WebSocket Streaming — Reference
+
+Opt-in. Only implement `/invocations-bidirectional-stream` if your model needs `InvokeEndpointWithBidirectionalStream` (STT, TTS, real-time voice, etc.). Standard streaming response (`InvokeEndpointWithResponseStream`) does **not** use this endpoint.
+
+## Protocol translation
+
+The client uses HTTP/2 on port 8443 with SigV4 auth. SageMaker translates HTTP/2 to WebSocket internally. Your container **only** implements WebSocket on port 8080. Do not implement HTTP/2.
+
+```
+Client (HTTP/2 SDK)  →  SageMaker (translates)  →  Your container (WebSocket, port 8080)
+```
+
+## Docker label — REQUIRED
+
+Without this label, SageMaker will not route WebSocket traffic to your container.
+
+```dockerfile
+LABEL com.amazonaws.sagemaker.capabilities.bidirectional-streaming=true
+```
+
+Do **not** add this label if you are not implementing the WebSocket endpoint.
+
+## Handshake
+
+SageMaker upgrades to WebSocket:
+
+```
+GET ws://localhost:8080/invocations-bidirectional-stream HTTP/1.1
+Connection: Upgrade
+Upgrade: websocket
+Sec-WebSocket-Version: 13
+Sec-WebSocket-Key: <base64-nonce>
+```
+
+Your container responds `101 Switching Protocols` with a computed `Sec-WebSocket-Accept`. FastAPI/Starlette handles this automatically.
+
+Path can be overridden via `X-Amzn-SageMaker-Model-Invocation-Path` header at invocation time.
+
+## Frame mapping — client → container
+
+| Client PayloadPart | Container receives |
+|---|---|
+| DataType = UTF8 | Text Data Frame |
+| DataType = BINARY | Binary Data Frame |
+
+## Frame mapping — container → client
+
+| Container sends | Client receives |
+|---|---|
+| Text Data Frame | PayloadPart with DataType=UTF8 |
+| Binary Data Frame | PayloadPart with DataType=BINARY |
+| Data Frame with FIN=0 | PayloadPart with CompletionState=PARTIAL |
+| Continuation Frame with FIN=1 | PayloadPart with CompletionState=COMPLETE |
+
+## Ping/Pong (required for connection health)
+
+- SageMaker sends WebSocket Ping every 60 seconds.
+- Container **must** respond with a Pong frame (RFC 6455 §5.5.3). Most WebSocket libraries do this automatically.
+- 5 consecutive missed Pongs → connection closed by SageMaker.
+- Container may send its own Pings; SageMaker responds with Pong.
+
+## Error handling
+
+Two options:
+
+**Text frame with structured error:**
+```json
+{"ModelStreamError": {"ErrorCode": "<code>", "Message": "<message>"}}
+```
+
+**WebSocket Close frame:** SageMaker wraps the close code + reason into `ModelStreamError` for the client.
+
+## Max connection duration — 30 minutes
+
+Hard limit. Client must reconnect after. For longer sessions (e.g., call-center calls), implement reconnection at the application/orchestration layer — **not** in the container. Design the container **stateless per-connection**; do not persist session state across reconnects on the server.
+
+## Recommended STT protocol
+
+- Client → Container: Binary frames (PCM audio chunks) + one Text config frame `{"sample_rate": 16000, "language": "en"}`
+- Container → Client: Text frames `{"text": "partial", "is_final": false}` and final `{"text": "final.", "is_final": true, "confidence": 0.95}`
+
+## Recommended TTS protocol
+
+- Client → Container: Text frames `{"text": "sentence", "voice": "id", "language": "en"}`
+- Container → Client: Binary frames (PCM audio, streaming as generated) + end signal `{"status": "complete", "duration_ms": 1240}`
+
+## TTS pronunciation dictionary (TTS models only)
+
+Applies only to text-to-speech models — skip for LLMs, STT, image, embedding, or any other modality. Because the container has zero outbound network, pronunciation dictionaries cannot be loaded from S3 at runtime. Recommended pattern: customer sends pronunciation overrides per-request:
+
+```json
+{"text": "Welcome to HDFC Bank", "pronunciations": {"HDFC": "H D F C"}, "voice": "id"}
+```
+
+Container reads and applies. No shared state between customers.
+
+## Per-inference billing on WebSocket
+
+Metering does **not** go on the main data stream. It goes on a **companion metadata WebSocket** at `/invocations-bidirectional-stream-metadata`.
+
+1. Container advertises support in the main endpoint's upgrade response header:
+   ```
+   X-Amzn-SageMaker-Metadata-Stream-Supported: true
+   ```
+2. SageMaker opens a second WebSocket to the metadata endpoint with the same `X-Amzn-SageMaker-Request-Id`.
+3. Container emits JSON frames on the metadata channel:
+   ```json
+   {"Metering": {"Dimension": "audio_seconds", "ConsumedUnits": 150, "ClientToken": "<uuid>"}}
+   ```
+
+`Dimension` must match the value configured in your Marketplace listing. `ClientToken` is a per-frame idempotency key.
+
+## Testing locally
+
+`wscat` for quick manual testing:
+
+```bash
+npm install -g wscat
+wscat --connect ws://127.0.0.1:8080/invocations-bidirectional-stream
+```
+
+For automated testing, use `templates/test/test_websocket.py`.
+
+## Client SDK — testing against a live SageMaker endpoint
+
+The local tests above hit the container directly on `ws://localhost:8080/…`. To exercise the full path from a SageMaker endpoint (HTTP/2 on port 8443 with SigV4 auth), you need the AWS SDK for bidirectional streaming. `boto3` does not implement it — it's a separate smithy-generated package.
+
+**Canonical package:** [`aws_sdk_sagemaker_runtime_http2`](https://pypi.org/project/aws_sdk_sagemaker_runtime_http2/) on PyPI. Underscores and hyphens both resolve.
+
+```bash
+pip install aws_sdk_sagemaker_runtime_http2
+```
+
+**Prerequisites that catch people out:**
+
+- **Python 3.12+ required.** Users on 3.10 or 3.11 see `ERROR: Could not find a version that satisfies the requirement` — reads like "package missing" but is really "no compatible release for your Python." This is the single most common install failure.
+- **Pre-alpha status.** Currently 0.x releases. The description on PyPI warns "changes may result in breaking changes prior to the release of version 1.0.0" — pin the version and expect churn.
+- **`awscrt` C dependency.** Pulled in transitively via `smithy-http[awscrt]`. Needs prebuilt wheels for the target platform. Fails on alpine musl and some older ARM boards; a source build via `pip install --no-binary=awscrt awscrt` may work but requires build tooling.
+- **Transitive deps:** `smithy-aws-core[eventstream,json]`, `smithy-core`, `smithy-http[awscrt]`. Corporate PyPI mirrors that don't proxy new AWS SDK packages may need to be primed with all four.
+
+**Minimal usage sketch:**
+
+```python
+from aws_sdk_sagemaker_runtime_http2.client import SageMakerRuntimeHTTP2Client
+from aws_sdk_sagemaker_runtime_http2.config import Config
+from aws_sdk_sagemaker_runtime_http2.models import (
+    InvokeEndpointWithBidirectionalStreamInput,
+    RequestPayloadPart,
+    RequestStreamEventPayloadPart,
+)
+from smithy_aws_core.identity import EnvironmentCredentialsResolver
+
+config = Config(
+    endpoint_uri=f"https://runtime.sagemaker.{region}.amazonaws.com:8443",
+    region=region,
+    aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
+)
+client = SageMakerRuntimeHTTP2Client(config=config)
+
+stream = await client.invoke_endpoint_with_bidirectional_stream(
+    InvokeEndpointWithBidirectionalStreamInput(
+        endpoint_name="<your-endpoint>",
+        model_invocation_path="",       # optional path override
+        model_query_string="",          # optional query params
+    )
+)
+
+# Send:
+await stream.input_stream.send(RequestStreamEventPayloadPart(
+    value=RequestPayloadPart(bytes_=b"...", data_type="BINARY"),   # or "UTF8"
+))
+
+# Receive:
+output = await stream.await_output()
+async for event in output[1]:
+    ...
+```
+
+Note the client is **async-only** (`await` everywhere) and uses `smithy_aws_core.identity.EnvironmentCredentialsResolver` — not boto3's credential chain — so `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars are the standard path. AWS CLI config and instance metadata are also picked up.
+
+**Voice/AI pipelines only:** if the model is being consumed by a voice-AI pipeline, the `pipecat` framework wraps this SDK in an extras install (`uv add "pipecat-ai[sagemaker]"`) — it pins compatible smithy versions and provides a `SageMakerBidiClient` wrapper. Not a general-purpose recommendation; skip for non-voice use cases and use the raw SDK above.

--- a/ai-infra/sagemaker-marketplace-onboarding/templates/Dockerfile
+++ b/ai-infra/sagemaker-marketplace-onboarding/templates/Dockerfile
@@ -1,0 +1,123 @@
+# Dockerfile — SageMaker Marketplace-compatible inference container.
+#
+# ==============================================================================
+#  ONE IMAGE PER ENDPOINT
+# ==============================================================================
+# Marketplace expects exactly ONE Docker image per model listing. Multi-stage
+# builds are fine (and encouraged for smaller final images), but only the FINAL
+# stage's image gets pushed to ECR and referenced from CreateModel. Do NOT try
+# to ship separate "loader" and "server" images — everything the container
+# needs at inference time (weights loader, HTTP server, model runtime) lives
+# in this one image.
+#
+# ==============================================================================
+#  HOW SAGEMAKER STARTS YOUR CONTAINER — the ENTRYPOINT + CMD contract
+# ==============================================================================
+# SageMaker literally runs:
+#
+#     docker run <image> serve
+#
+# Docker resolves that to: whatever is in ENTRYPOINT + "serve" appended as
+# argv. There are two supported patterns; pick ONE:
+#
+#   Pattern A — recommended for single-process containers:
+#     ENTRYPOINT ["python3", "app.py"]
+#     CMD ["serve"]
+#
+#     What happens: docker exec's `python3 app.py serve`. "serve" lands in
+#     sys.argv[1]. app.py can inspect it if you want dual train/serve modes.
+#     Running locally with `docker run <image>` (no args) also works — CMD
+#     provides "serve" as the default. `docker run <image> train` would
+#     replace "serve" with "train" for training use cases.
+#
+#   Pattern B — multi-process containers (see supervisord.conf):
+#     ENTRYPOINT ["/usr/bin/supervisord"]
+#     CMD ["-c", "/etc/supervisord.conf"]
+#
+#     Supervisord ignores the "serve" arg entirely, but that's fine — your
+#     `[program:api-gateway]` block runs `python3 app.py serve` explicitly.
+#
+# ==============================================================================
+#  WHY EXEC FORM (JSON ARRAY) IS REQUIRED
+# ==============================================================================
+# Exec form: ENTRYPOINT ["python3", "app.py"]   ✓
+# Shell form: ENTRYPOINT python3 app.py         ✗ BROKEN
+#
+# Shell form makes Docker wrap the command in `/bin/sh -c "..."`. Signals sent
+# to the container go to sh, which does NOT forward them to your Python
+# process. When SageMaker sends SIGTERM during scale-down, your app never
+# hears it, cannot flush buffers, cannot release GPU memory, and gets
+# SIGKILL'd after 30s. This is one of the most common Marketplace validation
+# failures — check your ENTRYPOINT form BEFORE anything else.
+#
+# ==============================================================================
+#  OTHER RULES THE SPEC ENFORCES (do not violate any of these)
+# ==============================================================================
+#   1. Run as root. Do not add a USER directive. Non-root causes permission
+#      issues with the /opt/ml/model/ mount.
+#   2. Do NOT bundle NVIDIA drivers — SageMaker provides them.
+#   3. Do NOT bake model weights into this image. Weights are packaged
+#      separately as model.tar and mounted at /opt/ml/model/ at deploy time.
+#   4. Do NOT use tini as init — it gets confused by the `serve` argument.
+#   5. Expose port 8080 only. If you run multiple internal processes, use
+#      supervisord and bind everything else to localhost.
+#   6. Container has ZERO outbound network at inference time. Bundle every
+#      dependency; no `pip install` at runtime, no HuggingFace Hub, no
+#      external license servers.
+
+# Use a CUDA runtime image matching the target instance's CUDA version.
+# For g5/g6 (Ampere/Ada) — 12.1 is a safe default. Adjust for other families.
+FROM nvidia/cuda:12.1.0-runtime-ubuntu22.04
+
+# --- (Only if you also implement the WebSocket endpoint /invocations-bidirectional-stream) ---
+# LABEL com.amazonaws.sagemaker.capabilities.bidirectional-streaming=true
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Belt-and-suspenders for HuggingFace ecosystems: hub calls will fail loudly
+# instead of hanging on DNS timeout. Delete or ignore if not using HF libs.
+ENV TRANSFORMERS_OFFLINE=1 \
+    HF_HUB_OFFLINE=1 \
+    HF_DATASETS_OFFLINE=1
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        python3 \
+        python3-pip \
+        python3-venv \
+        ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt /app/
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+COPY app.py model_loader.py inference.py /app/
+
+# SageMaker mounts model.tar contents here at deploy time. Read-only.
+# Do NOT COPY weights into the image.
+# ENV SM_MODEL_DIR=/opt/ml/model   # (default already read by app.py)
+
+EXPOSE 8080
+
+# --- Single-process ENTRYPOINT (default) ---
+# Exec-form ENTRYPOINT is REQUIRED. SageMaker will invoke:
+#   docker run <image> serve
+# The "serve" argument lands in sys.argv[1].
+ENTRYPOINT ["python3", "app.py"]
+CMD ["serve"]
+
+# --- Multi-process ENTRYPOINT (uncomment + comment out the block above) ---
+# Only if you need multiple internal processes (model server + API gateway,
+# inference + metrics sidecar, etc.). See templates/supervisord.conf.
+# Every program in supervisord.conf MUST pipe stdout to /dev/stdout with
+# stdout_logfile_maxbytes=0 — otherwise program logs never reach CloudWatch.
+#
+# RUN apt-get update && apt-get install -y --no-install-recommends supervisor && \
+#     rm -rf /var/lib/apt/lists/*
+# COPY supervisord.conf /etc/supervisord.conf
+# ENTRYPOINT ["/usr/bin/supervisord"]
+# CMD ["-c", "/etc/supervisord.conf"]

--- a/ai-infra/sagemaker-marketplace-onboarding/templates/PRE_SUBMISSION_CHECKLIST.md
+++ b/ai-infra/sagemaker-marketplace-onboarding/templates/PRE_SUBMISSION_CHECKLIST.md
@@ -1,0 +1,59 @@
+# Pre-Submission Checklist
+
+Walk through every item below before pushing to ECR and creating the model package. These are the conditions the SageMaker Marketplace validation job checks against.
+
+## Endpoints
+
+- [ ] `GET /ping` responds within 2 seconds once the model is loaded.
+- [ ] `/ping` **actually verifies the inference code path** (calls `smoke_check()`) — does not return static 200 based on object presence.
+- [ ] `/ping` returns **503** (not 200) while the model is loading or broken.
+- [ ] `POST /invocations` handles the test payload and returns a valid response with a sensible `Content-Type`.
+- [ ] `/invocations` returns non-2xx on error.
+- [ ] `GET /execution-parameters` returns valid values (optional but recommended).
+- [ ] Streaming (if enabled): `Transfer-Encoding: chunked` and chunks arrive progressively.
+
+## Startup and shutdown
+
+- [ ] `/ping` returns 200 within **8 minutes** of `docker run`.
+- [ ] Container shuts down gracefully within 30 seconds of SIGTERM.
+- [ ] `ENTRYPOINT` is exec form (`["python3", "app.py"]`).
+- [ ] `CMD` is `["serve"]`.
+
+## Runtime environment
+
+- [ ] Container runs as root.
+- [ ] Container works under `docker run --network none ...`.
+- [ ] Weights loaded from `/opt/ml/model/` (or `SM_MODEL_DIR`).
+- [ ] No NVIDIA drivers, no tini bundled.
+- [ ] Only port 8080 exposed.
+
+## Model artifacts
+
+- [ ] Weights NOT baked into the Docker image.
+- [ ] `model.tar` is uncompressed.
+- [ ] Weights uploaded to a seller S3 bucket.
+
+## Security
+
+- [ ] Trivy scan passes (no CRITICAL/HIGH).
+- [ ] ECR vulnerability scan passes.
+
+## Contract
+
+- [ ] `/invocations` does not branch on invocation mode.
+- [ ] No dependency on custom HTTP headers.
+- [ ] Only `/tmp` is written to at runtime.
+
+## Bidirectional WebSocket (only if implemented)
+
+- [ ] `/invocations-bidirectional-stream` responds to WebSocket upgrade on port 8080.
+- [ ] `LABEL com.amazonaws.sagemaker.capabilities.bidirectional-streaming=true` is set in the Dockerfile.
+- [ ] Container answers WebSocket Pings with Pongs.
+- [ ] Stateless per-connection; long sessions reconnect client-side.
+- [ ] Errors surface as `ModelStreamError` text frames or Close frames.
+
+## Per-inference billing (only if selected)
+
+- [ ] Metering emitted on every 2XX `/invocations` response via `X-Amzn-Inference-Metering: {"Dimension":"...","ConsumedUnits":N}`. Mini-batch: `ConsumedUnits` = number of inferences processed. No metering on non-2XX.
+- [ ] Dimension name matches the Marketplace listing configuration.
+- [ ] For WebSocket: `X-Amzn-SageMaker-Metadata-Stream-Supported: true` set on upgrade, `/invocations-bidirectional-stream-metadata` implemented.

--- a/ai-infra/sagemaker-marketplace-onboarding/templates/app.py
+++ b/ai-infra/sagemaker-marketplace-onboarding/templates/app.py
@@ -1,0 +1,205 @@
+"""
+SageMaker Marketplace-compatible inference server.
+
+Contract:
+- Runs on port 8080.
+- GET /ping         — Health check. 200 when model loaded, 503 otherwise. Must respond within 2s.
+- POST /invocations — Single entry point for Real-Time, Streaming response, and Batch Transform.
+                      SageMaker gives ZERO indication of which mode the request came from.
+- GET /execution-parameters — Optional. Advertises optimal batch config to SageMaker.
+
+Do NOT bake model weights into the Docker image. Weights are mounted read-only at
+/opt/ml/model/ (via env var SM_MODEL_DIR). See model_loader.py.
+"""
+
+import json
+import logging
+import os
+import signal
+import sys
+import time
+
+import uvicorn
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, Response, StreamingResponse
+
+from inference import predict, predict_stream, smoke_check
+from model_loader import load_model
+
+# --- Opt-in modules — uncomment only if selected in the skill's Phase 2 ---
+# from websocket_handler import router as ws_router
+# from metering import inference_metering_header
+
+# --- Structured logging (goes to CloudWatch via SageMaker stdout capture) ---
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(
+    logging.Formatter(
+        json.dumps(
+            {
+                "time": "%(asctime)s",
+                "level": "%(levelname)s",
+                "msg": "%(message)s",
+            }
+        )
+    )
+)
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+logger.addHandler(handler)
+
+app = FastAPI()
+
+# --- Wire up the bidirectional streaming router if enabled ---
+# app.include_router(ws_router)
+
+MODEL_DIR = os.environ.get("SM_MODEL_DIR", "/opt/ml/model")
+_model = None
+
+
+@app.on_event("startup")
+async def _startup() -> None:
+    """Load the model. Blocks until ready. /ping returns 503 until this exits.
+
+    Total container-startup budget until /ping = 200 is 8 minutes. That budget
+    covers S3 download of model.tar + extraction + this function. Log startup
+    duration so you can spot regressions before you burn the budget.
+
+    Also log the batch-mode env vars if present — useful when debugging why
+    /execution-parameters returned unexpected values.
+    """
+    global _model
+    load_start = time.perf_counter()
+    logger.info(f"Loading model from {MODEL_DIR}")
+    if os.environ.get("SAGEMAKER_BATCH") == "true":
+        logger.info(f"Batch mode: max_payload_mb="
+                    f"{os.environ.get('SAGEMAKER_MAX_PAYLOAD_IN_MB')}, "
+                    f"strategy={os.environ.get('SAGEMAKER_BATCH_STRATEGY')}, "
+                    f"max_concurrent={os.environ.get('SAGEMAKER_MAX_CONCURRENT_TRANSFORMS')}")
+    _model = load_model(MODEL_DIR)
+    load_ms = int((time.perf_counter() - load_start) * 1000)
+    logger.info(f"Model ready (load_ms={load_ms})")
+
+
+@app.get("/ping")
+async def ping() -> Response:
+    """Health check. Return 200 only when a lightweight inference path works.
+
+    The spec is explicit (§3.2): "Do NOT just return a static 200. Verify that
+    the model artifact is loaded, GPU memory is allocated, and the inference
+    code path is functional (lightweight test prediction)." If /ping keeps
+    returning 200 while the model is broken, SageMaker will keep routing
+    traffic to the dead instance instead of replacing it — a silent outage.
+
+    Budget: 2 seconds hard limit. Make smoke_check() cheap (single-token
+    generation, single-frame audio, single 8x8 pixel image, etc.), and cache
+    a "last healthy at" timestamp if the check is close to the budget.
+    """
+    if _model is None:
+        return Response(status_code=503)
+    try:
+        # Runs the actual inference code path. Fails 503 on any exception —
+        # do not swallow. SageMaker uses non-200 as the signal to replace
+        # the instance.
+        smoke_check(_model)
+    except Exception as exc:
+        logger.warning(f"/ping smoke check failed: {exc}")
+        return Response(status_code=503)
+    return Response(status_code=200)
+
+
+@app.post("/invocations")
+async def invocations(request: Request):
+    """The one and only inference endpoint.
+
+    Serves Real-Time, Streaming response, AND Batch Transform. Do not branch on
+    invocation mode — the container cannot tell them apart, and it should not try.
+
+    SageMaker only forwards these headers (all others are stripped):
+      Content-Type, Accept, X-Amzn-SageMaker-Custom-Attributes,
+      X-Amzn-SageMaker-Inference-Id, X-Amzn-SageMaker-Session-Id
+    """
+    content_type = request.headers.get("content-type", "application/json")
+    accept = request.headers.get("accept", "application/json")
+    inference_id = request.headers.get("x-amzn-sagemaker-inference-id", "")
+    body = await request.body()
+
+    start = time.perf_counter()
+    logger.info(f"Invocation received (id={inference_id}, bytes={len(body)}, "
+                f"content-type={content_type})")
+
+    # -----------------------------------------------------------------------
+    # Streaming response path.
+    # Triggered by the client using InvokeEndpointWithResponseStream. The
+    # container still receives a plain POST — the only signal that streaming
+    # is desired comes from the Accept header the provider chooses to use.
+    # A safer pattern: always support a streaming Accept type if your model
+    # can chunk output. Uncomment if you enabled streaming in Phase 0.
+    # -----------------------------------------------------------------------
+    # if accept == "application/x-ndjson":
+    #     async def chunks():
+    #         async for chunk in predict_stream(_model, body, content_type):
+    #             yield chunk
+    #     return StreamingResponse(chunks(), media_type=accept)
+
+    try:
+        result, response_content_type = predict(_model, body, content_type, accept)
+    except Exception as exc:
+        latency_ms = int((time.perf_counter() - start) * 1000)
+        logger.exception(f"Inference failed (id={inference_id}, latency_ms={latency_ms})")
+        return JSONResponse(
+            status_code=500,
+            content={"error": str(exc), "inference_id": inference_id},
+        )
+
+    latency_ms = int((time.perf_counter() - start) * 1000)
+    logger.info(f"Invocation completed (id={inference_id}, latency_ms={latency_ms}, "
+                f"bytes_out={len(result) if isinstance(result, (bytes, bytearray)) else 0})")
+
+    headers = {}
+    # --- Per-inference billing (uncomment if selected in Phase 2) ---
+    # `consumed_units` is whatever your predict() computed as the billable
+    # quantity for this specific invocation. For mini-batch requests that
+    # process multiple inferences in one call, set it to the number of
+    # inferences processed.
+    #
+    # Metering is ONLY honored on 2XX responses. If you return a non-2XX
+    # error, the buyer is not charged. Emit metering on every successful
+    # invocation, or you will not be paid for those calls.
+    #
+    # consumed_units = ...   # e.g. len(tokens_generated), audio_seconds, etc.
+    # headers["X-Amzn-Inference-Metering"] = inference_metering_header(consumed_units)
+
+    return Response(content=result, media_type=response_content_type, headers=headers)
+
+
+@app.get("/execution-parameters")
+async def execution_parameters() -> JSONResponse:
+    """Optional batch optimization hint. SageMaker calls this BEFORE /invocations
+    during Batch Transform to self-tune throughput.
+
+    Values below are conservative defaults — tune for your instance and model.
+    """
+    return JSONResponse(
+        content={
+            "MaxConcurrentTransforms": int(
+                os.environ.get("SAGEMAKER_MAX_CONCURRENT_TRANSFORMS", "4")
+            ),
+            "BatchStrategy": os.environ.get("SAGEMAKER_BATCH_STRATEGY", "SINGLE_RECORD"),
+            "MaxPayloadInMB": int(os.environ.get("SAGEMAKER_MAX_PAYLOAD_IN_MB", "6")),
+        }
+    )
+
+
+def _graceful_shutdown(signum, frame) -> None:
+    """SageMaker sends SIGTERM on shutdown. You have 30 seconds before SIGKILL."""
+    logger.info(f"Received signal {signum}; shutting down")
+    # Close any open resources here: release GPU memory, flush buffers, etc.
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    # SageMaker invokes: docker run <image> serve
+    # sys.argv[1] will be "serve"
+    signal.signal(signal.SIGTERM, _graceful_shutdown)
+    signal.signal(signal.SIGINT, _graceful_shutdown)
+    uvicorn.run(app, host="0.0.0.0", port=8080, log_level="info")

--- a/ai-infra/sagemaker-marketplace-onboarding/templates/inference.py
+++ b/ai-infra/sagemaker-marketplace-onboarding/templates/inference.py
@@ -1,0 +1,151 @@
+"""
+Framework-specific inference logic. The SKILL walkthrough will help fill this
+in based on the framework selected during Discovery.
+
+Three entry points:
+- smoke_check(model)                          — cheap sanity check run on every
+                                                /ping request. REQUIRED. Do not
+                                                make /ping a static 200.
+- predict(model, body, content_type, accept)  — single request/response
+- predict_stream(model, body, content_type)   — async generator that yields
+                                                chunks (only needed if streaming
+                                                was selected in Discovery)
+"""
+
+import io
+import json
+import zipfile
+from typing import AsyncIterator, Dict, Tuple
+
+
+def zip_outputs(files: Dict[str, bytes]) -> bytes:
+    """Zip multiple output files for a single /invocations response.
+
+    Use when your model produces >1 output artifact per invocation (e.g.
+    generated image + metadata json, transcribed text + speaker labels).
+    The container cannot write to S3 at runtime — return everything in one
+    zip and let the customer split on their side.
+
+    Set Content-Type: application/zip on the response (see predict() return).
+
+    Example:
+        return zip_outputs({
+            "image.png": png_bytes,
+            "metadata.json": json.dumps(meta).encode(),
+        }), "application/zip"
+
+    Keeps the zip in memory (io.BytesIO) — do not use /tmp unless the outputs
+    are very large (say, >100 MB total).
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for filename, data in files.items():
+            zf.writestr(filename, data)
+    return buf.getvalue()
+
+
+def smoke_check(model) -> None:
+    """Verify the inference code path is actually alive.
+
+    Called on every /ping request. Must complete well under 2 seconds. Raise
+    an exception (or return without raising) — the caller in app.py converts
+    exceptions to 503. Do NOT swallow errors here.
+
+    The spec is explicit: `/ping` that always returns 200 while the model is
+    broken keeps SageMaker routing traffic to the dead instance. This function
+    is what makes /ping *actually* meaningful.
+
+    Keep it CHEAP. Some cheap smoke checks by modality:
+      LLM      → generate 1 token from a fixed prompt
+      STT      → decode 100ms of pre-baked silence
+      TTS      → synthesize a single phoneme
+      Image    → forward-pass on a tiny (e.g. 8x8 or 32x32) tensor
+      Embed    → embed a fixed 1-token string
+      ONNX     → session.run on a cached warm-up tensor
+
+    Common pattern: run the smoke inference ONCE at startup, cache the input
+    tensor, and reuse it here.
+    """
+    # ------------------------------------------------------------------
+    # TODO — replace with a cheap inference call.
+    #
+    # PyTorch example:
+    #   with torch.no_grad():
+    #       _ = model(cached_smoke_input)   # cached_smoke_input built at load time
+    #
+    # HuggingFace generation example:
+    #   _ = model["model"].generate(cached_input_ids, max_new_tokens=1)
+    #
+    # ONNX Runtime example:
+    #   _ = model.run(None, {"input": cached_np_input})
+    # ------------------------------------------------------------------
+    raise NotImplementedError(
+        "Implement smoke_check() — /ping must verify the inference path, "
+        "not just object presence. See the spec §3.2."
+    )
+
+
+def predict(model, body: bytes, content_type: str, accept: str) -> Tuple[bytes, str]:
+    """Run one inference and return (response_bytes, response_content_type).
+
+    Parameters
+    ----------
+    model : the object returned by model_loader.load_model()
+    body  : raw request bytes. Up to 25 MB for Real-Time, 100 MB per record
+            for Batch Transform.
+    content_type : the buyer's Content-Type header (e.g. "application/json",
+                   "audio/wav"). Use this to parse the body.
+    accept : the buyer's Accept header. Use to decide response encoding.
+
+    Returns
+    -------
+    (response_bytes, response_content_type)
+        response_content_type should be "application/json" for JSON,
+        "application/zip" if you zipped multiple output files, etc.
+    """
+    # ------------------------------------------------------------------
+    # TODO — replace with your model's predict logic.
+    #
+    # Common patterns:
+    #
+    # JSON in, JSON out:
+    #     payload = json.loads(body)
+    #     result = model.predict(payload["input"])
+    #     return json.dumps({"output": result}).encode(), "application/json"
+    #
+    # Audio in, JSON out (transcription):
+    #     with io.BytesIO(body) as buf:
+    #         waveform, sr = torchaudio.load(buf)
+    #     text = model.transcribe(waveform, sr)
+    #     return json.dumps({"text": text}).encode(), "application/json"
+    #
+    # Multiple output files -> zip (see zip_outputs() helper below):
+    #     outputs = {"result.png": png_bytes, "metadata.json": meta_bytes}
+    #     return zip_outputs(outputs), "application/zip"
+    #
+    # If a step needs disk (e.g. ffmpeg piping through a temp file):
+    #   /tmp IS THE ONLY WRITABLE PATH. /opt/ml/model is read-only.
+    #   Use tempfile.NamedTemporaryFile(dir="/tmp"), and always clean up —
+    #   /tmp is shared across concurrent requests and does not survive
+    #   container restarts.
+    #     with tempfile.NamedTemporaryFile(dir="/tmp", suffix=".wav") as tf:
+    #         tf.write(body); tf.flush()
+    #         result = subprocess.run(["ffmpeg", "-i", tf.name, ...], ...)
+    # ------------------------------------------------------------------
+    raise NotImplementedError("Replace predict() with your model's inference logic.")
+
+
+async def predict_stream(model, body: bytes, content_type: str) -> AsyncIterator[bytes]:
+    """Yield response chunks for InvokeEndpointWithResponseStream.
+
+    Only needed if streaming response was selected in Phase 0. Each yielded
+    bytes object becomes a PayloadPart event on the client side.
+
+    Example (LLM token streaming):
+        payload = json.loads(body)
+        for token in model.generate_stream(payload["prompt"]):
+            yield json.dumps({"token": token}).encode() + b"\\n"
+    """
+    raise NotImplementedError(
+        "Replace predict_stream() if streaming response was selected."
+    )

--- a/ai-infra/sagemaker-marketplace-onboarding/templates/metering.py
+++ b/ai-infra/sagemaker-marketplace-onboarding/templates/metering.py
@@ -87,14 +87,48 @@ def make_metering_frame(
     """
     Build the JSON metering frame sent on the companion metadata WebSocket
     (/invocations-bidirectional-stream-metadata) for bidirectional streaming
-    per-inference billing.
+    per-inference billing (GA capability -- see "Introducing usage-based
+    pricing for Amazon SageMaker bidirectional streaming",
+    https://aws.amazon.com/blogs/machine-learning/introducing-usage-based-pricing-for-amazon-sagemaker-bidirectional-streaming/).
 
-    ClientToken is a per-frame idempotency key. Auto-generated if empty.
+    ClientToken is a per-frame idempotency key (max 64 chars). Auto-generated
+    if empty. A duplicate ClientToken sent again on the same connection is
+    recorded only once by SageMaker.
+
+    Constraints enforced by the metadata channel (validate before sending,
+    not after -- SageMaker silently drops malformed frames rather than
+    erroring back):
+      - Dimension: max 128 characters.
+      - ConsumedUnits: must be > 0.
+      - Exactly ONE metering record per WebSocket text frame -- never batch
+        multiple records into one frame.
+      - Max frame size: 512 bytes total (the serialized JSON, not just the
+        payload). A long ClientToken/Dimension can blow this budget on
+        otherwise-small payloads -- keep both short.
+      - Max send rate: 1 message per second per connection. Sending faster
+        risks dropped messages; batch your own accounting and flush at most
+        once per second rather than one frame per inference event.
+      - Text frames only -- binary frames are not accepted for metering.
+
+    Recommended calling pattern: call this once per second (or per natural
+    accounting boundary, e.g. every N seconds of audio processed) with the
+    INCREMENTAL units consumed since the last call, not a running total.
+    Sending incrementally means a mid-stream disconnect still gets the
+    provider paid for usage reported up to that point.
     """
-    return {
+    frame = {
         "Metering": {
             "Dimension": dimension,
             "ConsumedUnits": int(consumed_units),
             "ClientToken": client_token or str(uuid.uuid4()),
         }
     }
+    encoded_len = len(json.dumps(frame).encode("utf-8"))
+    if encoded_len > 512:
+        raise ValueError(
+            f"metering frame is {encoded_len} bytes; SageMaker's metadata "
+            "channel caps frames at 512 bytes -- shorten Dimension/ClientToken"
+        )
+    if len(dimension) > 128:
+        raise ValueError("Dimension exceeds the 128-character limit")
+    return frame

--- a/ai-infra/sagemaker-marketplace-onboarding/templates/metering.py
+++ b/ai-infra/sagemaker-marketplace-onboarding/templates/metering.py
@@ -1,0 +1,100 @@
+"""
+Per-inference billing metering for SageMaker Marketplace.
+
+This module is opt-in. Only include it if your Marketplace listing uses
+per-inference (usage-based) pricing rather than hourly pricing.
+
+Two emission modes, depending on which endpoint is being billed:
+
+1) Standard /invocations (Real-Time, Streaming response, Batch Transform):
+   Emit metering as an HTTP RESPONSE header. The value is a JSON string.
+
+       X-Amzn-Inference-Metering: {"Dimension": "inference.count", "ConsumedUnits": 3}
+
+   Mini-batch semantics: if a single /invocations call processes multiple
+   inferences (e.g. batching several inputs per request), set ConsumedUnits
+   to the number of inferences processed. For a single-inference call, use 1.
+
+   IMPORTANT: AWS Marketplace only charges the buyer for responses with
+   HTTP status codes in the 2XX range. Do not emit metering on 4XX/5XX
+   responses — it will be ignored. Conversely, if you return 200 with a
+   silent error body, you WILL be paid, so make error paths return proper
+   non-2XX status codes.
+
+2) Bidirectional WebSocket (/invocations-bidirectional-stream):
+   Metering goes on a COMPANION metadata WebSocket at
+   /invocations-bidirectional-stream-metadata, NOT on the main data stream.
+   Container signals support via X-Amzn-SageMaker-Metadata-Stream-Supported: true
+   in the WebSocket upgrade response, then emits frames like:
+       {"Metering": {"Dimension": "audio_seconds", "ConsumedUnits": 150,
+                     "ClientToken": "<uuid>"}}
+
+The DIMENSION name (e.g., "inference.count", "audio_seconds",
+"characters_processed", "tokens") must match what you configure on the
+Marketplace listing. SageMaker meters and bills based on this value.
+
+CRITICAL: If per-inference billing is enabled on your listing but the
+container fails to emit metering, you will not be paid for those invocations.
+Emit metering on EVERY successful /invocations response.
+
+Documentation: https://docs.aws.amazon.com/marketplace/latest/userguide/machine-learning-pricing.html
+"""
+
+import json
+import uuid
+from typing import Any, Dict
+
+
+# Set this to the dimension name you registered on your Marketplace listing.
+# Common values:
+#   - "inference.count"        — one unit per invocation (simple)
+#   - "audio_seconds"          — seconds of audio processed (STT/TTS)
+#   - "characters_synthesized" — characters generated (TTS)
+#   - "tokens"                 — LLM tokens produced
+#   - "pixels"                 — image pixels processed
+#   - "images"                 — image count (image classification/generation)
+DIMENSION = "inference.count"
+
+
+def inference_metering_header(consumed_units: int, dimension: str = DIMENSION) -> str:
+    """
+    Format the value for the X-Amzn-Inference-Metering response header on a
+    standard /invocations response.
+
+    Example:
+        response.headers["X-Amzn-Inference-Metering"] = \\
+            inference_metering_header(3)
+        # → '{"Dimension": "inference.count", "ConsumedUnits": 3}'
+
+    For mini-batch requests where the invocation processes multiple inferences,
+    pass the batch size:
+        inference_metering_header(len(batch_inputs))
+
+    Only emit this on 2XX responses — Marketplace ignores metering on error
+    responses (and does not charge the buyer).
+    """
+    return json.dumps({
+        "Dimension": dimension,
+        "ConsumedUnits": int(consumed_units),
+    })
+
+
+def make_metering_frame(
+    consumed_units: int,
+    dimension: str = DIMENSION,
+    client_token: str = "",
+) -> Dict[str, Any]:
+    """
+    Build the JSON metering frame sent on the companion metadata WebSocket
+    (/invocations-bidirectional-stream-metadata) for bidirectional streaming
+    per-inference billing.
+
+    ClientToken is a per-frame idempotency key. Auto-generated if empty.
+    """
+    return {
+        "Metering": {
+            "Dimension": dimension,
+            "ConsumedUnits": int(consumed_units),
+            "ClientToken": client_token or str(uuid.uuid4()),
+        }
+    }

--- a/ai-infra/sagemaker-marketplace-onboarding/templates/model_loader.py
+++ b/ai-infra/sagemaker-marketplace-onboarding/templates/model_loader.py
@@ -1,0 +1,80 @@
+"""
+Loads model weights from /opt/ml/model/ (or wherever SM_MODEL_DIR points).
+
+SageMaker mounts model.tar contents at /opt/ml/model/ (read-only) BEFORE the
+container starts serving. You cannot hardcode weights into the Docker image —
+that path is populated at deploy time.
+
+Cold-start budget: total 8 minutes from `docker run` until /ping returns 200.
+That includes S3 download of model.tar, extraction, and this function.
+"""
+
+import os
+from pathlib import Path
+
+
+def load_model(model_dir: str):
+    """Load and return the model object.
+
+    Called once at container startup. Blocks until the model is ready.
+    The FastAPI /ping route returns 503 until this returns.
+
+    Typical layouts inside model_dir:
+        /opt/ml/model/model_weights/config.json
+        /opt/ml/model/model_weights/model.safetensors
+        /opt/ml/model/model_weights/tokenizer.json
+        /opt/ml/model/config/inference_config.yaml
+    """
+    model_dir = Path(model_dir)
+    if not model_dir.exists():
+        raise RuntimeError(
+            f"Model directory {model_dir} does not exist. "
+            "SageMaker mounts model.tar contents here. Verify that "
+            "ModelDataUrl points at a valid model.tar in S3 and that the "
+            "packaging step (package_model.sh) ran successfully."
+        )
+
+    # ------------------------------------------------------------------
+    # TODO — replace this block with your framework's load logic.
+    #
+    # !!! NETWORK ISOLATION !!!
+    # The container has ZERO outbound network at runtime. This means any code
+    # that reaches out to a remote hub or S3 will silently fail during model
+    # load — and your endpoint will hit the 8-minute startup timeout.
+    #
+    # Common footguns:
+    #   - transformers `AutoModel.from_pretrained("org/model-name")`
+    #     — hub form, DOWNLOADS. Use `from_pretrained(<local-path>)` only.
+    #     Set `local_files_only=True` for safety.
+    #   - huggingface_hub `snapshot_download`, `hf_hub_download`
+    #   - `torch.hub.load(...)` — downloads from github
+    #   - Any git-lfs pull, wget, curl in the loader
+    #   - Even the DEFAULT tokenizer cache: some tokenizers phone home to
+    #     validate. Set `TRANSFORMERS_OFFLINE=1`, `HF_HUB_OFFLINE=1`, and
+    #     `HF_DATASETS_OFFLINE=1` in the Dockerfile ENV.
+    #
+    # HuggingFace Transformers example (LOCAL PATH ONLY):
+    #   from transformers import AutoModelForCausalLM, AutoTokenizer
+    #   weights = model_dir / "model_weights"
+    #   tokenizer = AutoTokenizer.from_pretrained(weights, local_files_only=True)
+    #   model = AutoModelForCausalLM.from_pretrained(
+    #       weights, torch_dtype="auto", device_map="auto", local_files_only=True,
+    #   )
+    #   return {"model": model, "tokenizer": tokenizer}
+    #
+    # Plain PyTorch example:
+    #   import torch
+    #   model = torch.load(model_dir / "model_weights" / "model.pt", map_location="cuda")
+    #   model.eval()
+    #   return model
+    #
+    # ONNX Runtime example:
+    #   import onnxruntime as ort
+    #   sess = ort.InferenceSession(str(model_dir / "model_weights" / "model.onnx"),
+    #                               providers=["CUDAExecutionProvider"])
+    #   return sess
+    # ------------------------------------------------------------------
+
+    raise NotImplementedError(
+        "Replace load_model() with your framework's loading code."
+    )

--- a/ai-infra/sagemaker-marketplace-onboarding/templates/package_model.sh
+++ b/ai-infra/sagemaker-marketplace-onboarding/templates/package_model.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Package model weights into model.tar for SageMaker Marketplace.
+#
+# The output goes to Marketplace-managed encrypted storage during
+# CreateModelPackage. Customers never see the raw weights — SageMaker
+# mounts them at /opt/ml/model/ inside the running container.
+#
+# Usage:  ./package_model.sh <weights-dir> <s3-uri>
+# Example: ./package_model.sh ./model_artifacts s3://my-seller-bucket/my-model/model.tar
+
+set -euo pipefail
+
+WEIGHTS_DIR="${1:-}"
+S3_URI="${2:-}"
+
+if [[ -z "$WEIGHTS_DIR" || -z "$S3_URI" ]]; then
+    echo "Usage: $0 <weights-dir> <s3-uri>"
+    echo "  weights-dir : local directory containing weight files, tokenizer, config"
+    echo "  s3-uri      : s3://<bucket>/<key> where model.tar will be uploaded"
+    exit 1
+fi
+
+if [[ ! -d "$WEIGHTS_DIR" ]]; then
+    echo "Weights directory $WEIGHTS_DIR does not exist"
+    exit 1
+fi
+
+# Use UNCOMPRESSED tar. The spec warns that gzip decompression adds 1–3 minutes
+# to cold start for large models — SageMaker has a hard 8-minute startup window.
+echo "Packaging $WEIGHTS_DIR into model.tar (uncompressed)..."
+tar -cf model.tar -C "$WEIGHTS_DIR" .
+
+echo ""
+echo "Contents of model.tar:"
+tar -tf model.tar | head -50
+echo ""
+
+SIZE_BYTES=$(stat -f%z model.tar 2>/dev/null || stat -c%s model.tar)
+SIZE_GB=$(awk "BEGIN {printf \"%.2f\", $SIZE_BYTES/1024/1024/1024}")
+echo "model.tar size: ${SIZE_GB} GB"
+echo ""
+
+echo "Uploading to $S3_URI..."
+aws s3 cp model.tar "$S3_URI"
+
+echo ""
+echo "Done. Reference this S3 URI as ModelDataUrl when creating your SageMaker Model:"
+echo "  $S3_URI"
+echo ""
+echo "Reminder: after CreateModelPackage, weights are transferred to a Marketplace-"
+echo "managed bucket and encrypted with a Marketplace KMS key. Keep a backup of the"
+echo "source weights — you will lose direct access to the version you just uploaded."

--- a/ai-infra/sagemaker-marketplace-onboarding/templates/requirements.txt
+++ b/ai-infra/sagemaker-marketplace-onboarding/templates/requirements.txt
@@ -1,0 +1,9 @@
+fastapi==0.115.0
+uvicorn[standard]==0.30.6
+# Add your model's dependencies here. Pin versions.
+# Examples:
+#   torch==2.4.0
+#   transformers==4.44.2
+#   accelerate==0.34.2
+#   safetensors==0.4.5
+#   onnxruntime-gpu==1.19.2

--- a/ai-infra/sagemaker-marketplace-onboarding/templates/supervisord.conf
+++ b/ai-infra/sagemaker-marketplace-onboarding/templates/supervisord.conf
@@ -1,0 +1,47 @@
+; Multi-process container config for SageMaker Marketplace.
+;
+; Use only when your container needs multiple internal processes (e.g. a model
+; server + an API gateway, or an inference process + a metrics sidecar).
+; Single-process containers should just use `ENTRYPOINT ["python3", "app.py"]`
+; in the Dockerfile instead — do not add supervisord for the sake of it.
+;
+; Critical rules:
+;   - Only port 8080 is visible to SageMaker. Every other internal process
+;     MUST bind to localhost. The FastAPI gateway is what the outside world
+;     reaches; it forwards to internal processes.
+;   - Every program MUST pipe stdout/stderr to /dev/stdout with
+;     `stdout_logfile_maxbytes=0`. Without this, program logs never reach
+;     CloudWatch — SageMaker only captures the container's own stdout.
+;   - `nodaemon=true` so supervisord runs in the foreground (PID 1). This is
+;     what lets SageMaker's SIGTERM propagate to child processes.
+
+[supervisord]
+nodaemon=true
+user=root
+
+[program:model-server]
+; Internal model server. Binds to localhost only — never expose beyond 8080.
+command=python3 model_server.py
+priority=1
+autostart=true
+autorestart=true
+stopsignal=TERM
+stopwaitsecs=25   ; SageMaker gives the container 30s after SIGTERM; leave buffer
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:api-gateway]
+; FastAPI on port 8080 — the ONLY thing SageMaker sees.
+; `serve` is the arg SageMaker passes: docker run <image> serve
+command=python3 app.py serve
+priority=2
+autostart=true
+autorestart=true
+stopsignal=TERM
+stopwaitsecs=25
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/ai-infra/sagemaker-marketplace-onboarding/templates/test/test_input.json
+++ b/ai-infra/sagemaker-marketplace-onboarding/templates/test/test_input.json
@@ -1,0 +1,4 @@
+{
+  "input": "replace this with a realistic sample of what your customers will send",
+  "parameters": {}
+}

--- a/ai-infra/sagemaker-marketplace-onboarding/templates/test/test_local.sh
+++ b/ai-infra/sagemaker-marketplace-onboarding/templates/test/test_local.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Local smoke tests for a SageMaker Marketplace-compatible container.
+# Run every test. If any fails, do not push to ECR — SageMaker will fail too.
+#
+# Usage: ./test_local.sh <image-tag> <weights-dir>
+# Example: ./test_local.sh my-model:latest ./model_artifacts
+
+set -euo pipefail
+
+IMAGE="${1:-my-model:latest}"
+WEIGHTS_DIR="${2:-./model_artifacts}"
+CONTAINER_NAME="sagemaker-marketplace-test"
+
+cleanup() {
+    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    docker rm -f "${CONTAINER_NAME}-isolated" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "==============================================================="
+echo "1. Starting container exactly as SageMaker would"
+echo "==============================================================="
+docker run --gpus all --rm \
+    --publish 8080:8080/tcp \
+    --volume "$(realpath "$WEIGHTS_DIR"):/opt/ml/model:ro" \
+    --detach --name "$CONTAINER_NAME" \
+    "$IMAGE" serve
+
+echo "Waiting up to 8 minutes for /ping to return 200..."
+DEADLINE=$(( $(date +%s) + 480 ))
+while (( $(date +%s) < DEADLINE )); do
+    if curl --silent --fail --max-time 2 http://127.0.0.1:8080/ping >/dev/null; then
+        echo "  /ping returned 200"
+        break
+    fi
+    sleep 5
+done
+
+if ! curl --silent --fail --max-time 2 http://127.0.0.1:8080/ping >/dev/null; then
+    echo "  FAILED: /ping did not return 200 within 8 minutes"
+    docker logs "$CONTAINER_NAME" | tail -50
+    exit 1
+fi
+
+echo ""
+echo "==============================================================="
+echo "2. /invocations with sample payload"
+echo "==============================================================="
+RESPONSE=$(curl --silent --max-time 60 -X POST \
+    -H "Content-Type: application/json" \
+    --data-binary @test/test_input.json \
+    http://127.0.0.1:8080/invocations)
+echo "  Response: $RESPONSE"
+
+echo ""
+echo "==============================================================="
+echo "3. /execution-parameters"
+echo "==============================================================="
+curl --silent --max-time 2 http://127.0.0.1:8080/execution-parameters
+echo ""
+
+echo ""
+echo "==============================================================="
+echo "4. SIGTERM graceful shutdown (must complete within 30s)"
+echo "==============================================================="
+START=$(date +%s)
+docker stop --time 30 "$CONTAINER_NAME"
+ELAPSED=$(( $(date +%s) - START ))
+echo "  Shutdown took ${ELAPSED}s (must be <=30s)"
+if (( ELAPSED > 30 )); then
+    echo "  FAILED: container was SIGKILLed. Check ENTRYPOINT — it must be exec form."
+    exit 1
+fi
+
+echo ""
+echo "==============================================================="
+echo "5. WebSocket smoke test (only if the container implements it)"
+echo "==============================================================="
+if [[ -f "test/test_websocket.py" ]] && \
+   docker exec "$CONTAINER_NAME" python3 -c "import websockets" >/dev/null 2>&1 || \
+   command -v python3 >/dev/null 2>&1; then
+    # Restart the main container since we already stopped it above
+    docker run --gpus all --rm \
+        --publish 8080:8080/tcp \
+        --volume "$(realpath "$WEIGHTS_DIR"):/opt/ml/model:ro" \
+        --detach --name "$CONTAINER_NAME" \
+        "$IMAGE" serve
+    # Wait for /ping again
+    DEADLINE=$(( $(date +%s) + 480 ))
+    while (( $(date +%s) < DEADLINE )); do
+        curl --silent --fail --max-time 2 http://127.0.0.1:8080/ping >/dev/null && break
+        sleep 5
+    done
+    if python3 test/test_websocket.py; then
+        echo "  WebSocket smoke test passed"
+    else
+        echo "  WebSocket smoke test failed — skipping if this container doesn't"
+        echo "  implement /invocations-bidirectional-stream (that's fine)."
+    fi
+fi
+
+echo ""
+echo "==============================================================="
+echo "6. Network isolation (--network none) — container must still start"
+echo "==============================================================="
+docker run --gpus all --rm \
+    --network none \
+    --volume "$(realpath "$WEIGHTS_DIR"):/opt/ml/model:ro" \
+    --detach --name "${CONTAINER_NAME}-isolated" \
+    "$IMAGE" serve
+
+# Give it a moment to start; then check that /ping eventually goes healthy
+# via `docker exec` since we published no port for the isolated run.
+sleep 60
+if docker exec "${CONTAINER_NAME}-isolated" \
+        python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/ping', timeout=2)"; then
+    echo "  Container started under --network none. Good."
+else
+    echo "  FAILED: container has a runtime dependency on external services."
+    echo "  Common causes: HuggingFace Hub download, pip install at startup,"
+    echo "  license server, S3 access."
+    docker logs "${CONTAINER_NAME}-isolated" | tail -50
+    exit 1
+fi
+
+echo ""
+echo "==============================================================="
+echo "All local tests passed."
+echo "==============================================================="

--- a/ai-infra/sagemaker-marketplace-onboarding/templates/test/test_streaming.py
+++ b/ai-infra/sagemaker-marketplace-onboarding/templates/test/test_streaming.py
@@ -1,0 +1,59 @@
+"""
+Test streaming response from /invocations.
+
+The container returns Transfer-Encoding: chunked; each chunk becomes a
+PayloadPart event on the SageMaker client side when the customer uses
+InvokeEndpointWithResponseStream.
+
+This test simulates that by reading the raw HTTP response in chunks and
+confirming they arrive progressively rather than all at once.
+"""
+
+import json
+import sys
+import time
+
+import requests
+
+
+def main(url: str = "http://127.0.0.1:8080/invocations",
+         payload_path: str = "test/test_input.json",
+         accept: str = "application/x-ndjson") -> None:
+    with open(payload_path, "rb") as f:
+        payload = f.read()
+
+    headers = {"Content-Type": "application/json", "Accept": accept}
+    print(f"POST {url}")
+    print(f"  Accept: {accept}")
+
+    start = time.perf_counter()
+    with requests.post(url, data=payload, headers=headers, stream=True, timeout=480) as r:
+        r.raise_for_status()
+        print(f"  Status: {r.status_code}")
+        print(f"  Transfer-Encoding: {r.headers.get('Transfer-Encoding', '(none)')}")
+        if r.headers.get("Transfer-Encoding") != "chunked":
+            print("  WARNING: response is not chunked. Streaming may not be enabled.")
+
+        chunk_count = 0
+        first_chunk_at = None
+        for chunk in r.iter_content(chunk_size=None):
+            if not chunk:
+                continue
+            if first_chunk_at is None:
+                first_chunk_at = time.perf_counter() - start
+            chunk_count += 1
+            elapsed = time.perf_counter() - start
+            print(f"  [chunk #{chunk_count} at +{elapsed:.2f}s, {len(chunk)}B]: "
+                  f"{chunk[:120]!r}")
+
+    if chunk_count < 2:
+        print("  WARNING: only one chunk received. Streaming does not appear to work.")
+        print("  Confirm predict_stream() yields incrementally and app.py uses "
+              "StreamingResponse for this Accept type.")
+        sys.exit(1)
+
+    print(f"  Time-to-first-chunk: {first_chunk_at:.2f}s (target: <1s for good UX)")
+
+
+if __name__ == "__main__":
+    main()

--- a/ai-infra/sagemaker-marketplace-onboarding/templates/test/test_websocket.py
+++ b/ai-infra/sagemaker-marketplace-onboarding/templates/test/test_websocket.py
@@ -1,0 +1,57 @@
+"""
+Local test for /invocations-bidirectional-stream.
+
+Verifies:
+- WebSocket handshake succeeds
+- Container responds to WebSocket Ping frames (Pong reply)
+- Text and Binary frames flow both directions
+- Graceful close on client disconnect
+
+Requires: pip install websockets
+
+This test hits the container directly on ws://localhost:8080. To test against
+a deployed SageMaker endpoint (HTTP/2 on port 8443 with SigV4), use the AWS
+`aws_sdk_sagemaker_runtime_http2` SDK — see reference/websocket.md for install
+notes (Python 3.12+, pre-alpha status, awscrt platform wheels).
+"""
+
+import asyncio
+import json
+import sys
+
+import websockets
+
+
+async def test() -> None:
+    uri = "ws://127.0.0.1:8080/invocations-bidirectional-stream"
+
+    async with websockets.connect(uri) as ws:
+        print("Connected")
+
+        # 1) Send a client Ping; expect a Pong within a reasonable window.
+        pong_waiter = await ws.ping()
+        await asyncio.wait_for(pong_waiter, timeout=5)
+        print("Ping/Pong OK")
+
+        # 2) Send an initial config Text frame (adjust for your protocol).
+        config = json.dumps({"sample_rate": 16000, "language": "en"})
+        await ws.send(config)
+
+        # 3) Send a small Binary frame (adjust to something your model accepts).
+        await ws.send(b"\x00" * 3200)  # 100ms of 16kHz 16-bit silence
+
+        # 4) Receive at least one response frame with a short timeout.
+        try:
+            reply = await asyncio.wait_for(ws.recv(), timeout=5)
+            print(f"Received: {reply[:200]!r}")
+        except asyncio.TimeoutError:
+            print("WARNING: no response within 5s — model may still be warming up")
+            sys.exit(1)
+
+        # 5) Graceful close.
+        await ws.close()
+        print("Closed cleanly")
+
+
+if __name__ == "__main__":
+    asyncio.run(test())

--- a/ai-infra/sagemaker-marketplace-onboarding/templates/websocket_handler.py
+++ b/ai-infra/sagemaker-marketplace-onboarding/templates/websocket_handler.py
@@ -1,0 +1,149 @@
+"""
+Bidirectional WebSocket endpoint for SageMaker Marketplace.
+
+This module is opt-in. Only include it if your model needs
+InvokeEndpointWithBidirectionalStream (STT, TTS, real-time voice, etc.).
+
+Contract:
+- Endpoint path: /invocations-bidirectional-stream
+- Protocol: WebSocket on port 8080. SageMaker terminates HTTP/2 externally
+  and translates to WebSocket internally — your container only sees WebSocket.
+- Must respond to WebSocket Ping frames (SageMaker sends every 60s;
+  5 consecutive missed Pongs → connection closed).
+- Max connection duration: 30 MINUTES. Client reconnects after.
+- Errors: send Text frame with {"ModelStreamError": {"ErrorCode": "...",
+  "Message": "..."}} OR send a Close frame with a status code + reason.
+
+Required Docker label (in Dockerfile):
+    LABEL com.amazonaws.sagemaker.capabilities.bidirectional-streaming=true
+
+Without this label, SageMaker will NOT route WebSocket traffic to the container.
+
+Per-inference billing (opt-in, further):
+    See metering.py. Metering for bidirectional streaming goes on a COMPANION
+    metadata WebSocket at /invocations-bidirectional-stream-metadata, NOT on
+    the main data stream.
+
+Fragmentation (advanced):
+    The SageMaker protocol maps WebSocket Data Frame FIN=0 → PayloadPart
+    CompletionState=PARTIAL, and Continuation Frame FIN=1 → COMPLETE. If you
+    need to emit PARTIAL/COMPLETE semantics (e.g. streaming a single logical
+    message across many audio chunks), you cannot use FastAPI's default
+    `websocket.send_text()` / `send_bytes()` — those always emit unfragmented
+    frames (FIN=1). To emit fragmented frames, either:
+      1) Drop down to raw ASGI send with `type="websocket.send"` and a
+         custom FIN bit — non-trivial, framework-version dependent, OR
+      2) Use the `websockets` library directly (bypass FastAPI's WebSocket
+         wrapper) via a custom ASGI route. It exposes `fragmented=` on send.
+    For most use cases, sending each chunk as a separate complete Text or
+    Binary frame is fine — SageMaker treats each as its own PayloadPart with
+    CompletionState=COMPLETE. Fragmentation is only necessary when the
+    receiving client depends on the PARTIAL/COMPLETE grouping semantics.
+"""
+
+import json
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from inference import handle_stream_session   # provider writes this
+try:
+    from metering import make_metering_frame  # only present if per-inference opted in
+    METERING_ENABLED = True
+except ImportError:
+    METERING_ENABLED = False
+
+logger = logging.getLogger()
+
+router = APIRouter()
+
+
+@router.websocket("/invocations-bidirectional-stream")
+async def bidirectional_stream(websocket: WebSocket) -> None:
+    # If per-inference billing is enabled, signal that we support a companion
+    # metadata channel BEFORE calling accept().
+    if METERING_ENABLED:
+        # FastAPI does not expose upgrade-response headers directly; the
+        # recommended way is to set them on accept() via `subprotocol` or
+        # response headers on a raw ASGI send. Uvicorn 0.30+ supports
+        # setting headers on websocket.accept via the `headers` keyword.
+        await websocket.accept(
+            headers=[(b"x-amzn-sagemaker-metadata-stream-supported", b"true")]
+        )
+    else:
+        await websocket.accept()
+
+    inference_id = websocket.headers.get("x-amzn-sagemaker-inference-id", "")
+    session_id = websocket.headers.get("x-amzn-sagemaker-session-id", "")
+    logger.info(f"WS session opened (inference_id={inference_id}, session_id={session_id})")
+
+    try:
+        # Hand off to the provider's per-connection handler. The handler is
+        # a coroutine that reads from the websocket and writes back frames.
+        # Keep it STATELESS between connections — sessions >30min must
+        # reconnect at the application layer, not persist server-side.
+        await handle_stream_session(websocket)
+
+    except WebSocketDisconnect:
+        logger.info(f"WS client disconnected (inference_id={inference_id})")
+
+    except Exception as exc:
+        logger.exception(f"WS session error (inference_id={inference_id})")
+        # Send a ModelStreamError text frame so the client sees a structured error
+        try:
+            await websocket.send_text(json.dumps({
+                "ModelStreamError": {
+                    "ErrorCode": type(exc).__name__,
+                    "Message": str(exc),
+                }
+            }))
+            await websocket.close(code=1011, reason="internal error")
+        except Exception:
+            pass  # already closed
+
+
+@router.websocket("/invocations-bidirectional-stream-metadata")
+async def bidirectional_metadata(websocket: WebSocket) -> None:
+    """
+    Companion metadata channel for per-inference billing on bidirectional
+    streaming connections.
+
+    SageMaker opens this second WebSocket in parallel with the main data
+    connection, matching by X-Amzn-SageMaker-Request-Id header. The container
+    sends billing frames on this channel while the main channel carries only
+    inference data.
+
+    Only wire this up if per-inference billing is enabled. Otherwise leave
+    the route unregistered — SageMaker will not open the metadata channel
+    unless the main endpoint's upgrade response advertises
+    X-Amzn-SageMaker-Metadata-Stream-Supported: true.
+    """
+    if not METERING_ENABLED:
+        await websocket.close(code=1002, reason="metering not enabled")
+        return
+
+    await websocket.accept()
+    request_id = websocket.headers.get("x-amzn-sagemaker-request-id", "")
+    logger.info(f"WS metadata channel opened (request_id={request_id})")
+
+    try:
+        # The provider signals billable units by calling report_metering()
+        # from inside handle_stream_session on the main channel. The bridge
+        # between the two is application-defined; a common pattern is a
+        # per-request asyncio.Queue keyed by request_id. Example scaffold:
+        #
+        #   from metering_bridge import get_queue
+        #   queue = get_queue(request_id)
+        #   while True:
+        #       units, dimension, client_token = await queue.get()
+        #       frame = make_metering_frame(units, dimension, client_token)
+        #       await websocket.send_text(json.dumps(frame))
+        #
+        # TODO — replace with your metering-bridge implementation.
+        while True:
+            msg = await websocket.receive_text()  # keep alive
+            logger.debug(f"metadata channel received: {msg[:120]}")
+
+    except WebSocketDisconnect:
+        logger.info(f"WS metadata channel closed (request_id={request_id})")


### PR DESCRIPTION
## What

Adds a Claude Code skill (`ai-infra/sagemaker-marketplace-onboarding/`) that walks a model provider through making their container compatible with the AWS SageMaker Marketplace container contract: `/ping` + `/invocations` (Real-Time, Streaming, Async, Batch Transform), optional bidirectional WebSocket, optional per-inference metering, weights packaging, local testing, ECR push, and a `CreateModelPackage` hand-off for sellers who also want to publish.

## Commits

1. **feat**: skill added verbatim (SKILL.md, 8 reference docs, 15 scaffold templates), scaffolded under `ai-infra/` to match this repo's existing `ai-coding-assistants/skills/aws-bento-deck` layout.
2. **docs**: added `reference/iam-temporary-delegation.md` — buyer-approved, time-limited (≤12h) STS access for post-launch customer support, replacing long-lived cross-account IAM roles. Sourced from the AWS ML blog "Deepgram enhances Amazon SageMaker AI support with AWS IAM Temporary Delegation."
3. **docs**: added `reference/observability.md` — SageMaker's automatic CloudWatch metrics, detailed observability (per-GPU/host Prometheus via PromQL), and CloudWatch Embedded Metric Format (EMF) for container-emitted business metrics under network isolation. Sourced from the AWS ML blog "Deepgram deepens Amazon SageMaker AI observability with Enhanced Metrics." Added a Phase 12 ("operating a live listing") pointer section to `SKILL.md` covering both new references.
4. **docs**: added `README.md` with install instructions (Claude Code plugin marketplace + manual copy, Codex, Kiro), matching the existing `aws-bento-deck` skill's docs. Registered the skill as an installable plugin (`.claude-plugin/plugin.json` + an entry in the repo-root `.claude-plugin/marketplace.json`).
5. **docs+feat**: implemented usage-based pricing for bidirectional streaming — the companion metadata WebSocket protocol (`/invocations-bidirectional-stream-metadata`): opt-in headers including `X-Amzn-SageMaker-Metadata-Stream-Required` and `-Invocation-Path`, message schema, size/rate limits (512 bytes, 1 msg/sec, one record per frame, text-only), and the 4-scenario failure-mode table. Updated `reference/websocket.md`, `reference/billing.md`, `templates/metering.py` (frame-size/dimension validation + incremental-emission guidance), and both checklists (`reference/checklist.md`, `reference/gap-checks.md`).
6. **docs**: added `reference/pipecat-integration.md` — how Pipecat's open-source voice-agent framework wraps a SageMaker bidirectional-streaming endpoint. Covers the 3-layer client architecture grounded in the real `pipecat-ai/pipecat` source, a control-message-vocabulary table (Speak/Flush/Clear/KeepAlive/Finalize/Close), both real Pipecat contribution paths (community-maintained repo vs. core PR), and an illustrative (not scaffolded) service-wrapper code appendix.
7. **feat**: wired the Pipecat reference into the skill's active flow — a Phase 5 pointer for STT/TTS providers designing their WebSocket protocol, a new optional Phase 13 ("Pipecat ecosystem hand-off") that triggers on modality STT/TTS + WebSocket implemented + Phase 8 passed (independent of Phase 0's goal flag), offering a single AskUserQuestion (skip / community-maintained repo / core PR) and walking the applicable requirements checklist — and the reference-index entry.
8. **docs**: added a lightweight, ask-first pointer to CloudWatch EMF metering-mirroring in Phase 5 (only when per-inference billing was selected).

## Related

Cross-linking for reviewer awareness: [guidance-for-voice-agents-on-aws#34](https://github.com/aws-solutions-library-samples/guidance-for-voice-agents-on-aws/pull/34) adds a "Publishing a SageMaker Model" guide that points model providers at this skill (Marketplace compliance) and its `reference/pipecat-integration.md` (Pipecat compatibility) as the two prerequisites for getting a model consumable in that Guidance's architecture.

## Design notes on the two most recent additions

**Pipecat orchestration (commits 6–7):** wired into the skill as a fully optional Phase 13, not a default code-generation path. The service-wrapper code the skill points to is documented as an *illustrative appendix*, not a scaffolded template — a generic Pipecat wrapper can't be genuinely fill-in-the-blank because it must match whatever bespoke WebSocket control-message vocabulary the seller's own container implements (which this skill deliberately doesn't mandate). Phase 13 helps the user adapt that appendix to their own protocol, in a separate Pipecat-integration repo or fork — never the seller's own model container project.

**EMF metering-mirroring (commit 8):** intentionally doc-pointer-only, not wired into `templates/metering.py` by default. It's a self-serve convenience for sellers who want their own CloudWatch copy to reconcile against the AWS bill — not required for Marketplace billing, which is already handled correctly by the `X-Amzn-Inference-Metering` header / metadata-channel frame. Wiring it into the default templates would need a heavier validation pass (non-blocking design so a metrics bug can never affect the payment-critical header/frame value, plus a Phase 8 test-gate check that EMF `ConsumedUnits` exactly matches the header). Left as an explicit ask-first option in Phase 5 rather than default behavior; promoting it to a default template is a clean, separately-scoped follow-up if sellers consistently want it.

Both choices follow this skill's existing pattern (e.g. Phase 11's `CreateModelPackage` hand-off): point, ask, and generate/act only on explicit confirmation — never auto-generate code or take action the user didn't ask for.

## Testing

Skill content only (no executable app-runtime changes beyond `metering.py`'s validation helper) — verified structure matches the existing `aws-bento-deck` skill layout, and cross-checked reference doc claims (EMF mechanics, IAM temporary delegation permissions/duration caps, SageMaker metric names, bidi metering frame limits, Pipecat's real source and contribution requirements) against the respective AWS/Deepgram/Pipecat source docs linked in each file.

