### PR TITLE
Add plugin-importer Agent Plugin

### DIFF
--- a/ai-coding-assistants/agent-plugins/README.md
+++ b/ai-coding-assistants/agent-plugins/README.md
@@ -5,5 +5,6 @@ Plugins packaged in the vendor-neutral [Agent Plugins 1.0.0](https://agent-plugi
 | Plugin | What it does |
 |---|---|
 | [aws-diagram-design](./aws-diagram-design) | AWS-branded editorial diagrams (27 types, official icons, Amazon Ember) as HTML/SVG/PNG; draw.io and Mermaid redraw; read-only current-state diagrams from a live account. |
+| [plugin-importer](./plugin-importer) | Brings plugins already installed through Claude Code or Codex into Kiro, packaging unchanged — or imports straight from a marketplace GitHub URL. |
 
 Related: [kiro-powers](../kiro-powers) holds Powers in the earlier `POWER.md` format.

--- a/ai-coding-assistants/agent-plugins/plugin-importer/CHANGELOG.md
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## 1.1.0
 
+- Marketplace metadata is treated as untrusted. An entry's `name` must be a single path segment
+  (`[\w.-]{1,64}`); a string `source` or a remote `path` must resolve inside its repository.
+  Entries that fail either check are skipped with a warning, and the install directory is checked
+  against its base before anything is copied. The `CLAUDE_PLUGIN_ROOT` prefix in generated hook
+  commands is shell-quoted.
+- `--project-local` installs are recorded in the project's `.kiro/.kiro-port-manifest.json` — skills,
+  hooks, agents and the MCP server keys merged into `.kiro/settings/mcp.json`. `unport` run from that
+  project removes exactly those, the staging copy under `.kiro/.ported/` is deleted after the install,
+  and hook scripts the plugin ships are kept under `.kiro/.kiro-port-assets/<name>/` so the installed
+  hooks still resolve.
+- `unport` exits non-zero and changes nothing when it finds no record of the name, instead of
+  printing `removed`.
+- `--as skills` on a plugin with no `skills/` directory no longer crashes and leaves a half-built
+  staging directory behind; it reports that there is nothing to place and points at `--as power`.
+- `tests/regression-test.py` — 71 checks against synthetic fixtures in an isolated `KIRO_HOME`, no
+  framework, no network.
 - Flat-list `hooks.json` variants (`{"hooks": [{"event": ...}]}`) are now accepted alongside the
   nested form, without renaming event names — they carry over unchanged.
 - Skills-only installs no longer silently drop everything when a folder name collides with an

--- a/ai-coding-assistants/agent-plugins/plugin-importer/CHANGELOG.md
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+## 1.1.0
+
+- Flat-list `hooks.json` variants (`{"hooks": [{"event": ...}]}`) are now accepted alongside the
+  nested form, without renaming event names — they carry over unchanged.
+- Skills-only installs no longer silently drop everything when a folder name collides with an
+  already-installed skill of a different plugin — if nothing could be copied, the report says so and
+  suggests `--as power`.
+- Symlinked files inside a plugin are copied by content, not re-linked — a relative symlink pointing
+  outside the plugin directory (common in marketplaces with shared files) no longer breaks after the
+  copy.
+- A skill that references a sibling folder without a `SKILL.md` (shared assets, not itself a skill) now
+  has that folder copied alongside it in skills-only installs.
+- `${CLAUDE_PLUGIN_ROOT}` substitutions that point into an intermediate staging directory are
+  redirected to the permanent asset path when that directory is removed after a skills-only install,
+  instead of being left dangling.
+
+## 1.0.0
+
+First release.
+
+- `scan` lists plugins installed through Claude Code or Codex, with each one's components and a
+  recommended destination. `--from` reads a marketplace or plugin repository instead, following
+  entries that point at another git repository.
+- `port` converts and installs. Skill-bearing plugins go to `~/.kiro/skills/` with their hooks and
+  agents alongside, so slash commands and hooks both keep working; plugins with `commands/` or MCP
+  servers become Powers. `--as skills` / `--as power` override, `--project-local` writes into the
+  current project, `--out` generates without installing.
+- `unport` removes everything an import installed and leaves the original plugin untouched.
+- Bodies are copied byte-for-byte and checked after the copy. The only substitution is
+  `${CLAUDE_PLUGIN_ROOT}` → the installed path.
+- Hooks are rewritten to Kiro's `v1` schema with tool matchers mapped. Fields Kiro has no equivalent
+  for — `if`, `timeout`, `asyncRewake` — are reported rather than dropped silently, and `shell` is
+  honoured by wrapping the command.
+- `keywords` are derived from plugin and skill names only; anything beyond that is recommended in the
+  report and never written without asking.

--- a/ai-coding-assistants/agent-plugins/plugin-importer/LICENSE
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/LICENSE
@@ -1,0 +1,16 @@
+MIT No Attribution
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/ai-coding-assistants/agent-plugins/plugin-importer/README.ko.md
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/README.ko.md
@@ -110,6 +110,7 @@ Kiro는 슬래시가 아니라 **키워드**로 Power를 켭니다. 이 플러�
 | `skills/import-plugins` | 스킬 | 이식을 진행하고 보고서를 읽어주고 키워드를 제안합니다. |
 | `skills/import-plugins/scripts/kiro-port.py` | 스크립트 | 변환기. Python 3.11+, 표준 라이브러리만. |
 | `skills/import-plugins/references/kiro-mapping.md` | 참고 자료 | 컴포넌트별 대응과 Kiro 동작. |
+| `tests/regression-test.py` | 테스트 | `python3 tests/regression-test.py` — 임시 `KIRO_HOME`에 합성 픽스처를 이식해 확인합니다. 프레임워크·네트워크 없음. |
 
 변환기를 직접 쓰려면:
 

--- a/ai-coding-assistants/agent-plugins/plugin-importer/README.ko.md
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/README.ko.md
@@ -28,6 +28,10 @@ Kiro **Powers** 패널 → **Add Custom Power** → **Import power from a folder
 `ai-coding-assistants/agent-plugins/plugin-importer` 선택. 이 디렉터리의 GitHub 주소를 붙여 넣어도 됩니다.
 Power는 세션 시작 시 로드되므로 설치 후 새 세션을 여세요.
 
+**Kiro는 `kiro-cli --v3`로 실행하세요.** 클래식 모드나 `--no-interactive`에서도 Power·스킬은 정상 로드되지만,
+훅은 조용히 아무 동작도 하지 않습니다 — 어느 쪽이든 `/hooks`는 0으로 표시됩니다. 이식된 플러그인의 훅이
+실제로 발동하려면 `--v3`가 필요합니다.
+
 `python3`(3.11+)와 `git`이 `PATH`에 있어야 합니다. macOS·kiro-cli 2.21.0 환경을 기준으로 만들고
 점검했습니다. 다른 플랫폼·버전은 아직 확인하지 않았습니다.
 

--- a/ai-coding-assistants/agent-plugins/plugin-importer/README.ko.md
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/README.ko.md
@@ -1,0 +1,128 @@
+# plugin-importer
+
+[English](README.md) | **한국어**
+
+**Claude Code나 Codex에서 설치해 쓰던 플러그인을, 내용 그대로 Kiro에서.**
+
+Kiro용 [Agent Plugins 1.0.0](https://agent-plugins.org/) 규격 플러그인입니다. 한 번 설치하고 옮겨달라고
+말하면 됩니다. Claude Code(`/plugin install …`)나 Codex(`codex plugin add …`)로 설치한 기록을 읽어 각
+플러그인을 바이트 단위로 복사하고, Kiro가 읽는 파일 하나를 더해 등록합니다. Claude Code나 Codex 형식으로만
+배포되는 제품은 마켓플레이스 GitHub 주소만으로 가져옵니다.
+
+> "Claude Code에서 쓰던 플러그인 전부 Kiro로 옮겨줘"
+> "obra/superpowers-marketplace 마켓플레이스 Kiro로 가져와줘"
+
+두 형식은 **내용물**을 이미 공유합니다. SKILL.md, 훅 스크립트, MCP 정의가 양쪽에서 같습니다. 다른 것은
+포장뿐입니다. Anthropic의 포장은 Agent Plugins 표준에 포함되지 않아, Claude Code 플러그인은 Kiro에서 그대로
+열리지 않습니다. 이 플러그인은 그 포장만 더합니다.
+
+## 설치
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/aws-samples/sample-apj-sup-sa.git
+cd sample-apj-sup-sa
+git sparse-checkout set ai-coding-assistants/agent-plugins/plugin-importer
+```
+
+Kiro **Powers** 패널 → **Add Custom Power** → **Import power from a folder** →
+`ai-coding-assistants/agent-plugins/plugin-importer` 선택. 이 디렉터리의 GitHub 주소를 붙여 넣어도 됩니다.
+Power는 세션 시작 시 로드되므로 설치 후 새 세션을 여세요.
+
+`python3`(3.11+)와 `git`이 `PATH`에 있어야 합니다. macOS·kiro-cli 2.21.0 환경을 기준으로 만들고
+점검했습니다. 다른 플랫폼·버전은 아직 확인하지 않았습니다.
+
+## 사용
+
+말하면 됩니다. 명령을 외울 필요는 없습니다.
+
+```
+> Claude Code와 Codex에서 쓰던 플러그인 보여줘        # 목록만 보여주고 아무것도 바꾸지 않는다
+> commit-commands, frontend-design 옮겨줘            # 원하는 것만 이름으로 지목
+> commit-commands 제거해줘                           # 되돌리기
+```
+
+`~/.claude/plugins/` 와 `~/.codex/` 에서 찾은 것을 구성과 목적지와 함께 나열합니다. 옮긴 것을 쓰려면 새
+세션을 엽니다.
+
+Claude Code의 **프로젝트 스코프** 설치는 Kiro를 그 프로젝트 안에서 실행할 때만 대상이 됩니다. Claude Code의
+가시성 규칙과 같습니다. *"이 프로젝트에만"* 이라고 하면 전역 설치 대신 프로젝트의 `.kiro/` 에 씁니다.
+
+### 남의 마켓플레이스에서
+
+벤더가 `/plugin marketplace add acme/acme-plugins` 후 `/plugin install acme-review@acme-plugins` 를
+안내하는 경우, Kiro에서는 문장 하나입니다.
+
+```
+> acme/acme-plugins 에서 acme-review 가져와줘
+```
+
+저장소를 받아 `.claude-plugin/marketplace.json` 을 읽고 지정한 플러그인을 변환해 등록합니다. 항목이 다른
+git 저장소를 가리켜도 따라갑니다. 원하는 것을 이름으로 지목하세요. 큰 마켓플레이스는 항목이 수천 개입니다.
+
+## 플러그인이 어디로 가는가
+
+판단 기준은 하나입니다. **Power 없이도 그 자리에서 작동하는가.** 작동하면 Power를 씌우지 않습니다. Power는
+키워드를 통과해야 켜지고 슬래시 명령을 잃는 대가가 있으니, 꼭 필요할 때만 씁니다.
+
+- **스킬**은 Kiro가 이미 표준으로 읽습니다. `~/.kiro/skills/`에 놓기만 하면 되고, Power가 전혀 필요 없습니다.
+- **훅**은 파일이 `~/.kiro/hooks/`에 있으면 그 자체로 발화합니다. Power 등록 여부와 무관합니다. 그래서 스킬과
+  훅이 같이 있는 플러그인이라도 훅 때문에 Power가 필요해지지 않습니다. 둘 다 스킬 쪽 경로로 보냅니다.
+- **명령**은 Kiro에 그 개념이 없어서 스킬로 바꿔야 하는데, 그 변환 결과를 담을 곳이 Power뿐입니다. Power 필수.
+- **MCP 서버**는 Power가 활성화될 때만 연결됩니다. Power 필수.
+- **에이전트만 있고 스킬이 없으면** 옮길 스킬이 없으니 Power를 만들어 그 안에 채웁니다.
+- **마크다운 지침뿐**이면 아예 옮기지 않습니다. Power는 키워드로 켜지는데 지침은 늘 적용돼야 하므로, Power로
+  만드는 순간 제작자의 의도가 바뀝니다.
+
+| 플러그인 구성 | 목적지 | 이유 |
+|---|---|---|
+| `commands/` 또는 `.mcp.json` 있음 | Power | 이 둘은 Power만 담을 수 있습니다 |
+| 스킬 있음 (훅·에이전트가 함께 있어도) | `~/.kiro/skills/` + `~/.kiro/hooks/` + `~/.kiro/agents/` | 스킬은 이미 Power 없이 작동하고, 훅도 마찬가지라 슬래시와 훅을 둘 다 유지합니다 |
+| 스킬 없이 훅·에이전트만 | Power | 담을 자리가 필요해서입니다 |
+| 마크다운 지침뿐 | 옮기지 않고 `~/.kiro/steering/` 경로만 안내 | Power는 조건부, steering은 항상 적용이라 성격이 다릅니다 |
+
+`--as skills` 와 `--as power` 로 뒤집을 수 있습니다. 지침 파일은 자동 변환하지 않습니다. `inclusion: always`
+가 붙은 steering 파일이 원래 지침처럼 항상 적용된다는 점에서 더 가깝습니다.
+
+본문은 바이트 단위로 복사되고, 하나라도 다르면 이식이 중단됩니다. 원본 `.claude-plugin/`·`commands/`·
+`agents/` 는 제자리에 남아서 그 디렉터리가 Claude Code 플러그인으로도 계속 쓰입니다. Kiro에 대응이 없는 것
+— `SessionEnd`·`UserPromptExpansion` 훅, `argument-hint`, `.toml` 명령, 원격(`http`·`sse`) MCP 서버,
+에이전트의 `tools`·`model` 제한 — 은 비슷한 것으로 흉내 내지 않고 기록합니다.
+
+**컴포넌트별 상세는 `references/kiro-mapping.md`** 에 있습니다. 버그를 찾아 나서기 전에 알아둘 Kiro 동작도
+함께 있습니다. Power 안 스킬은 슬래시로 호출되지 않고, Power의 원격 MCP 서버는 무시되며, 마크다운 에이전트는
+세션을 그 에이전트로 시작해야 적용됩니다.
+
+## 키워드 — 사람이 정하는 항목
+
+Kiro는 슬래시가 아니라 **키워드**로 Power를 켭니다. 이 플러그인은 키워드를 플러그인·스킬 이름에서만 채우고
+그 이상은 지어내지 않습니다. 제작자가 고르지 않은 단어는 제작자가 의도하지 않은 상황에서 Power를 켜기
+때문입니다. 대신 이식이 끝나면 각 표현이 맡는 상황과 함께 몇 개를 제안하고, `plugin.json` 에 넣는 것은
+승인을 받은 뒤에 합니다. 옮긴 뒤 뭔가 켜지지 않는다면 거의 항상 이것이 원인입니다.
+
+## 구성
+
+| 컴포넌트 | 종류 | 역할 |
+|---|---|---|
+| `skills/import-plugins` | 스킬 | 이식을 진행하고 보고서를 읽어주고 키워드를 제안합니다. |
+| `skills/import-plugins/scripts/kiro-port.py` | 스크립트 | 변환기. Python 3.11+, 표준 라이브러리만. |
+| `skills/import-plugins/references/kiro-mapping.md` | 참고 자료 | 컴포넌트별 대응과 Kiro 동작. |
+
+변환기를 직접 쓰려면:
+
+```bash
+S=~/.kiro/powers/installed/plugin-importer/skills/import-plugins/scripts/kiro-port.py
+python3 $S scan                                   # Claude Code / Codex 설치 목록
+python3 $S port superpowers commit-commands       # 변환·설치·등록
+python3 $S port --from acme/acme-plugins --all    # 마켓플레이스 저장소에서 직접
+python3 $S port eli5 --as skills                  # 강제로 폴더 복사
+python3 $S port ralph-loop --project-local        # 전역 대신 ./.kiro/ 에
+python3 $S port --all --out ./powers              # 생성만 — 모노레포로 배포할 때
+python3 $S unport superpowers                     # 제거
+```
+
+`--out` 은 Claude Code 마켓플레이스를 Kiro 설치용 모노레포로 바꾸는 방법입니다. 생성된 디렉터리 하나하나가
+완전한 플러그인이면서 Claude Code 플러그인으로도 그대로 작동합니다.
+
+## 라이선스
+
+MIT-0 — [LICENSE](LICENSE) 참고.

--- a/ai-coding-assistants/agent-plugins/plugin-importer/README.md
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/README.md
@@ -1,0 +1,139 @@
+# plugin-importer
+
+**English** | [한국어](README.ko.md)
+
+**The plugins you installed in Claude Code or Codex, running in Kiro — contents untouched.**
+
+An [Agent Plugins 1.0.0](https://agent-plugins.org/) plugin for Kiro. Install it once, then ask for
+your plugins. It reads what you installed through Claude Code (`/plugin install …`) or Codex
+(`codex plugin add …`), copies each plugin byte-for-byte, adds the one file Kiro needs, and registers
+the result. It also imports straight from a marketplace GitHub URL, for products published only in
+Claude Code or Codex format.
+
+> "Claude Code에서 쓰던 플러그인 전부 Kiro로 옮겨줘"
+> "Bring `obra/superpowers-marketplace` into Kiro"
+
+Both formats already share their *contents*: SKILL.md files, hook scripts and MCP definitions are the
+same on either side. Only the packaging differs. Anthropic's packaging is not part of the Agent
+Plugins standard, so a Claude Code plugin does not load in Kiro as it stands. This adds the packaging
+and nothing else.
+
+## Install
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/aws-samples/sample-apj-sup-sa.git
+cd sample-apj-sup-sa
+git sparse-checkout set ai-coding-assistants/agent-plugins/plugin-importer
+```
+
+Kiro **Powers** panel → **Add Custom Power** → **Import power from a folder** → select
+`ai-coding-assistants/agent-plugins/plugin-importer`. Pasting this directory's GitHub URL works too.
+Start a new session afterwards; Powers load at session start.
+
+Requires `python3` (3.11+) and `git` on `PATH`. Built and exercised on macOS against kiro-cli
+2.21.0; other platforms and versions have not been checked.
+
+## Usage
+
+Ask; you do not need the commands.
+
+```
+> Claude Code와 Codex에서 쓰던 플러그인 보여줘        # lists what is installed, changes nothing
+> commit-commands, frontend-design 옮겨줘            # name the ones you want
+> commit-commands 제거해줘                           # undo
+```
+
+Everything found in `~/.claude/plugins/` and `~/.codex/` is listed with its components and a
+destination. Open a new session to use the imported plugins.
+
+Claude Code **project-scoped** installs are offered only when Kiro runs inside that project, mirroring
+Claude Code's own visibility. Say *"이 프로젝트에만"* to write into the project's `.kiro/` instead of
+installing globally.
+
+### From someone else's marketplace
+
+A vendor tells your team to run `/plugin marketplace add acme/acme-plugins` and
+`/plugin install acme-review@acme-plugins`. From Kiro that is one sentence:
+
+```
+> acme/acme-plugins 에서 acme-review 가져와줘
+```
+
+The importer fetches the repository, reads its `.claude-plugin/marketplace.json`, and converts and
+registers the plugin you named. Entries pointing at another git repository are followed. Name the plugins
+you want — a large marketplace has thousands of entries.
+
+## Where a plugin lands
+
+One question decides it: **does this work without a Power?** If it does, no Power gets built. A
+Power only activates after a keyword match and costs the plugin its slash commands, so it is used
+only where nothing else can carry the component.
+
+- **Skills** already work — Kiro reads the Agent Skills standard directly. Straight to
+  `~/.kiro/skills/`, no Power needed.
+- **Hooks** fire on their own once the file sits in `~/.kiro/hooks/`, Power registration or not. So a
+  plugin with both skills and hooks sends both down the skills path: it keeps its slash commands and
+  its hooks still fire.
+- **Commands** have no Kiro equivalent; they become skills, and a Power is the only place to put the
+  result. Required.
+- **MCP servers** connect only when their Power activates. Required.
+- **Agents with no skills** need somewhere to live, so a Power is built to hold them.
+- **Markdown guidance alone** is not moved at all. A Power activates on keywords; guidance is meant to
+  always apply, so wrapping it in a Power would change what the author intended.
+
+| Plugin holds | Destination | Why |
+|---|---|---|
+| `commands/` or `.mcp.json` | a Power | Only a Power can carry these |
+| skills, with or without hooks and agents | `~/.kiro/skills/`, plus `~/.kiro/hooks/` and `~/.kiro/agents/` | Skills already work without a Power, and so do hooks — both slash commands and hooks survive |
+| hooks or agents but no skills | a Power | Somewhere to hold them |
+| Markdown guidance only | nothing moved; `~/.kiro/steering/` path only | A Power is conditional; steering is always-on — different jobs |
+
+`--as skills` and `--as power` override this. Guidance files are never converted automatically — a
+steering file with `inclusion: always` is the closer match, since it stays always-on the way the
+guidance did.
+
+Bodies are copied byte-for-byte and the import aborts if one differs. The original
+`.claude-plugin/`, `commands/` and `agents/` stay in place, so the same directory still works as a
+Claude Code plugin. Anything Kiro has no equivalent for — `SessionEnd` and `UserPromptExpansion`
+hooks, `argument-hint`, `.toml` commands, remote (`http`/`sse`) MCP servers, an agent's `tools` and
+`model` limits — is reported rather than approximated.
+
+**`references/kiro-mapping.md` has the per-component detail**, along with the Kiro behaviours worth
+knowing before you go looking for a bug: skills inside a Power are not slash commands, remote MCP
+servers in a Power are ignored, and a markdown agent applies only when the session starts with it.
+
+## Keywords — the one thing you decide
+
+Kiro activates a Power by **keywords**, not by slash command. The importer fills them from the plugin
+and skill names and refuses to invent more: a keyword the author never chose would activate the Power
+in situations the author never intended. After each import it suggests a few phrases with the
+situation each covers, and asks before writing any of them into `plugin.json`. If something does not
+activate after an import, this is almost always why.
+
+## Contents
+
+| Component | Kind | What it does |
+|---|---|---|
+| `skills/import-plugins` | skill | Runs the import, reads the report back, suggests keywords. |
+| `skills/import-plugins/scripts/kiro-port.py` | script | The converter. Python 3.11+, standard library only. |
+| `skills/import-plugins/references/kiro-mapping.md` | reference | Per-component mapping and Kiro behaviours. |
+
+Running the converter directly, if you prefer:
+
+```bash
+S=~/.kiro/powers/installed/plugin-importer/skills/import-plugins/scripts/kiro-port.py
+python3 $S scan                                   # what Claude Code / Codex have installed
+python3 $S port superpowers commit-commands       # convert, install, register
+python3 $S port --from acme/acme-plugins --all    # straight from a marketplace repo
+python3 $S port eli5 --as skills                  # force a plain folder copy
+python3 $S port ralph-loop --project-local        # into ./.kiro/ instead of globally
+python3 $S port --all --out ./powers              # generate only, e.g. to publish a monorepo
+python3 $S unport superpowers                     # remove
+```
+
+`--out` turns a Claude Code marketplace into a Kiro-installable monorepo: each generated directory is
+a complete plugin that still works as a Claude Code plugin.
+
+## License
+
+MIT-0 — see [LICENSE](LICENSE).

--- a/ai-coding-assistants/agent-plugins/plugin-importer/README.md
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/README.md
@@ -30,6 +30,10 @@ Kiro **Powers** panel → **Add Custom Power** → **Import power from a folder*
 `ai-coding-assistants/agent-plugins/plugin-importer`. Pasting this directory's GitHub URL works too.
 Start a new session afterwards; Powers load at session start.
 
+**Run Kiro with `kiro-cli --v3`.** Classic mode and `--no-interactive` sessions load Powers and skills
+fine, but hooks silently do nothing in them — `/hooks` reports 0 either way. `--v3` is required for a
+ported plugin's hooks to fire at all.
+
 Requires `python3` (3.11+) and `git` on `PATH`. Built and exercised on macOS against kiro-cli
 2.21.0; other platforms and versions have not been checked.
 

--- a/ai-coding-assistants/agent-plugins/plugin-importer/README.md
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/README.md
@@ -121,6 +121,7 @@ activate after an import, this is almost always why.
 | `skills/import-plugins` | skill | Runs the import, reads the report back, suggests keywords. |
 | `skills/import-plugins/scripts/kiro-port.py` | script | The converter. Python 3.11+, standard library only. |
 | `skills/import-plugins/references/kiro-mapping.md` | reference | Per-component mapping and Kiro behaviours. |
+| `tests/regression-test.py` | tests | `python3 tests/regression-test.py` — ports synthetic fixtures into a temporary `KIRO_HOME`. No framework, no network. |
 
 Running the converter directly, if you prefer:
 

--- a/ai-coding-assistants/agent-plugins/plugin-importer/plugin.json
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/plugin.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "plugin-importer",
+  "version": "1.1.0",
+  "description": "Bring the plugins you installed from Claude Code or Codex marketplaces into Kiro — contents untouched, only the packaging changes. Skill-bearing plugins land in ~/.kiro/skills/ with their hooks and agents; plugins with commands or MCP servers become Powers. Also imports straight from a marketplace GitHub URL.",
+  "author": {
+    "name": "AWS APJ Startup Solutions Architects"
+  },
+  "homepage": "https://github.com/aws-samples/sample-apj-sup-sa/tree/main/ai-coding-assistants/agent-plugins/plugin-importer",
+  "repository": "https://github.com/aws-samples/sample-apj-sup-sa",
+  "license": "MIT-0",
+  "keywords": [
+    "클로드에서 쓰던 플러그인 가져와",
+    "claude 플러그인 가져와",
+    "코덱스 플러그인 가져와",
+    "쓰던 플러그인 옮겨",
+    "플러그인 가져와",
+    "플러그인 옮겨",
+    "플러그인 이식",
+    "플러그인 마이그레이션",
+    "마켓플레이스 가져와",
+    "설치한 플러그인 보여줘",
+    "bring my claude code plugins",
+    "import claude code plugin",
+    "import codex plugin",
+    "migrate plugin to kiro",
+    "port plugin to kiro",
+    "plugin marketplace import",
+    "claude code plugin",
+    "codex plugin",
+    "plugin marketplace"
+  ]
+}

--- a/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/SKILL.md
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: import-plugins
+description: Bring plugins the user already installed in Claude Code or Codex into Kiro, or import one straight from a marketplace GitHub URL. Use when the user mentions Claude Code plugins, Codex plugins, a plugin marketplace, or asks to bring, move, port or migrate their plugins to Kiro. Not for authoring a new plugin from loose files.
+---
+
+# Import Claude Code / Codex plugins into Kiro
+
+A script does the conversion. You run it, read its report back to the user, and help with the one
+decision it refuses to make: activation keywords. **Never edit plugin contents yourself** — the
+script copies bodies byte-for-byte and stops if one differs, and that guarantee is the point of this
+skill.
+
+The script is at a fixed path. Set it once:
+
+```bash
+S=~/.kiro/powers/installed/plugin-importer/skills/import-plugins/scripts/kiro-port.py
+```
+
+If that path is missing, `ls ~/.kiro/powers/installed/*/skills/import-plugins/scripts/` to find it.
+Never glob the home directory — it takes minutes and finds nothing useful.
+
+## 1. See what there is
+
+```bash
+python3 $S scan                      # what Claude Code and Codex have installed
+python3 $S scan --from <source>      # a marketplace or plugin repo: URL, owner/repo, or local path
+```
+
+`scan` prints each plugin's components and where it recommends putting them. Show that list grouped
+by tool. Project-scoped Claude Code installs appear only when Kiro runs inside that project, matching
+Claude Code's own visibility.
+
+With `--from`, entries whose source points at another git repository print as `원격: <url>`. `port`
+fetches only the ones you name, so always pass explicit names unless the marketplace is small.
+
+**Ask which ones rather than defaulting to everything.** Each Power the user does not need is context
+they pay for every session, and plugins carrying `node_modules` can exhaust the editor's file
+descriptors — the script excludes those trees and warns past 2,000 files.
+
+## 2. Port
+
+```bash
+python3 $S port <name>[@<market>] ...          # or --all
+python3 $S port --from <source> <name>...
+```
+
+Follow the recommendation from `scan` unless the user wants otherwise:
+
+| Plugin holds | Goes to |
+|---|---|
+| `commands/` or `.mcp.json` | a Power — only a Power can carry those |
+| skills (hooks and agents may come along) | `~/.kiro/skills/`, plus `~/.kiro/hooks/` and `~/.kiro/agents/` |
+| hooks or agents but no skills | a Power |
+| Markdown guidance only | nothing is moved; report the `~/.kiro/steering/` path and stop |
+
+`--as skills` and `--as power` override it. `--as skills` on a plugin with commands or MCP drops
+those, and the script says so. `--project-local` writes into the current project's `.kiro/` instead of
+installing globally. `--out DIR` only generates, which is how you turn a marketplace into a
+Kiro-installable monorepo. `--smoke` checks that Kiro loads the result.
+
+## 3. Report back, then offer keywords
+
+For each plugin:
+
+1. Say what came over and what the report marked `❌` or `⚠️`. **Do not soften the losses.** See
+   `references/kiro-mapping.md` for what each one means.
+2. `keywords` were derived from names only. Read the plugin's description and its skills'
+   `description` lines, then append to the report:
+
+   ```
+   ## 권장 키워드
+   이 Power가 켜져야 하는 상황에서 사용자가 실제로 칠 단어입니다. 적용하려면 plugin.json 의 keywords 에 추가하세요.
+   - 커밋       — "커밋해줘", "변경사항 커밋" 같은 요청
+   - PR 만들기  — …
+   ```
+
+   Three to six phrases in the user's language, each with the situation it covers. **Recommend only** —
+   do not write them into `plugin.json` unless asked.
+3. Tell them to start a new session. Powers and skills load at session start.
+4. If the plugin went into a Power (skills stayed inside it, not `~/.kiro/skills/`), warn that asking
+   for a skill by name — or even naming the Power itself — often fails, because the model's file
+   search does not reliably look inside `~/.kiro/powers/installed/`; it can go either way with the
+   same phrasing. The one thing that works every time is giving the skill's exact path
+   (`~/.kiro/powers/installed/<plugin>/skills/<skill>/SKILL.md`).
+
+## 4. Removing
+
+```bash
+python3 $S unport <name>
+```
+
+Removes everything the import installed — Power, skills, hooks, agents, supporting files — and leaves
+the original plugin untouched.
+
+## What the script guarantees
+
+- Skill, command and agent bodies and hook scripts are copied byte-for-byte, asserted after the copy.
+- The only body edit is `${CLAUDE_PLUGIN_ROOT}` → the installed path.
+- `.claude-plugin/`, `commands/`, `agents/` stay in place, so the same directory still works as a
+  Claude Code plugin.
+- Anything Kiro has no equivalent for is reported, never approximated.
+- Powers it did not create are never overwritten.

--- a/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/SKILL.md
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/SKILL.md
@@ -30,7 +30,7 @@ python3 $S scan --from <source>      # a marketplace or plugin repo: URL, owner/
 by tool. Project-scoped Claude Code installs appear only when Kiro runs inside that project, matching
 Claude Code's own visibility.
 
-With `--from`, entries whose source points at another git repository print as `원격: <url>`. `port`
+With `--from`, entries whose source points at another git repository print as `remote: <url>`. `port`
 fetches only the ones you name, so always pass explicit names unless the marketplace is small.
 
 **Ask which ones rather than defaulting to everything.** Each Power the user does not need is context
@@ -68,13 +68,15 @@ For each plugin:
    `description` lines, then append to the report:
 
    ```
-   ## 권장 키워드
-   이 Power가 켜져야 하는 상황에서 사용자가 실제로 칠 단어입니다. 적용하려면 plugin.json 의 keywords 에 추가하세요.
-   - 커밋       — "커밋해줘", "변경사항 커밋" 같은 요청
-   - PR 만들기  — …
+   ## Suggested keywords
+   Phrases the user would actually type when this Power should activate. Add them to
+   plugin.json's keywords to apply.
+   - commit       — requests like "commit this", "commit my changes"
+   - open a PR    — …
    ```
 
-   Three to six phrases in the user's language, each with the situation it covers. **Recommend only** —
+   Three to six phrases in the user's language (Korean, English, or whatever they use), each with
+   the situation it covers. **Recommend only** —
    do not write them into `plugin.json` unless asked.
 3. Tell them to start a new session. Powers and skills load at session start.
 4. If the plugin went into a Power (skills stayed inside it, not `~/.kiro/skills/`), mention that its

--- a/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/SKILL.md
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/SKILL.md
@@ -77,11 +77,11 @@ For each plugin:
    Three to six phrases in the user's language, each with the situation it covers. **Recommend only** —
    do not write them into `plugin.json` unless asked.
 3. Tell them to start a new session. Powers and skills load at session start.
-4. If the plugin went into a Power (skills stayed inside it, not `~/.kiro/skills/`), warn that asking
-   for a skill by name — or even naming the Power itself — often fails, because the model's file
-   search does not reliably look inside `~/.kiro/powers/installed/`; it can go either way with the
-   same phrasing. The one thing that works every time is giving the skill's exact path
-   (`~/.kiro/powers/installed/<plugin>/skills/<skill>/SKILL.md`).
+4. If the plugin went into a Power (skills stayed inside it, not `~/.kiro/skills/`), mention that its
+   skills resolve by plain-language request in a `kiro-cli --v3` session (a native `Kiro Powers` tool
+   reads them by name) — but only there. In classic mode or `--no-interactive`, that tool isn't
+   available and asking by name won't reliably find it; giving the skill's exact path
+   (`~/.kiro/powers/installed/<plugin>/skills/<skill>/SKILL.md`) is the fallback that works everywhere.
 
 ## 4. Removing
 

--- a/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/references/kiro-mapping.md
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/references/kiro-mapping.md
@@ -1,0 +1,132 @@
+# Where each component lands in Kiro
+
+Read this when the user asks what happened to a specific component, or when the report shows a `❌`
+you need to explain.
+
+## What counts as "installed"
+
+`scan` and `port` read exactly two files: `~/.claude/plugins/installed_plugins.json` and
+`~/.codex/config.toml`. A name matches only if it appears there — this has nothing to do with whether
+the plugin conforms to the Agent Plugins standard. Claude Code and Codex plugins never conform to that
+standard on their own; converting them into something that does is the whole point of this tool. A
+name failing to match means the name was never installed as a Claude Code or Codex plugin at all
+(typo, a raw MCP server entry, a plugin that exists only in someone's description) — not that it lacks
+Agent Plugins support.
+
+Project-scoped entries (`scope: "project"` in `installed_plugins.json`) only match when the current
+directory is inside that project, mirroring Claude Code's own visibility rule.
+
+One thing never shows up in either file: a plugin loaded with `claude --plugin-dir <path>` or
+`--plugin-url <url>` is session-only by design (Claude Code's own `--help` says so) and is never
+written to `installed_plugins.json`. `scan`/`port` cannot see it, and there's no fallback for that
+case — bringing that plugin's contents into Kiro means pointing at its directory directly with `--from`.
+
+## Component map
+
+| Claude Code / Codex | Kiro | Notes |
+|---|---|---|
+| `skills/<name>/SKILL.md` | `~/.kiro/skills/<name>/` or a Power's `skills/` | Same Agent Skills standard. Body is copied unchanged. |
+| `commands/<name>.md` | `skills/<name>/SKILL.md` inside a Power | Frontmatter gains `name`; `allowed-tools` and `argument-hint` are dropped. Body unchanged. |
+| `commands/<name>.toml` | — | Not Markdown. Not converted; reported. |
+| `hooks/hooks.json` | `~/.kiro/hooks/<plugin>.json` | Rewritten to Kiro's `{"version":"v1","hooks":[…]}`. Scripts themselves are untouched. |
+| `agents/<name>.md` | `~/.kiro/agents/<name>.md` | Body unchanged; frontmatter Kiro has no field for is dropped and reported. |
+| `.mcp.json` | `mcp.json` in the Power root | Wrapped in `mcpServers` with the Agent Plugins `$schema`. Server entries unchanged. |
+| `.claude-plugin/plugin.json` | `plugin.json` in the plugin root | New file. The original stays in place. |
+| `${CLAUDE_PLUGIN_ROOT}` | the installed path | The only substitution ever made inside a body. |
+
+## Hook events
+
+Event names are copied as-is: `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `Stop`, `SessionStart`.
+Tool matchers are translated: `Bash` → `execute_bash`, `Read` → `fs_read`, `Write` / `Edit` →
+`fs_write`.
+
+Some plugins write `hooks.json` as a flat list of `{"event", "command", ...}` objects instead of the
+nested `{event: [{matcher, hooks: [...]}]}` form — both are accepted.
+
+**Hooks fire, but only in a `kiro-cli --v3` interactive session.** Checked directly: a hook installed
+under `~/.kiro/hooks/` shows up in `/hooks` and actually runs (verified with a marker file written on
+`PreToolUse`/`PostToolUse`/`UserPromptSubmit`/`Stop`) when the session is started with `kiro-cli --v3`
+and left interactive. It reports 0 hooks and never fires under classic mode (`kiro-cli` without
+`--v3`) or a `--no-interactive` headless invocation of either mode — those two are the cases to
+recognise when someone says "the hook isn't firing."
+
+[kiro.dev/docs/hooks/](https://kiro.dev/docs/hooks/) names the triggers differently (`PromptSubmit`,
+`AgentStop`, plus IDE-only ones this CLI doesn't have) and describes `.kiro/hooks/` as project-local
+only. Neither matches what was just verified — a hook file named with the *docs'* names
+(`PromptSubmit`, `AgentStop`) sitting at the *docs'* path never fired, while the original Claude Code
+names (`UserPromptSubmit`, `Stop`) at the global `~/.kiro/hooks/` path did. The docs page may describe
+a different Kiro surface, or a spec ahead of what's shipped; either way, this converter follows what a
+live `--v3` session actually does, not what that page says.
+
+Fields Kiro has no equivalent for are reported rather than guessed at:
+
+- `if` — the original ran only under that condition; the Kiro hook has no condition field, so it
+  runs on every call the matcher catches — not "always" in the abstract, but *more often* than the
+  author intended. When several `if`-scoped hooks shared one command (common for "review on commit,
+  review on push, …"), they all collapse onto the same broad matcher: the report says how many, and
+  that many now run **per matching call**, not per original condition. The converter keeps them
+  distinguishable by folding the condition into the hook's name.
+- `shell` — the command is wrapped as `<shell> -c '…'`, since dropping it would run a `.cmd` or
+  similar file directly and fail.
+- `timeout`, `asyncRewake`, `rewakeMessage` — dropped.
+- `SessionEnd`, `UserPromptExpansion` — no Kiro event. Skipped, never approximated.
+
+## Kiro behaviours that surprise people
+
+- **A skill inside a Power is not a slash command.** `/name` works for a skill in `~/.kiro/skills/`;
+  the same file inside a Power is not recognised. Ask for it by name instead ("run the X skill").
+  This is why skill-bearing plugins go to `~/.kiro/skills/` by default.
+- **Hooks only fire in `kiro-cli --v3` interactive sessions.** Classic mode and `--no-interactive`
+  headless sessions load the same `~/.kiro/hooks/*.json` file but `/hooks` reports 0 and nothing runs.
+  If a hook seems to do nothing, check which mode the session was actually started in before assuming
+  the conversion is wrong.
+- **Remote MCP servers in a Power are ignored.** `stdio` servers register with their tools; `http` and
+  `sse` servers produce nothing and no error. Their definition has to move to
+  `~/.kiro/settings/mcp.json`.
+- **Markdown agents do not appear in `kiro-cli agent list`, and `--agent <name>` cannot load one either**
+  (`Error: no agent with name <name> found` — the classic agent registry is JSON-only). In `--v3` (KAS)
+  sessions, `~/.kiro/agents/*.md` is loaded separately as a "user profile"; a plain-language request
+  that matches the persona works without switching agents, but the profile is not selectable by name.
+- **A Power's own skills resolve by name — but only in `kiro-cli --v3`.** In a `--v3` session, asking
+  by plain description ("ponytail 사용법 알려줘", "shorty.py 오버엔지니어링된 부분만 리뷰해줘") reliably
+  surfaces a native `Kiro Powers` tool call (`action=readSkill, powerName=<plugin>, skillName=<skill>`)
+  that reads the right skill directly — verified across a Power's several skills in one session,
+  including ones with no filename or keyword overlap with the prompt. Earlier testing that reported
+  this as unreliable, or as requiring the exact `SKILL.md` path, was run in classic mode or
+  `--no-interactive`, where that tool isn't available — the same distinction as the hooks note above.
+  If a Power's skill still isn't found in an actual `--v3` interactive session, that's worth treating as
+  a real finding, not an expected limitation.
+- **Powers and skills load at session start.** Nothing appears until the next session.
+
+## Why some plugins should not become Powers
+
+A Power adds keyword activation and hides its skills from the slash list. That is worth it for
+`commands/` (which only a Power can carry) and for MCP servers (which connect on activation). It is
+not worth it for a plugin that only holds skills — the folder can sit in `~/.kiro/skills/` exactly as
+it sat in `~/.claude/skills/`, and it keeps its slash commands.
+
+A plugin that is only Markdown guidance is not a Power at all. Kiro's equivalent is a steering file
+with `inclusion: always`, which is always on; a Power activates on keywords, so converting one would
+change what the author intended.
+
+## What is added, and what is left alone
+
+| | Item | Detail |
+|---|---|---|
+| **Unchanged** | Skill, command and agent bodies; hook scripts; MCP server definitions; `scripts/` and `references/` inside skills | Byte-for-byte. The import aborts if a copied body differs. |
+| **Unchanged** | `.claude-plugin/`, `commands/`, `agents/`, `hooks/` | Left in place, so the same directory still installs as a Claude Code plugin. |
+| **Added** | `plugin.json` at the root | `$schema`, `name`, `version`, `description`, `author`, `license`, and name-derived `keywords`. |
+| **Rewritten** | `commands/<x>.md` → `skills/<x>/SKILL.md` | Gains `name`; drops `allowed-tools` and `argument-hint`. Body identical. |
+| **Rewritten** | `.mcp.json` → `mcp.json` | Wrapped in `mcpServers` with the Agent Plugins `$schema`. Entries identical. |
+| **Rewritten** | `hooks/hooks.json` → `~/.kiro/hooks/<plugin>.json` | Kiro's `v1` schema. Scripts untouched. |
+| **Rewritten** | `agents/<x>.md` → `~/.kiro/agents/<x>.md` | Body identical. Frontmatter Kiro has no field for is dropped and listed. |
+
+Hooks and agents live outside the Power because the Agent Plugins standard has no portable slot for
+them. `unport <name>` removes everything an import installed and leaves the original alone.
+
+## File count
+
+Kiro opens a file descriptor per file under a skill tree and does not close it
+([kirodotdev/Kiro#10625](https://github.com/kirodotdev/Kiro/issues/10625)), so a plugin carrying
+`node_modules` can break shell commands for the whole session. `node_modules`, `.venv`, `dist`,
+`build` and friends are excluded from the copy, and a warning is printed past 2,000 files.

--- a/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/scripts/kiro-port.py
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/scripts/kiro-port.py
@@ -132,18 +132,35 @@ def scan_sources() -> list[dict]:
     return out
 
 
+def safe_name(name) -> bool:
+    """A plugin name is used as a single path segment under ~/.kiro and as a Power name.
+    Anything else (absolute path, `..`, separators, shell metacharacters) is rejected —
+    marketplace.json fetched with --from is untrusted input."""
+    return isinstance(name, str) and name not in (".", "..") and re.fullmatch(r"[\w.-]{1,64}", name) is not None
+
+
 def marketplace_plugins(root: Path, fetch: bool = False, only: set | None = None) -> list[dict]:
     """Plugin list inside a marketplace repo (.claude-plugin/marketplace.json).
     An entry's `source` is either a string (path inside the repo) or a dict pointing at another
     git repo (`url` / `git-subdir` / `github`). fetch=True also fetches that other repo.
-    If there's no marketplace.json and the repo itself is a plugin, that's the one entry."""
+    If there's no marketplace.json and the repo itself is a plugin, that's the one entry.
+    Entries whose `name` isn't a safe path segment, or whose `source` resolves outside the
+    fetched repo, are skipped with a warning — those values come from the remote repo."""
     mj = root / ".claude-plugin/marketplace.json"
     items = []
+    root_r = root.resolve()
     if mj.exists():
         for e in json.loads(mj.read_text()).get("plugins", []):
+            name = e.get("name")
+            if not safe_name(name):
+                print(f"   ⚠️ skipped a marketplace entry with an unsafe name: {name!r} (must match [\\w.-]{{1,64}})")
+                continue
             src, p = e.get("source"), None
             if isinstance(src, str):
                 p = (root / src).resolve()
+                if not p.is_relative_to(root_r):
+                    print(f"   ⚠️ {name}: `source` points outside the marketplace repo ({src!r}), skipped")
+                    continue
                 p = p if p.is_dir() else None
             elif isinstance(src, dict):
                 if not fetch or (only is not None and e["name"] not in only):
@@ -154,16 +171,24 @@ def marketplace_plugins(root: Path, fetch: bool = False, only: set | None = None
                 repo = src.get("url") or src.get("repo") or ""
                 if repo:
                     try:
-                        p = fetch_source(repo, ref=src.get("ref")) / (src.get("path") or "")
+                        fetched = fetch_source(repo, ref=src.get("ref")).resolve()
+                        p = (fetched / (src.get("path") or "")).resolve()
+                        if not p.is_relative_to(fetched):
+                            print(f"   ⚠️ {name}: remote `path` points outside its repo ({src.get('path')!r}), skipped")
+                            continue
                     except subprocess.CalledProcessError:
                         p = None
                     p = p if p and p.is_dir() else None
             if p:
-                items.append({"name": e["name"], "path": p, "version": str(e.get("version", "")),
+                items.append({"name": name, "path": p, "version": str(e.get("version", "")),
                               "description": e.get("description", "")})
     elif (root / ".claude-plugin/plugin.json").exists() or (root / "plugin.json").exists():
         m = json.loads(next(p for p in (root / ".claude-plugin/plugin.json", root / "plugin.json") if p.exists()).read_text())
-        items.append({"name": m.get("name", root.name), "path": root, "version": str(m.get("version", "")),
+        name = m.get("name", root.name)
+        if not safe_name(name):
+            print(f"   ⚠️ plugin.json `name` {name!r} isn't a safe path segment, using the directory name `{root.name}`")
+            name = root.name
+        items.append({"name": name, "path": root, "version": str(m.get("version", "")),
                       "description": m.get("description", "")})
     return items
 
@@ -366,7 +391,7 @@ class Port:
                     if h.get("type", "command") != "command":
                         skipped.append(f"{event}[{i}].hooks[{j}] type={h.get('type')}")
                         continue
-                    cmd = f'CLAUDE_PLUGIN_ROOT="{self.dst}" ' + self.sub_root(h["command"])
+                    cmd = f"CLAUDE_PLUGIN_ROOT={shlex.quote(str(self.dst))} " + self.sub_root(h["command"])
                     # `shell` says which shell to run this command through. Kiro's hook has no
                     # matching field, so the command itself is wrapped in that shell — dropping it
                     # would run a `.cmd`-style file directly and fail.
@@ -455,7 +480,10 @@ def install_skills_only(power_dir: Path, report: list[str], name: str) -> None:
     dst_root = KIRO / "skills"
     dst_root.mkdir(parents=True, exist_ok=True)
     placed = []
-    skill_dirs = sorted((power_dir / "skills").iterdir())
+    skill_dirs = sorted((power_dir / "skills").iterdir()) if (power_dir / "skills").is_dir() else []
+    if not skill_dirs:
+        report.append("- ❌ Nothing to place as skills — this plugin has no `skills/` directory. "
+                       "Use `--as power` (commands, MCP servers and agents can only live in a Power)")
     for sk in skill_dirs:
         if not (sk / "SKILL.md").exists():
             continue
@@ -487,7 +515,7 @@ def install_skills_only(power_dir: Path, report: list[str], name: str) -> None:
         shared_copied.append(shared.name)
     if shared_copied:
         report.append(f"- Also moved {len(shared_copied)} shared folder(s) referenced by skills: {shared_copied}")
-    total_src = len([sk for sk in (power_dir / "skills").iterdir() if (sk / "SKILL.md").exists()])
+    total_src = len([sk for sk in skill_dirs if (sk / "SKILL.md").exists()])
     if total_src and not placed:
         report.append("- ❌ No skills were moved — all of them were skipped on a name clash. "
                        "Same folder name doesn't mean same content across plugins "
@@ -538,33 +566,110 @@ def install_skills_only(power_dir: Path, report: list[str], name: str) -> None:
     _manifest_put(name, {"mode": "skills", "skills": placed, "hooks": hooks, "agents": agents})
 
 
-def install_project_local(power_dir: Path, project: Path, report: list[str]) -> None:
-    """Unpack into the project's .kiro/ instead of a Power (matches CC's project scope)."""
+def project_manifest(project: Path) -> Path:
+    """Project-local installs are recorded inside the project, so `unport` run from that project
+    can undo exactly what was written there — the global manifest never sees them."""
+    return project / ".kiro/.kiro-port-manifest.json"
+
+
+def install_project_local(power_dir: Path, project: Path, report: list[str], name: str) -> None:
+    """Unpack into the project's .kiro/ instead of a Power (matches CC's project scope).
+    Everything written is recorded in the project manifest for `unport`."""
     k = project / ".kiro"
+    skills, hooks, agents, mcp_keys = [], [], [], []
     for sk in (power_dir / "skills").iterdir() if (power_dir / "skills").is_dir() else []:
         dst = k / "skills" / sk.name
         if dst.exists():
             report.append(f"- ⚠️ `{dst}` already exists, skipped")
             continue
         shutil.copytree(sk, dst)
-    report.append(f"- Skills → `{k / 'skills'}`")
-    for hook in (power_dir / "dev.kiro/hooks").glob("*.json"):
+        skills.append(sk.name)
+    report.append(f"- Skills → `{k / 'skills'}`: {skills}")
+    # ${CLAUDE_PLUGIN_ROOT} was substituted with the staging path, which the caller deletes.
+    # Anything that still points there (hook scripts, references/) is kept under .kiro and rewritten.
+    hook_files = list((power_dir / "dev.kiro/hooks").glob("*.json"))
+    needs_assets = bool(hook_files) or any(
+        str(power_dir) in (k / "skills" / s / "SKILL.md").read_text(errors="ignore") for s in skills)
+    asset_root = None
+    if needs_assets:
+        asset_root = k / ".kiro-port-assets" / name
+        if asset_root.exists():
+            shutil.rmtree(asset_root)
+        asset_root.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(power_dir, asset_root, ignore=shutil.ignore_patterns("dev.kiro", "PORT-REPORT.md"))
+        report.append(f"- Preserved referenced files at `{asset_root}`")
+        for s in skills:
+            p = k / "skills" / s / "SKILL.md"
+            body = p.read_text(errors="ignore")
+            if str(power_dir) in body:
+                p.write_text(body.replace(str(power_dir), str(asset_root)))
+    for hook in hook_files:
         (k / "hooks").mkdir(parents=True, exist_ok=True)
-        shutil.copy(hook, k / "hooks" / hook.name)
+        body = hook.read_text()
+        if asset_root:
+            body = body.replace(str(power_dir), str(asset_root))
+        (k / "hooks" / hook.name).write_text(body)
+        hooks.append(hook.name)
         report.append(f"- Hook → `{k / 'hooks' / hook.name}`")
     for ag in (power_dir / "dev.kiro/agents").glob("*.md"):
         (k / "agents").mkdir(parents=True, exist_ok=True)
-        if not (k / "agents" / ag.name).exists():
-            shutil.copy(ag, k / "agents" / ag.name)
-            report.append(f"- Agent → `{k / 'agents' / ag.name}`")
+        if (k / "agents" / ag.name).exists():
+            report.append(f"- ⚠️ `{k / 'agents' / ag.name}` already exists, skipped")
+            continue
+        shutil.copy(ag, k / "agents" / ag.name)
+        agents.append(ag.name)
+        report.append(f"- Agent → `{k / 'agents' / ag.name}`")
     mcp = power_dir / "mcp.json"
     if mcp.exists():
         target = k / "settings/mcp.json"
         cur = _load(target, {"mcpServers": {}})
-        cur.setdefault("mcpServers", {}).update(json.loads(mcp.read_text())["mcpServers"])
+        servers = cur.setdefault("mcpServers", {})
+        for key, val in json.loads(mcp.read_text())["mcpServers"].items():
+            if key in servers:
+                report.append(f"- ⚠️ MCP server `{key}` already defined in `{target}`, left as is")
+                continue
+            servers[key] = val
+            mcp_keys.append(key)
         _save(target, cur)
-        report.append(f"- MCP → merged into `{target}`")
+        report.append(f"- MCP → merged into `{target}`: {mcp_keys}")
+    man_p = project_manifest(project)
+    man = _load(man_p, {})
+    man[name] = {"mode": "project", "skills": skills, "hooks": hooks, "agents": agents, "mcp": mcp_keys,
+                 "assets": asset_root is not None}
+    _save(man_p, man)
     report.append("- Note: project-local isn't a Power, so there's no keywords activation. Skills work through Kiro's default skill matching")
+
+
+def unregister_project(name: str, project: Path) -> bool:
+    """Undo a --project-local install recorded in the project manifest. Returns whether one was found."""
+    man_p = project_manifest(project)
+    man = _load(man_p, {})
+    ent = man.get(name)
+    if not ent:
+        return False
+    k = project / ".kiro"
+    for sk in ent.get("skills", []):
+        shutil.rmtree(k / "skills" / sk, ignore_errors=True)
+    for h in ent.get("hooks", []):
+        (k / "hooks" / h).unlink(missing_ok=True)
+    for a in ent.get("agents", []):
+        (k / "agents" / a).unlink(missing_ok=True)
+    shutil.rmtree(k / ".kiro-port-assets" / name, ignore_errors=True)
+    if ent.get("mcp"):
+        target = k / "settings/mcp.json"
+        cur = _load(target, {"mcpServers": {}})
+        for key in ent["mcp"]:
+            cur.get("mcpServers", {}).pop(key, None)
+        _save(target, cur)
+    (k / ".kiro-port-reports" / f"{name}.md").unlink(missing_ok=True)
+    del man[name]
+    if man:
+        _save(man_p, man)
+    else:
+        man_p.unlink(missing_ok=True)
+    print(f"removed {name} from {k} ({len(ent.get('skills', []))} skill(s), "
+          f"{len(ent.get('hooks', []))} hook(s), {len(ent.get('mcp', []))} MCP server(s))")
+    return True
 
 
 def register(name: str, power_dir: Path, report: list[str]) -> None:
@@ -595,7 +700,12 @@ def register(name: str, power_dir: Path, report: list[str]) -> None:
         report.append(f"- Agent installed: `{dst}`")
 
 
-def unregister(name: str) -> None:
+def unregister(name: str, cwd: Path) -> bool:
+    """Remove everything an import installed. Checks the current project's manifest first
+    (--project-local), then the global manifest (skills mode), then the Power directory.
+    Returns False — and touches nothing — when no record of `name` exists anywhere."""
+    if unregister_project(name, cwd):
+        return True
     man = _load(MANIFEST, {})
     ent = man.get(name)
     if ent and ent.get("mode") == "skills":
@@ -608,29 +718,37 @@ def unregister(name: str) -> None:
         shutil.rmtree(KIRO / ".kiro-port-assets" / name, ignore_errors=True)
         for a in ent.get("agents", []):
             (KIRO / "agents" / a).unlink(missing_ok=True)
+        (KIRO / ".kiro-port-reports" / f"{name}.md").unlink(missing_ok=True)
         del man[name]
         _save(MANIFEST, man)
         print(f"removed {name} ({len(ent.get('skills', []))} skill(s))")
-        return
+        return True
+    power_dir = KIRO / "powers/installed" / name
+    reg_p = KIRO / "powers/registries/user-added.json"
+    inst_p = KIRO / "powers/installed.json"
+    reg = _load(reg_p, {"powers": []})
+    inst = _load(inst_p, {"installedPowers": []})
+    registered = any(p.get("name") == name for p in reg["powers"]) or \
+        any(p.get("name") == name for p in inst["installedPowers"])
+    if not power_dir.is_dir() and not registered and not ent:
+        print(f"nothing to remove: no import named `{name}` in this project, in the global manifest, "
+              f"or under {KIRO / 'powers/installed'}")
+        return False
     if ent:
         del man[name]
         _save(MANIFEST, man)
-    power_dir = KIRO / "powers/installed" / name
     if power_dir.is_dir():
         for hook in (power_dir / "dev.kiro/hooks").glob("*.json"):
             (KIRO / "hooks" / hook.name).unlink(missing_ok=True)
         for ag in (power_dir / "dev.kiro/agents").glob("*.md"):
             (KIRO / "agents" / ag.name).unlink(missing_ok=True)
         shutil.rmtree(power_dir)
-    reg_p = KIRO / "powers/registries/user-added.json"
-    reg = _load(reg_p, {"powers": []})
-    reg["powers"] = [p for p in reg["powers"] if p["name"] != name]
+    reg["powers"] = [p for p in reg["powers"] if p.get("name") != name]
     _save(reg_p, reg)
-    inst_p = KIRO / "powers/installed.json"
-    inst = _load(inst_p, {"installedPowers": []})
-    inst["installedPowers"] = [p for p in inst["installedPowers"] if p["name"] != name]
+    inst["installedPowers"] = [p for p in inst["installedPowers"] if p.get("name") != name]
     _save(inst_p, inst)
     print(f"removed {name}")
+    return True
 
 
 def smoke(names: list[str]) -> None:
@@ -671,9 +789,10 @@ def main() -> None:
     cwd = Path.cwd().resolve()
 
     if a.cmd == "unport":
-        for n in a.names:
-            unregister(n)
-        return
+        if not a.names:
+            sys.exit("unport: name at least one plugin")
+        ok = [unregister(n, cwd) for n in a.names]
+        sys.exit(0 if all(ok) else 1)
 
     if a.src:
         root = fetch_source(a.src)
@@ -739,6 +858,9 @@ def main() -> None:
     taken = {p.name for p in (KIRO / "powers/installed").iterdir()} if (KIRO / "powers/installed").is_dir() else set()
     for s in picked:
         name = s["name"]
+        if not safe_name(name):
+            print(f"\n== {name!r}  → skipped: not a safe plugin name (must match [\\w.-]{{1,64}})")
+            continue
         kind, ncomp = classify(Path(s["path"]))
         mode = a.mode if a.mode != "auto" else recommend(kind)
         if a.project_local:
@@ -763,6 +885,9 @@ def main() -> None:
             name = alt
         taken.add(name)
         power_dir = base / name
+        if not power_dir.resolve().is_relative_to(base.resolve()):
+            print(f"   ⛔ `{power_dir}` resolves outside `{base}`. Skipped.")
+            continue
         where = (f"{cwd}/.kiro/" if mode == "project" else
                  f"{KIRO}/skills/" if mode == "skills" else power_dir)
         why = {"skills": "skills-only, not wrapped in a Power", "power": f"{kind} components", "project": "project-local"}[mode]
@@ -778,7 +903,10 @@ def main() -> None:
         report = [f"# Port report — {name}", f"source: `{s['path']}` ({s['tool']} marketplace `{s['market']}`, scope {s['scope']})", ""]
         Port(s["path"], power_dir, report).run(name, s["version"])
         if mode == "project":
-            install_project_local(power_dir, cwd, report)
+            install_project_local(power_dir, cwd, report, name)
+            shutil.rmtree(power_dir)  # staging only — the real files are in .kiro/{skills,hooks,agents}
+            if base.is_dir() and not any(base.iterdir()):
+                base.rmdir()
         elif mode == "skills" and not a.out:
             install_skills_only(power_dir, report, name)
             shutil.rmtree(power_dir)  # no staging leftovers kept
@@ -801,8 +929,8 @@ def main() -> None:
                        "- Agents are plain markdown under `~/.kiro/agents/`. Tool restrictions (`tools`) are stripped"]
         if power_dir.exists():
             (power_dir / "PORT-REPORT.md").write_text("\n".join(report) + "\n")
-        else:  # skills mode leaves no Power directory, so the report is kept separately
-            rp = KIRO / ".kiro-port-reports" / f"{name}.md"
+        else:  # skills and project modes leave no Power directory, so the report is kept separately
+            rp = (cwd / ".kiro" if mode == "project" else KIRO) / ".kiro-port-reports" / f"{name}.md"
             rp.parent.mkdir(parents=True, exist_ok=True)
             rp.write_text("\n".join(report) + "\n")
         print("\n".join(report[3:]))

--- a/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/scripts/kiro-port.py
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/scripts/kiro-port.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
-"""Claude Code / Codex 마켓플레이스로 설치한 플러그인을 Kiro Power로 이식한다.
+"""Port plugins installed from a Claude Code / Codex marketplace into a Kiro Power.
 
-    kiro-port.py scan                      # CC·Codex에 설치된 플러그인 목록
-    kiro-port.py port <name>[@<market>]... # 변환 + ~/.kiro 에 설치·등록
+    kiro-port.py scan                      # list what CC/Codex have installed
+    kiro-port.py port <name>[@<market>]... # convert + install/register under ~/.kiro
     kiro-port.py port --all
-    kiro-port.py unport <name>...          # 이식한 Power 제거
-옵션: --dry-run  --out DIR(설치하지 않고 저장소만 생성)  --smoke(kiro-cli v3로 로드 확인)
+    kiro-port.py unport <name>...          # remove a ported Power
+Options: --dry-run  --out DIR (generate a repo without installing)  --smoke (verify kiro-cli v3 loads it)
 
-원칙: 본문은 바이트 단위로 그대로. 바뀌는 것은 포장(plugin.json, 머리말 한 줄, 훅 스키마)과
-위치만. 사람이 정해야 할 것(keywords 등)은 REPORT에 남긴다. 표준 밖 항목은 지우지 않고
-dev.kiro/ 및 ~/.kiro/hooks, ~/.kiro/agents 로 옮긴다.
+Principle: bodies stay byte-for-byte. What changes is packaging (plugin.json, one frontmatter
+line, the hook schema) and location. Anything a human should decide (keywords, etc.) goes in the
+REPORT. Anything outside the standard isn't deleted — it moves to dev.kiro/ and then
+~/.kiro/hooks, ~/.kiro/agents.
 """
 import argparse
 import json
@@ -27,27 +28,30 @@ KIRO = Path(os.environ.get("KIRO_HOME", HOME / ".kiro"))
 PLUGIN_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
 MCP_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json"
 HOOK_EVENTS = {"PreToolUse", "PostToolUse", "UserPromptSubmit", "Stop", "SessionStart"}
-# 이벤트명은 그대로 옮긴다. kiro.dev/docs/hooks/ 는 PromptSubmit/AgentStop 이라 적지만, 실제 `kiro-cli
-# --v3` 인터랙티브 세션에 두 이름을 나란히 걸어 직접 확인한 결과 발동하는 건 원래 이름
-# (UserPromptSubmit/Stop) 쪽이었다 — 문서가 실제 CLI 동작과 다르다.
+# Event names are carried over unchanged. kiro.dev/docs/hooks/ names them PromptSubmit/AgentStop,
+# but installing both names side by side in a live `kiro-cli --v3` interactive session showed the
+# original names (UserPromptSubmit/Stop) are the ones that actually fire — the docs page doesn't
+# match what the CLI does.
 HOOK_TOOL_MAP = {"Bash": "execute_bash", "Read": "fs_read", "Write": "fs_write", "Edit": "fs_write"}
 CMD_DROP_KEYS = {"allowed-tools", "argument-hint"}
-# Kiro 는 스킬 트리의 모든 파일마다 fd 를 열고 닫지 않아(kirodotdev/Kiro#10625) 파일이 많으면
-# 확장 호스트의 fd 가 고갈되고 `spawn EBADF` 로 셸이 죽는다. 실행에 불필요한 트리는 옮기지 않는다.
+# Kiro opens a file descriptor per file under a skill tree and never closes it
+# (kirodotdev/Kiro#10625); enough files exhausts the extension host's fds and kills the shell with
+# `spawn EBADF`. Trees that aren't needed at runtime aren't copied.
 EXCLUDE = shutil.ignore_patterns(
     ".git", "node_modules", ".venv", "venv", "__pycache__", ".pytest_cache", ".mypy_cache",
     "dist", "build", ".next", ".turbo", "target", "*.log", "*.map", ".DS_Store")
-FILE_WARN = 2000  # 이보다 파일이 많으면 경고
+FILE_WARN = 2000  # warn past this many files
 AGENT_DROP_KEYS = {"tools", "model", "mcpServers", "hooks", "permissionMode", "color", "effort",
                    "initialPrompt", "disallowedTools", "skills", "memory", "background", "isolation", "maxTurns"}
 MANIFEST = Path(os.environ.get("KIRO_HOME", HOME / ".kiro")) / ".kiro-port-manifest.json"
 
 
 def classify(src: Path) -> tuple[str, dict]:
-    """플러그인을 skills(스킬만) / plugin(복합) / guidance(지침) 로 분류.
+    """Classify a plugin as skills-only / plugin (mixed) / guidance.
 
-    Power 로 감쌀 필요가 있는지 판단하기 위한 것. 스킬만 있으면 Kiro 도 Agent Skills 표준을
-    읽으므로 폴더 복사로 충분하고, Power 로 만들면 keywords 활성화 단계가 더 붙는다.
+    Decides whether it needs wrapping in a Power. Skills alone are already covered by Kiro's own
+    Agent Skills support, so a plain folder copy is enough; wrapping them in a Power adds a
+    keyword-activation step on top.
     """
     n = {
         "skills": len([d for d in (src / "skills").iterdir() if (d / "SKILL.md").exists()])
@@ -61,15 +65,16 @@ def classify(src: Path) -> tuple[str, dict]:
     m = json.loads(mf.read_text()) if mf else {}
     if (src / "hooks/hooks.json").exists() or isinstance(m.get("hooks"), str):
         n["hooks"] = 1
-    # 훅과 에이전트는 어차피 Power 밖(~/.kiro/hooks, ~/.kiro/agents)에 설치되므로 Power 를 요구하지 않는다.
-    # 검증: superpowers 를 Power 등록 해제하고 스킬만 전역에 둬도 SessionStart 훅이 그대로 발화한다.
-    # Power 가 반드시 필요한 것은 mcp.json(Power 활성화 시 연결)과, 스킬로 바꿀 commands 다.
+    # Hooks and agents install outside the Power (~/.kiro/hooks, ~/.kiro/agents) either way, so
+    # they don't require one. Confirmed: unregistering superpowers' Power and leaving only its
+    # skills installed globally still lets its SessionStart hook fire. A Power is only required
+    # for mcp.json (connects when the Power activates) and for commands (which become skills).
     if n["commands"] or n["mcp"]:
         return "plugin", n
     if n["skills"]:
         return "skills", n
     if n["hooks"] or n["agents"]:
-        return "sidecar", n   # 스킬 없이 훅/에이전트만 — Power 껍데기만 필요
+        return "sidecar", n   # hooks/agents with no skills — just needs a Power shell to live in
     return "guidance", n
 
 
@@ -79,14 +84,14 @@ def global_skill_count() -> int:
 
 
 def recommend(kind: str) -> str:
-    """분류에 따라 설치 방식을 권한다. 스킬만 있으면 Power 로 감쌀 이유가 없다."""
+    """Recommend an install mode from the classification. Skills alone have no reason to be wrapped in a Power."""
     return {"plugin": "power", "guidance": "steering", "skills": "skills", "sidecar": "power"}[kind]
 
 
-# ------------------------------------------------------------------ 설치 상태 읽기
+# ------------------------------------------------------------------ reading install state
 
 def scan_sources() -> list[dict]:
-    """CC와 Codex가 로컬에 설치해 둔 플러그인 디렉터리 목록."""
+    """Plugin directories CC and Codex have installed locally."""
     out = []
     cc = HOME / ".claude/plugins/installed_plugins.json"
     if cc.exists():
@@ -99,7 +104,7 @@ def scan_sources() -> list[dict]:
                     out.append({"tool": "claude", "name": name, "market": market, "path": p,
                                 "version": inst.get("version", ""), "scope": inst.get("scope", ""),
                                 "project": inst.get("projectPath", "")})
-    # Codex: config.toml 의 [marketplaces.*] + [plugins."name@market"] 가 설치 상태
+    # Codex: [marketplaces.*] + [plugins."name@market"] in config.toml is the install state
     cfg_p = HOME / ".codex/config.toml"
     if cfg_p.exists():
         cfg = tomllib.loads(cfg_p.read_text())
@@ -113,13 +118,13 @@ def scan_sources() -> list[dict]:
             root = roots.get(mk)
             if not root or not p.get("enabled", True):
                 continue
-            if mk.startswith("openai-"):  # ChatGPT/Codex 앱 내장 플러그인 — 런타임 종속, 이식 대상 아님
+            if mk.startswith("openai-"):  # bundled ChatGPT/Codex app plugins — runtime-coupled, not portable
                 continue
-            # 설치본은 ~/.codex/plugins/cache/<market>/<name>/<version>/ (최신 것 하나)
+            # the install lives at ~/.codex/plugins/cache/<market>/<name>/<version>/ (take the newest)
             vers = sorted((HOME / ".codex/plugins/cache" / mk / name).glob("*/"), key=os.path.getmtime)
             if vers:
                 cands = [{"name": name, "path": vers[-1], "version": vers[-1].name}]
-            else:  # 캐시가 없으면 마켓플레이스 스냅샷의 로컬 소스
+            else:  # no cache — fall back to the marketplace snapshot's local source
                 cands = [c for c in marketplace_plugins(root) if c["name"] == name]
             for cand in cands:
                 out.append({"tool": "codex", "name": name, "market": mk, "path": cand["path"],
@@ -128,10 +133,10 @@ def scan_sources() -> list[dict]:
 
 
 def marketplace_plugins(root: Path, fetch: bool = False, only: set | None = None) -> list[dict]:
-    """마켓플레이스 저장소(.claude-plugin/marketplace.json) 안의 플러그인 목록.
-    항목 `source` 가 문자열이면 저장소 안의 경로, dict 면 다른 git 저장소를 가리킨다
-    (`url` / `git-subdir` / `github`). fetch=True 면 그 저장소도 받아온다.
-    marketplace.json 이 없고 저장소 자체가 플러그인이면 그 하나."""
+    """Plugin list inside a marketplace repo (.claude-plugin/marketplace.json).
+    An entry's `source` is either a string (path inside the repo) or a dict pointing at another
+    git repo (`url` / `git-subdir` / `github`). fetch=True also fetches that other repo.
+    If there's no marketplace.json and the repo itself is a plugin, that's the one entry."""
     mj = root / ".claude-plugin/marketplace.json"
     items = []
     if mj.exists():
@@ -142,7 +147,7 @@ def marketplace_plugins(root: Path, fetch: bool = False, only: set | None = None
                 p = p if p.is_dir() else None
             elif isinstance(src, dict):
                 if not fetch or (only is not None and e["name"] not in only):
-                    # 원격 저장소는 지목된 것만 받아온다 (대형 마켓플레이스는 항목이 수천 개)
+                    # only fetch remote repos for entries explicitly named (large marketplaces run to thousands of entries)
                     items.append({"name": e["name"], "path": None, "version": str(e.get("version", "")),
                                   "description": e.get("description", ""), "remote": src})
                     continue
@@ -164,7 +169,7 @@ def marketplace_plugins(root: Path, fetch: bool = False, only: set | None = None
 
 
 def fetch_source(src: str, ref: str | None = None) -> Path:
-    """로컬 경로 | owner/repo | git URL → 로컬 디렉터리 (git 은 얕게 클론, 캐시 재사용)."""
+    """Local path | owner/repo | git URL -> local directory (shallow clone for git, cache reused)."""
     p = Path(src).expanduser()
     if p.is_dir():
         return p.resolve()
@@ -177,10 +182,10 @@ def fetch_source(src: str, ref: str | None = None) -> Path:
     return dst
 
 
-# ------------------------------------------------------------------ frontmatter (YAML 부분집합)
+# ------------------------------------------------------------------ frontmatter (a YAML subset)
 
 def split_frontmatter(text: str):
-    """(머리말 줄 목록, 본문) — 본문은 바이트 그대로 보존하기 위해 문자열로 반환."""
+    """(frontmatter lines, body) — body is returned as a string so it stays byte-identical."""
     if not text.startswith("---"):
         return [], text
     end = text.find("\n---", 3)
@@ -192,7 +197,7 @@ def split_frontmatter(text: str):
 
 
 def fm_blocks(lines: list[str]) -> list[tuple[str, list[str]]]:
-    """머리말을 (키, 원문 줄들) 블록으로. 들여쓴 연속 줄은 앞 키에 붙인다."""
+    """Group frontmatter into (key, original lines) blocks. Indented continuation lines attach to the preceding key."""
     blocks, cur = [], None
     for ln in lines:
         m = re.match(r"^([\w-]+)\s*:", ln)
@@ -209,7 +214,7 @@ def rebuild_fm(blocks: list[tuple[str, list[str]]], body: str) -> str:
     return "---\n" + "\n".join(lines) + "\n---" + body
 
 
-# ------------------------------------------------------------------ 변환
+# ------------------------------------------------------------------ conversion
 
 class Port:
     def __init__(self, src: Path, power_dir: Path, report: list[str]):
@@ -217,7 +222,7 @@ class Port:
         self.root_token = "${CLAUDE_PLUGIN_ROOT}"
 
     def sub_root(self, s: str) -> str:
-        # 허용되는 유일한 본문 수정: 설치 위치가 확정되므로 절대경로로 치환
+        # The one body edit this tool ever makes: the install location is now fixed, so substitute the absolute path
         return s.replace(self.root_token, str(self.dst))
 
     def manifest(self) -> dict:
@@ -230,41 +235,41 @@ class Port:
     def run(self, name: str, version_hint: str) -> None:
         m = self.manifest()
         if m.get("name") and m["name"] != name:
-            # 매니페스트 name 과 등록 이름(디렉터리)이 다르면 Kiro 가 Power 목록 전체를 조용히 버린다.
-            # 등록 이름을 진실로 삼고 원래 값을 보고서에 남긴다.
-            self.report.append(f"- ⚠️ 원본 매니페스트 `name`은 `{m['name']}` 이지만 Power 이름은 `{name}` 로 맞춤 "
-                               f"(마켓플레이스 항목 이름과 매니페스트가 다른 경우. Kiro 는 이름 중복·불일치 시 로드하지 않음)")
-        # 1) 원본 복사 (CC 포맷 그대로 보존 → 같은 디렉터리를 CC도 계속 읽을 수 있음).
-        #    node_modules 등은 제외한다 — fd 누출로 Kiro 확장 호스트를 죽인다(#10625).
-        #    심볼릭 링크는 내용을 그대로 복사한다(symlinks=False) — 마켓플레이스 내부에서
-        #    플러그인 밖을 가리키는 상대 심볼릭 링크(예: ../../../.claude/commands/x.md)가
-        #    옮겨진 위치에서는 깨지기 때문.
+            # If the manifest's `name` differs from the registered (directory) name, Kiro silently
+            # drops the whole Power list. The registered name wins; the original is noted in the report.
+            self.report.append(f"- ⚠️ Source manifest `name` is `{m['name']}` but the Power was named `{name}` to match "
+                               f"(the marketplace entry name and the manifest disagreed. Kiro refuses to load on a name clash or mismatch)")
+        # 1) Copy the source as-is (preserves the CC format, so the same directory still works as a CC plugin).
+        #    node_modules and similar are excluded — fd leaks kill Kiro's extension host (#10625).
+        #    Symlinks are copied by content (symlinks=False) — a relative symlink inside a
+        #    marketplace pointing outside the plugin (e.g. ../../../.claude/commands/x.md) would
+        #    break once moved.
         shutil.copytree(self.src, self.dst, symlinks=False, ignore=EXCLUDE)
         skipped = [p.name for p in self.src.iterdir()
                    if p.is_dir() and p.name in ("node_modules", ".venv", "venv", "dist", "build", "target")]
         if skipped:
-            self.report.append(f"- 복사 제외: {skipped} (런타임 의존성/빌드 산출물. 필요하면 원본에서 다시 설치)")
+            self.report.append(f"- Excluded from copy: {skipped} (runtime dependencies/build output. Reinstall from source if needed)")
         nfiles = sum(1 for p in self.dst.rglob("*") if p.is_file())
         if nfiles > FILE_WARN:
-            self.report.append(f"- ⚠️ 파일 {nfiles}개. Kiro 는 스킬 트리의 모든 파일마다 fd 를 열어두므로"
-                               f"(kirodotdev/Kiro#10625) 이 정도면 `spawn EBADF` 로 셸이 멈출 수 있다")
+            self.report.append(f"- ⚠️ {nfiles} files. Kiro keeps a file descriptor open per file under a skill tree "
+                               f"(kirodotdev/Kiro#10625); this many can stall the shell with `spawn EBADF`")
         skills = self.dst / "skills"
         skill_names = [d.name for d in skills.iterdir() if (d / "SKILL.md").exists()] if skills.is_dir() else []
-        # 2) skills/ 본문의 ${CLAUDE_PLUGIN_ROOT}만 치환
+        # 2) Substitute ${CLAUDE_PLUGIN_ROOT} inside skills/ bodies only
         for f in skills.rglob("*") if skills.is_dir() else []:
             if f.is_file() and f.suffix in (".md", ".sh", ".py", ".json", ".yaml", ".yml"):
                 t = f.read_text(errors="replace")
                 if self.root_token in t:
                     f.write_text(self.sub_root(t))
-                    self.report.append(f"- `{f.relative_to(self.dst)}`: `${{CLAUDE_PLUGIN_ROOT}}` → 설치 경로로 치환")
+                    self.report.append(f"- `{f.relative_to(self.dst)}`: `${{CLAUDE_PLUGIN_ROOT}}` → substituted with the install path")
         # 3) commands/*.md → skills/<name>/SKILL.md
         cmd_dir = self.dst / "commands"
         for cmd in sorted(cmd_dir.glob("*.md")) if cmd_dir.is_dir() else []:
             self.command_to_skill(cmd, skill_names)
         others = [p.name for p in cmd_dir.iterdir() if p.is_file() and p.suffix != ".md"] if cmd_dir.is_dir() else []
         if others:
-            self.report.append(f"- ❌ `.md` 아닌 command 는 변환하지 않음: {others}")
-        # 4) plugin.json (루트)
+            self.report.append(f"- ❌ Commands that aren't `.md` are not converted: {others}")
+        # 4) plugin.json (root)
         pj = {"$schema": PLUGIN_SCHEMA, "name": name,
               "version": str(m.get("version") or version_hint or "1.0.0"),
               "description": m.get("description", "")}
@@ -273,10 +278,10 @@ class Port:
                 pj[k] = m[k]
         pj["keywords"] = sorted(set([pj["name"]] + skill_names))
         (self.dst / "plugin.json").write_text(json.dumps(pj, ensure_ascii=False, indent=2) + "\n")
-        self.report.append(f"- `plugin.json` 생성. `keywords`는 플러그인·스킬 **이름에서만** 추출: "
-                           f"{pj['keywords']} — 활성화 트리거이므로 필요하면 직접 수정")
+        self.report.append(f"- Generated `plugin.json`. `keywords` were derived **from names only**: "
+                           f"{pj['keywords']} — these are activation triggers, edit directly if you need more")
         if not m.get("version"):
-            self.report.append("- 원본에 `version` 없음 → `1.0.0`")
+            self.report.append("- Source had no `version` → defaulted to `1.0.0`")
         # 5) .mcp.json → mcp.json
         mcp_src = self.dst / ".mcp.json"
         if mcp_src.exists():
@@ -284,15 +289,15 @@ class Port:
             servers = raw.get("mcpServers", raw)
             (self.dst / "mcp.json").write_text(json.dumps(
                 {"$schema": MCP_SCHEMA, "mcpServers": servers}, ensure_ascii=False, indent=2) + "\n")
-            self.report.append(f"- `mcp.json` 생성 (서버 정의 무수정): {list(servers)}")
-            # 검증(kiro-cli 2.21.0): Power 의 mcp.json 에서 stdio 서버는 정상 등록되지만
-            # 원격 http/sse 서버는 조용히 무시된다(오류도 없음).
+            self.report.append(f"- Generated `mcp.json` (server definitions unchanged): {list(servers)}")
+            # Confirmed (kiro-cli 2.21.0): stdio servers in a Power's mcp.json register normally,
+            # but remote http/sse servers are silently ignored (no error either).
             remote = [n for n, s in servers.items()
                       if isinstance(s, dict) and s.get("type") in ("http", "sse", "streamable-http")]
             if remote:
                 self.report.append(
-                    f"- ❌ 원격 MCP 서버 {remote} 는 Power 에서 로드되지 않습니다 (오류도 표시되지 않음). "
-                    f"쓰려면 정의를 `~/.kiro/settings/mcp.json` 에 직접 옮기세요. stdio 서버는 정상 동작합니다")
+                    f"- ❌ Remote MCP server(s) {remote} do not load from a Power (and produce no error). "
+                    f"To use them, move the definition into `~/.kiro/settings/mcp.json` directly — stdio servers work as-is")
         # 6) hooks → dev.kiro/hooks/<name>.json
         hooks_file = self.dst / "hooks/hooks.json"
         if not hooks_file.exists() and isinstance(m.get("hooks"), str):
@@ -307,7 +312,7 @@ class Port:
         sname = cmd.stem
         target = self.dst / "skills" / sname / "SKILL.md"
         if sname in skill_names:
-            self.report.append(f"- ⚠️ command `{sname}` 은 같은 이름의 skill 이 있어 건너뜀")
+            self.report.append(f"- ⚠️ Command `{sname}` skipped — a skill with the same name already exists")
             return
         text = cmd.read_text(errors="replace")
         fm, body = split_frontmatter(text)
@@ -318,26 +323,28 @@ class Port:
             kept.insert(0, ("name", [f"name: {sname}"]))
         if not any(k == "description" for k, _ in kept):
             kept.append(("description", [f"description: {sname}"]))
-            self.report.append(f"- command `{sname}`: `description` 없어 이름으로 채움 — 확인 필요")
+            self.report.append(f"- Command `{sname}`: had no `description`, filled in with the name — worth checking")
         target.parent.mkdir(parents=True)
         target.write_text(rebuild_fm(kept, self.sub_root(body)))
-        assert split_frontmatter(target.read_text())[1] == self.sub_root(body), "본문 불일치"
-        note = f" (머리말에서 제거: {', '.join(dropped)})" if dropped else ""
-        self.report.append(f"- command `{sname}.md` → `skills/{sname}/SKILL.md`, 본문 동일{note}")
+        assert split_frontmatter(target.read_text())[1] == self.sub_root(body), "body mismatch"
+        note = f" (dropped from frontmatter: {', '.join(dropped)})" if dropped else ""
+        self.report.append(f"- Command `{sname}.md` → `skills/{sname}/SKILL.md`, body unchanged{note}")
         skill_names.append(sname)
 
     def convert_hooks(self, hooks_file: Path, pname: str) -> None:
-        """Claude Code hooks.json → Kiro v1 스키마.
+        """Claude Code hooks.json → Kiro's v1 schema.
 
-        Kiro 가 모르는 필드(`if`, `asyncRewake`, `timeout` 등)는 버리지 않고 보고서에 남긴다.
-        특히 `if` 는 같은 command 를 조건별로 여러 번 등록하는 데 쓰이므로, 이걸 잃으면
-        결과물이 '같은 훅의 중복'처럼 보이고 조건 분기가 조용히 사라진다.
+        Fields Kiro doesn't know about (`if`, `asyncRewake`, `timeout`, etc.) aren't dropped
+        silently — they're reported. `if` in particular is what lets the same command be
+        registered multiple times under different conditions; losing it makes the result look
+        like duplicate copies of one hook, with the conditional branching gone without a trace.
         """
         raw = json.loads(hooks_file.read_text())
         raw_hooks = raw.get("hooks", {})
         if isinstance(raw_hooks, list):
-            # 일부 플러그인은 {event,command,...} 평면 리스트로 쓴다(중첩 matcher/hooks 배열이 아님).
-            # 이하 로직이 기대하는 {event: [{matcher, hooks:[{type,command,...}]}]} 형태로 맞춘다.
+            # Some plugins write hooks as a flat list of {event,command,...} objects instead of
+            # nested matcher/hooks arrays. Normalize into the {event: [{matcher, hooks:[{type,command,...}]}]}
+            # shape the rest of this logic expects.
             grouped: dict = {}
             for item in raw_hooks:
                 ev = item["event"]
@@ -360,12 +367,13 @@ class Port:
                         skipped.append(f"{event}[{i}].hooks[{j}] type={h.get('type')}")
                         continue
                     cmd = f'CLAUDE_PLUGIN_ROOT="{self.dst}" ' + self.sub_root(h["command"])
-                    # `shell` 은 이 명령을 어떤 셸로 돌리라는 지시다. Kiro 훅에는 대응 필드가 없으므로
-                    # 명령 자체를 그 셸로 감싼다. 버리면 `.cmd` 같은 파일이 직접 실행돼 실패한다.
+                    # `shell` says which shell to run this command through. Kiro's hook has no
+                    # matching field, so the command itself is wrapped in that shell — dropping it
+                    # would run a `.cmd`-style file directly and fail.
                     sh = h.get("shell")
                     if sh:
                         cmd = f"{sh} -c {shlex.quote(cmd)}"
-                    # Kiro 에 대응 필드가 없는 것들. 이름에 실어 구분을 남기고 보고서에 적는다.
+                    # Fields Kiro has nothing to hold. Carried in the name for disambiguation and noted in the report.
                     extra = {k: v for k, v in h.items() if k not in ("type", "command", "shell")}
                     label = re.sub(r"[^\w.-]+", "-", str(extra.get("if", ""))).strip("-").lower()
                     name = f"{pname}-{event.lower()}-{i}-{j}" + (f"-{label}" if label else "")
@@ -380,14 +388,15 @@ class Port:
             d = self.dst / "dev.kiro/hooks"
             d.mkdir(parents=True, exist_ok=True)
             (d / f"{pname}.json").write_text(json.dumps({"version": "v1", "hooks": out}, ensure_ascii=False, indent=2) + "\n")
-            self.report.append(f"- hooks {len(out)}개 → `dev.kiro/hooks/{pname}.json` (설치 시 `~/.kiro/hooks/`로 복사)")
+            self.report.append(f"- {len(out)} hook(s) → `dev.kiro/hooks/{pname}.json` (copied to `~/.kiro/hooks/` on install)")
             self.report.append(
-                "  ⚠️ `kiro-cli --v3`의 인터랙티브 세션에서만 발동한다(직접 확인). 클래식 모드(`kiro-cli`, "
-                "`--v3` 없이)나 `--no-interactive` 헤드리스 세션에서는 훅이 로드되지 않아 `/hooks`가 0으로 "
-                "표시된다."
+                "  ⚠️ Only fires in a `kiro-cli --v3` interactive session (confirmed directly). In classic mode "
+                "(`kiro-cli` without `--v3`) or a `--no-interactive` headless session, hooks never load and "
+                "`/hooks` reports 0."
             )
-        # if 를 잃은 훅들이 같은 trigger+matcher 를 공유하면, 서로 다른 조건에서 한 번씩 돌던 것이
-        # 조건 없이 전부 같은 자리에 겹쳐 매 호출마다 그 개수만큼 반복 실행된다. 이 배수를 알려준다.
+        # If several hooks that lost their `if` share the same trigger+matcher, what used to run
+        # once per distinct condition now collapses onto the same broad match and runs that many
+        # times per call. Report that multiplier.
         if_dropped = [h for h in out if any(n == h["name"] for n, e in dropped if "if" in e)]
         overlap = {}
         for h in if_dropped:
@@ -395,15 +404,15 @@ class Port:
             overlap.setdefault(key, []).append(h["name"])
         for name, extra in dropped:
             keys = ", ".join(f"`{k}`" for k in extra)
-            self.report.append(f"- ❌ `{name}`: Kiro 에 대응 없는 필드를 옮기지 못했습니다 — {keys}")
+            self.report.append(f"- ❌ `{name}`: fields Kiro has no equivalent for were not carried over — {keys}")
             if "if" in extra:
                 n_same = next((len(v) for v in overlap.values() if name in v), 1)
-                self.report.append(f"    원본은 `{extra['if']}` 일 때만 실행됩니다. Kiro 훅에는 조건 필드가 없어 "
-                                   f"**매처에 걸리는 모든 호출에서 실행**됩니다" +
-                                   (f" — 같은 명령이 이 자리에 {n_same}개 겹쳐 있어, 호출 한 번에 {n_same}번 돕니다"
+                self.report.append(f"    The original only ran when `{extra['if']}` held. Kiro's hook has no condition field, so it "
+                                   f"**runs on every call the matcher catches**" +
+                                   (f" — {n_same} identical commands now sit at this spot, so one call runs it {n_same} times"
                                     if n_same > 1 else ""))
         if skipped:
-            self.report.append(f"- ❌ 대응 없는 훅은 변환하지 않음: {skipped}")
+            self.report.append(f"- ❌ Hooks with no Kiro equivalent were not converted: {skipped}")
 
     def convert_agent(self, ag: Path) -> None:
         fm, body = split_frontmatter(ag.read_text(errors="replace"))
@@ -413,11 +422,11 @@ class Port:
         d = self.dst / "dev.kiro/agents"
         d.mkdir(parents=True, exist_ok=True)
         (d / ag.name).write_text(rebuild_fm(kept, self.sub_root(body)))
-        note = f" (머리말 제거: {', '.join(dropped)} — Kiro md 에이전트에 대응 없음)" if dropped else ""
-        self.report.append(f"- agent `{ag.name}` → `dev.kiro/agents/` 본문 동일{note}. 설치 시 `~/.kiro/agents/`로 복사")
+        note = f" (dropped from frontmatter: {', '.join(dropped)} — no Kiro md-agent equivalent)" if dropped else ""
+        self.report.append(f"- Agent `{ag.name}` → `dev.kiro/agents/`, body unchanged{note}. Copied to `~/.kiro/agents/` on install")
 
 
-# ------------------------------------------------------------------ Kiro 설치·등록
+# ------------------------------------------------------------------ Kiro install/register
 
 def _load(p: Path, default):
     return json.loads(p.read_text()) if p.exists() else default
@@ -437,10 +446,11 @@ def _manifest_put(name: str, entry: dict) -> None:
 
 
 def install_skills_only(power_dir: Path, report: list[str], name: str) -> None:
-    """스킬은 ~/.kiro/skills/ 에, 훅·에이전트는 Power 밖 제자리에 둔다.
+    """Skills go to ~/.kiro/skills/; hooks and agents stay outside the Power, in their own place.
 
-    Power 로 감싸지 않으므로 스킬이 슬래시(`/스킬이름`)로 호출된다. 훅은 ~/.kiro/hooks/ 에
-    설치되면 Power 등록과 무관하게 발화하므로 함께 살린다(검증: superpowers).
+    Since it isn't wrapped in a Power, skills are callable by slash (`/skill-name`). Hooks
+    installed under ~/.kiro/hooks/ fire regardless of Power registration, so they're kept too
+    (confirmed with superpowers).
     """
     dst_root = KIRO / "skills"
     dst_root.mkdir(parents=True, exist_ok=True)
@@ -451,14 +461,15 @@ def install_skills_only(power_dir: Path, report: list[str], name: str) -> None:
             continue
         dst = dst_root / sk.name
         if dst.exists():
-            report.append(f"- ⚠️ `{dst}` 이미 있어 건너뜀 (같은 이름의 스킬)")
+            report.append(f"- ⚠️ `{dst}` already exists, skipped (a skill with this name)")
             continue
         shutil.copytree(sk, dst)
         placed.append(sk.name)
-    report.append(f"- 스킬 {len(placed)}개 → `{dst_root}` : {placed}")
-    # 스킬이 아닌 형제 폴더(SKILL.md 없음)를 한 스킬이 상대경로(../폴더명/)나
-    # ${CLAUDE_PLUGIN_ROOT}/skills/폴더명 으로 참조하면, 그 폴더도 같이 옮겨야 링크가 안 깨진다.
-    # 평평한 skills/ 구조라 상대경로는 그대로 살아있다 — 폴더 자체만 옮기면 된다.
+    report.append(f"- {len(placed)} skill(s) → `{dst_root}`: {placed}")
+    # A sibling folder that isn't itself a skill (no SKILL.md) may be referenced by a skill via a
+    # relative path (../folder-name/) or ${CLAUDE_PLUGIN_ROOT}/skills/folder-name — that folder has
+    # to move too or the reference breaks. Skills/ is flat, so the relative path still resolves —
+    # only the folder itself needs copying.
     shared_dirs = [d for d in skill_dirs if d.is_dir() and not (d / "SKILL.md").exists()]
     shared_copied = []
     for shared in shared_dirs:
@@ -470,24 +481,25 @@ def install_skills_only(power_dir: Path, report: list[str], name: str) -> None:
             continue
         dst = dst_root / shared.name
         if dst.exists():
-            report.append(f"- ⚠️ `{dst}` 이미 있어 공유 폴더를 건너뜀 (참조하는 스킬이 깨질 수 있음)")
+            report.append(f"- ⚠️ `{dst}` already exists, shared folder skipped (a referencing skill may break)")
             continue
         shutil.copytree(shared, dst)
         shared_copied.append(shared.name)
     if shared_copied:
-        report.append(f"- 스킬이 참조하는 공유 폴더 {len(shared_copied)}개도 함께 옮김: {shared_copied}")
+        report.append(f"- Also moved {len(shared_copied)} shared folder(s) referenced by skills: {shared_copied}")
     total_src = len([sk for sk in (power_dir / "skills").iterdir() if (sk / "SKILL.md").exists()])
     if total_src and not placed:
-        report.append("- ❌ 스킬을 하나도 옮기지 못했습니다 — 전부 이름이 겹쳐 건너뛰었습니다. "
-                       "폴더 이름이 같아도 내용은 다른 플러그인별 전용 스킬입니다 "
-                       "(예: `api-patterns`는 여러 플러그인이 같은 이름으로 각자 다른 내용을 담음). "
-                       "`--as power`로 다시 옮기면 이름 충돌 없이 Power 안에 별도로 보관됩니다")
-    report.append("- Power 로 만들지 않았습니다. 스킬이 `/이름` 슬래시로 호출되고, Kiro 기본 스킬 매칭도 됩니다")
+        report.append("- ❌ No skills were moved — all of them were skipped on a name clash. "
+                       "Same folder name doesn't mean same content across plugins "
+                       "(e.g. `api-patterns` shows up under several plugins, each with different content). "
+                       "Re-run with `--as power` to keep it separate inside a Power, with no name collision")
+    report.append("- Not wrapped in a Power. Skills are callable by `/name` slash, and Kiro's default skill matching also applies")
     hooks, agents = [], []
     hook_files = list((power_dir / "dev.kiro/hooks").glob("*.json"))
-    # ${CLAUDE_PLUGIN_ROOT}는 Port.run 2단계에서 이미 power_dir 절대경로로 치환돼 있다.
-    # 스킬 본문이 skills/ 밖(references/, scripts/ 등)을 그 경로로 참조하면, power_dir가
-    # 곧 삭제되므로(호출부에서 rmtree) 훅이 없어도 그 트리를 보존하고 경로를 다시 써야 한다.
+    # ${CLAUDE_PLUGIN_ROOT} was already substituted with power_dir's absolute path back in step 2
+    # of Port.run. If a skill body references that path outside skills/ (references/, scripts/,
+    # etc.), power_dir is about to be deleted (the caller rmtrees it) — that tree needs preserving,
+    # and the path rewritten, even when there are no hooks.
     needs_assets = bool(hook_files) or any(
         str(power_dir) in (dst_root / p / "SKILL.md").read_text(errors="ignore")
         for p in placed
@@ -500,7 +512,7 @@ def install_skills_only(power_dir: Path, report: list[str], name: str) -> None:
         asset_root.parent.mkdir(parents=True, exist_ok=True)
         shutil.copytree(power_dir, asset_root, symlinks=True,
                         ignore=shutil.ignore_patterns("dev.kiro", "PORT-REPORT.md"))
-        report.append(f"- 참조 파일을 `{asset_root}` 에 보존했습니다")
+        report.append(f"- Preserved referenced files at `{asset_root}`")
         for p in placed:
             skill_md = dst_root / p / "SKILL.md"
             body = skill_md.read_text(errors="ignore")
@@ -514,45 +526,45 @@ def install_skills_only(power_dir: Path, report: list[str], name: str) -> None:
         if asset_root:
             body = body.replace(str(power_dir), str(asset_root))
         dst.write_text(body); hooks.append(hook.name)
-        report.append(f"- 훅 설치: `{dst}` (Power 등록과 무관하게 발화합니다)")
+        report.append(f"- Hook installed: `{dst}` (fires regardless of Power registration)")
     for ag in (power_dir / "dev.kiro/agents").glob("*.md"):
         dst = KIRO / "agents" / ag.name
         dst.parent.mkdir(parents=True, exist_ok=True)
         if dst.exists():
-            report.append(f"- ⚠️ `{dst}` 이미 있어 건너뜀")
+            report.append(f"- ⚠️ `{dst}` already exists, skipped")
             continue
         shutil.copy(ag, dst); agents.append(ag.name)
-        report.append(f"- 에이전트 설치: `{dst}` (`kiro-cli --v3 --agent {ag.stem}` 로 시작해야 적용됩니다)")
+        report.append(f"- Agent installed: `{dst}` (start with `kiro-cli --v3 --agent {ag.stem}` for it to apply)")
     _manifest_put(name, {"mode": "skills", "skills": placed, "hooks": hooks, "agents": agents})
 
 
 def install_project_local(power_dir: Path, project: Path, report: list[str]) -> None:
-    """Power 대신 프로젝트의 .kiro/ 에 풀어놓는다 (CC의 project 스코프에 대응)."""
+    """Unpack into the project's .kiro/ instead of a Power (matches CC's project scope)."""
     k = project / ".kiro"
     for sk in (power_dir / "skills").iterdir() if (power_dir / "skills").is_dir() else []:
         dst = k / "skills" / sk.name
         if dst.exists():
-            report.append(f"- ⚠️ `{dst}` 이미 있어 건너뜀")
+            report.append(f"- ⚠️ `{dst}` already exists, skipped")
             continue
         shutil.copytree(sk, dst)
-    report.append(f"- 스킬 → `{k / 'skills'}`")
+    report.append(f"- Skills → `{k / 'skills'}`")
     for hook in (power_dir / "dev.kiro/hooks").glob("*.json"):
         (k / "hooks").mkdir(parents=True, exist_ok=True)
         shutil.copy(hook, k / "hooks" / hook.name)
-        report.append(f"- 훅 → `{k / 'hooks' / hook.name}`")
+        report.append(f"- Hook → `{k / 'hooks' / hook.name}`")
     for ag in (power_dir / "dev.kiro/agents").glob("*.md"):
         (k / "agents").mkdir(parents=True, exist_ok=True)
         if not (k / "agents" / ag.name).exists():
             shutil.copy(ag, k / "agents" / ag.name)
-            report.append(f"- 에이전트 → `{k / 'agents' / ag.name}`")
+            report.append(f"- Agent → `{k / 'agents' / ag.name}`")
     mcp = power_dir / "mcp.json"
     if mcp.exists():
         target = k / "settings/mcp.json"
         cur = _load(target, {"mcpServers": {}})
         cur.setdefault("mcpServers", {}).update(json.loads(mcp.read_text())["mcpServers"])
         _save(target, cur)
-        report.append(f"- MCP → `{target}` 에 병합")
-    report.append("- 참고: 프로젝트 로컬은 Power가 아니므로 keywords 활성화 없음. 스킬은 Kiro 기본 스킬 매칭으로 동작")
+        report.append(f"- MCP → merged into `{target}`")
+    report.append("- Note: project-local isn't a Power, so there's no keywords activation. Skills work through Kiro's default skill matching")
 
 
 def register(name: str, power_dir: Path, report: list[str]) -> None:
@@ -567,20 +579,20 @@ def register(name: str, power_dir: Path, report: list[str]) -> None:
     if not any(p["name"] == name for p in inst["installedPowers"]):
         inst["installedPowers"].append({"name": name, "registryId": "user-added"})
     _save(inst_p, inst)
-    # Power 밖으로 나가야 하는 것들
+    # Things that have to live outside the Power
     for hook in (power_dir / "dev.kiro/hooks").glob("*.json"):
         dst = KIRO / "hooks" / hook.name
         dst.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(hook, dst)
-        report.append(f"- 훅 설치: `{dst}`")
+        report.append(f"- Hook installed: `{dst}`")
     for ag in (power_dir / "dev.kiro/agents").glob("*.md"):
         dst = KIRO / "agents" / ag.name
         if dst.exists():
-            report.append(f"- ⚠️ `{dst}` 이미 있어 건너뜀")
+            report.append(f"- ⚠️ `{dst}` already exists, skipped")
             continue
         dst.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(ag, dst)
-        report.append(f"- 에이전트 설치: `{dst}`")
+        report.append(f"- Agent installed: `{dst}`")
 
 
 def unregister(name: str) -> None:
@@ -598,7 +610,7 @@ def unregister(name: str) -> None:
             (KIRO / "agents" / a).unlink(missing_ok=True)
         del man[name]
         _save(MANIFEST, man)
-        print(f"removed {name} (스킬 {len(ent.get('skills', []))}개)")
+        print(f"removed {name} ({len(ent.get('skills', []))} skill(s))")
         return
     if ent:
         del man[name]
@@ -622,7 +634,7 @@ def unregister(name: str) -> None:
 
 
 def smoke(names: list[str]) -> None:
-    """kiro-cli v3에 실제 로드되는지 확인. TTY가 필요해 script(1)로 감싼다."""
+    """Confirm kiro-cli v3 actually loads it. Needs a TTY, so it's wrapped in script(1)."""
     prompt = "Do not use any tools. List the names of all installed powers you can see, one per line, then stop."
     log = Path("/tmp/kiro-port-smoke.txt")
     subprocess.run(["script", "-q", str(log), "kiro-cli", "chat", "--v3", "--no-interactive", prompt],
@@ -645,16 +657,16 @@ def main() -> None:
     ap.add_argument("names", nargs="*")
     ap.add_argument("--all", action="store_true")
     ap.add_argument("--dry-run", action="store_true")
-    ap.add_argument("--out", type=Path, help="설치하지 않고 이 디렉터리에 Power 저장소만 생성")
+    ap.add_argument("--out", type=Path, help="generate a Power repo here without installing it")
     ap.add_argument("--smoke", action="store_true")
     ap.add_argument("--scope", choices=["user", "project", "all"], default="all",
-                    help="CC 설치 스코프 필터. 기본: user 전부 + 현재 디렉터리에 해당하는 project")
+                    help="CC install-scope filter. Default: all user installs + whatever project scope matches the current directory")
     ap.add_argument("--project-local", action="store_true",
-                    help="Power 대신 현재 디렉터리의 .kiro/ 에 풀어놓기 (project 스코프 대응)")
+                    help="unpack into the current directory's .kiro/ instead of a Power (matches CC's project scope)")
     ap.add_argument("--from", dest="src", metavar="SOURCE",
-                    help="설치 기록 대신 마켓플레이스/플러그인 저장소에서 직접: 로컬 경로 | owner/repo | git URL")
+                    help="skip install records and go straight to a marketplace/plugin repo: local path | owner/repo | git URL")
     ap.add_argument("--as", dest="mode", choices=["auto", "skills", "power"], default="auto",
-                    help="설치 방식. auto(기본): 스킬만 있으면 ~/.kiro/skills/, 복합이면 Power")
+                    help="install mode. auto (default): skills-only goes to ~/.kiro/skills/, mixed goes to a Power")
     a = ap.parse_args()
     cwd = Path.cwd().resolve()
 
@@ -665,43 +677,43 @@ def main() -> None:
 
     if a.src:
         root = fetch_source(a.src)
-        # scan 은 목록만 (원격 항목은 받아오지 않음), port 는 지목된 것만 받아온다
+        # scan just lists (remote entries aren't fetched); port fetches only the ones named
         only = None if a.all else {n.partition("@")[0] for n in a.names}
         cands = marketplace_plugins(root, fetch=(a.cmd == "port"), only=only)
         sources = [{"tool": "market", "name": c["name"], "market": Path(a.src).name, "path": c["path"],
                     "version": c["version"], "scope": "user", "project": "",
                     "remote": c.get("remote")} for c in cands]
         if not sources:
-            sys.exit(f"{a.src}: .claude-plugin/marketplace.json 도 plugin.json 도 없음")
+            sys.exit(f"{a.src}: no .claude-plugin/marketplace.json or plugin.json found")
     else:
         sources = scan_sources()
     if a.cmd == "scan":
-        LABEL = {"skills": "스킬 폴더 복사", "power": "Power", "steering": "steering 수동 배치"}
-        print(f"{'플러그인':30} {'출처':7} {'구성':34} 권장")
+        LABEL = {"skills": "skills folder copy", "power": "Power", "steering": "manual steering placement"}
+        print(f"{'plugin':30} {'source':7} {'components':34} recommendation")
         for s in sources:
             if not s.get("path"):
                 r = s.get("remote") or {}
-                print(f"{s['name']:30} {s['market'][:7]:7} 원격: {r.get('url') or r.get('repo','')}")
+                print(f"{s['name']:30} {s['market'][:7]:7} remote: {r.get('url') or r.get('repo','')}")
                 continue
             kind, n = classify(Path(s["path"]))
             rec = recommend(kind)
             comp = " ".join(f"{k[:4]}{v}" for k, v in n.items() if v)
-            proj = "·프로젝트" if s["scope"] == "project" else ""
+            proj = "·project" if s["scope"] == "project" else ""
             print(f"{s['name']:30} {s['tool']:7} {comp:34} {LABEL[rec]}{proj}")
-        print(f"\n전역 스킬 {global_skill_count()}개 (~/.kiro/skills)")
-        print("구성에 commands·agents·hooks·mcp 가 있으면 Power, 스킬만이면 폴더 복사가 기본입니다. "
-              "`--as skills|power` 로 바꿀 수 있습니다.")
+        print(f"\n{global_skill_count()} global skill(s) (~/.kiro/skills)")
+        print("A Power is the default when commands/agents/hooks/mcp are present; skills-only defaults to a folder copy. "
+              "Override with `--as skills|power`.")
         return
 
     def in_scope(s: dict) -> bool:
-        # project 스코프는 그 프로젝트 안에서 실행할 때만 대상 (CC와 같은 가시성)
+        # project scope only applies when running inside that project (matches CC's own visibility)
         if s["scope"] == "project":
             here = s.get("project") and cwd.is_relative_to(Path(s["project"]).resolve())
             return a.scope in ("project", "all") and bool(here)
         return a.scope in ("user", "all")
     sources = [s for s in sources if in_scope(s)]
 
-    # 선택: name 또는 name@market. 같은 이름이 여러 곳이면 CC 우선, 최신 순
+    # Selection: name or name@market. If the same name shows up in several places, prefer CC, newest first
     picked = []
     for key in (["*"] if a.all else a.names):
         n, _, mk = key.partition("@")
@@ -710,18 +722,18 @@ def main() -> None:
         cands = [s for s in cands if s.get("path")]
         for s in unfetched:
             r = s.get("remote") or {}
-            print(f"   ⚠️ {s['name']}: 원격 저장소를 받지 못했습니다 ({r.get('url') or r.get('repo', '?')})")
+            print(f"   ⚠️ {s['name']}: could not fetch the remote repo ({r.get('url') or r.get('repo', '?')})")
         if not cands:
-            sys.exit(f"not found: {key} (scan 으로 확인)")
+            sys.exit(f"not found: {key} (check with scan)")
         seen = set()
-        # 같은 이름이 여러 곳이면 CC 설치본 → Codex 설치본 → 마켓플레이스 원본 순
+        # If the same name shows up in several places: CC install → Codex install → marketplace source, in that order
         for s in sorted(cands, key=lambda s: (s["tool"] != "claude", s["scope"] == "market", s["name"])):
             if s["name"] not in seen:
                 seen.add(s["name"])
                 picked.append(s)
 
     if a.project_local:
-        base = cwd / ".kiro/.ported"  # 변환 중간물. 실제 파일은 .kiro/{skills,hooks,agents} 로 분배
+        base = cwd / ".kiro/.ported"  # conversion staging area — actual files land in .kiro/{skills,hooks,agents}
     else:
         base = a.out or (KIRO / "powers/installed")
     taken = {p.name for p in (KIRO / "powers/installed").iterdir()} if (KIRO / "powers/installed").is_dir() else set()
@@ -732,35 +744,35 @@ def main() -> None:
         if a.project_local:
             mode = "project"
         if mode == "steering":
-            print(f"\n== {name}  → 옮기지 않았습니다")
-            print(f"   스킬·명령·훅·MCP 가 없어 플러그인이라기보다 지침 문서입니다. Kiro 에서는 "
-                  f"`~/.kiro/steering/` 에 `inclusion: always` 머리말을 붙여 두는 자리가 맞고, "
-                  f"Power 로 만들면 '항상 적용'이 '키워드 조건부'로 바뀌어 의도가 달라집니다.\n"
-                  f"   원본: {s['path']}")
+            print(f"\n== {name}  → not moved")
+            print(f"   No skills, commands, hooks, or MCP — this reads as guidance rather than a plugin. In Kiro the "
+                  f"right place for it is `~/.kiro/steering/` with an `inclusion: always` frontmatter line; "
+                  f"wrapping it in a Power would turn 'always applies' into 'keyword-conditional' and change what was intended.\n"
+                  f"   Source: {s['path']}")
             continue
         if mode == "skills":
-            # 훅·에이전트는 Power 밖에 설치되므로 skills 모드에서도 함께 살린다.
+            # Hooks and agents install outside the Power either way, so they're kept even in skills mode.
             lost = [k for k in ("commands", "mcp") if ncomp[k]]
-            if lost:  # 사용자가 --as skills 를 강제한 경우
-                print(f"   ⚠️ `{name}` 은 {lost} 도 가지고 있습니다. 스킬만 복사하면 이건 옮겨지지 "
-                      f"않습니다. 전부 옮기려면 `--as power` 를 쓰세요.")
-        # Power 이름은 Kiro 전체에서 유일해야 한다 (중복이면 Power 목록 전체가 로드되지 않는다)
+            if lost:  # the user forced --as skills
+                print(f"   ⚠️ `{name}` also has {lost}. A skills-only copy won't bring that over — "
+                      f"use `--as power` to bring everything.")
+        # Power names must be unique across Kiro — a clash silently drops the whole Power list from loading
         if name in taken and not (KIRO / "powers/installed" / name / "PORT-REPORT.md").exists():
             alt = f"{name}-{s['market']}".replace("@", "-")[:64]
-            print(f"   ⚠️ `{name}` 은 이미 다른 Power가 쓰는 이름 → `{alt}` 로 설치")
+            print(f"   ⚠️ `{name}` is already used by another Power → installing as `{alt}` instead")
             name = alt
         taken.add(name)
         power_dir = base / name
         where = (f"{cwd}/.kiro/" if mode == "project" else
                  f"{KIRO}/skills/" if mode == "skills" else power_dir)
-        why = {"skills": "스킬만 있어 Power 로 감싸지 않음", "power": f"{kind} 구성", "project": "프로젝트 로컬"}[mode]
+        why = {"skills": "skills-only, not wrapped in a Power", "power": f"{kind} components", "project": "project-local"}[mode]
         print(f"\n== {name}  ({s['tool']} · {s['market']} · {s['scope']})  →  {where}  [{why}]")
         if a.dry_run:
             continue
         if power_dir.exists():
             if not (power_dir / "PORT-REPORT.md").exists():
-                print(f"   ⛔ `{power_dir}` 는 이 도구가 만든 Power가 아닙니다 (이미 설치된 Power). 건너뜀. "
-                      f"교체하려면 먼저 Kiro에서 제거하세요.")
+                print(f"   ⛔ `{power_dir}` isn't a Power this tool created (an existing Power). Skipped. "
+                      f"Remove it from Kiro first if you want to replace it.")
                 continue
             shutil.rmtree(power_dir)
         report = [f"# Port report — {name}", f"source: `{s['path']}` ({s['tool']} marketplace `{s['market']}`, scope {s['scope']})", ""]
@@ -769,27 +781,27 @@ def main() -> None:
             install_project_local(power_dir, cwd, report)
         elif mode == "skills" and not a.out:
             install_skills_only(power_dir, report, name)
-            shutil.rmtree(power_dir)  # 중간 산출물은 남기지 않는다
+            shutil.rmtree(power_dir)  # no staging leftovers kept
         elif not a.out:
             if s["scope"] == "project":
-                report.append(f"- ⚠️ 원본은 `{s['project']}` 프로젝트 스코프였으나 Power는 전역 설치됨. "
-                              f"프로젝트에만 두려면 그 디렉터리에서 `--project-local`")
+                report.append(f"- ⚠️ Source was project-scoped to `{s['project']}` but the Power installed globally. "
+                              f"Run `--project-local` from that directory to keep it project-only")
             register(name, power_dir, report)
         report.append("")
-        report.append("## 사람이 확인할 것")
+        report.append("## Worth checking by hand")
         if mode == "skills":
             lost = [k for k in ("commands", "mcp") if ncomp[k]]
             if lost:
-                report.append(f"- ❌ {lost} 는 옮겨지지 않았습니다 — Power 만 담을 수 있습니다 (`--as power`)")
-            report += [f"- 스킬은 `{KIRO}/skills/` 에 있습니다. 이름이 겹치면 건너뛰었으니 위 ⚠️ 를 확인하세요",
-                       "- keywords 자동 활성화가 필요하면 `--as power` 로 다시 옮기세요"]
+                report.append(f"- ❌ {lost} weren't moved — only a Power can carry those (`--as power`)")
+            report += [f"- Skills are in `{KIRO}/skills/`. Anything with a name clash was skipped — check the ⚠️ above",
+                       "- Run `--as power` again if you need keywords-based auto-activation"]
         else:
-            report += ["- `plugin.json`의 `keywords` — 이름에서 기계적으로 뽑았음. 이 Power가 켜져야 하는 상황의 단어로 다듬기",
-                       "- 훅이 있었다면 `~/.kiro/hooks/`에 복사됐는지, 도구명 매핑이 맞는지",
-                       "- 에이전트는 `~/.kiro/agents/`에 마크다운 그대로. 도구 제한(`tools`)은 제거됨"]
+            report += ["- `plugin.json`'s `keywords` — pulled mechanically from names. Tune them to the actual phrases that should activate this Power",
+                       "- If there were hooks, check they copied to `~/.kiro/hooks/` and that the tool-name mapping is right",
+                       "- Agents are plain markdown under `~/.kiro/agents/`. Tool restrictions (`tools`) are stripped"]
         if power_dir.exists():
             (power_dir / "PORT-REPORT.md").write_text("\n".join(report) + "\n")
-        else:  # skills 모드는 Power 디렉터리를 남기지 않으므로 별도 보관
+        else:  # skills mode leaves no Power directory, so the report is kept separately
             rp = KIRO / ".kiro-port-reports" / f"{name}.md"
             rp.parent.mkdir(parents=True, exist_ok=True)
             rp.write_text("\n".join(report) + "\n")
@@ -798,10 +810,10 @@ def main() -> None:
         reg = [p["name"] for p in _load(KIRO / "powers/installed.json", {"installedPowers": []})["installedPowers"]]
         nskill = sum(1 for n in reg for _ in (KIRO / "powers/installed" / n / "skills").glob("*/SKILL.md"))
         nfile = sum(1 for n in reg for p in (KIRO / "powers/installed" / n).rglob("*") if p.is_file())
-        print(f"\n등록 Power {len(reg)}개 · 스킬 {nskill}개 · 파일 {nfile}개")
+        print(f"\n{len(reg)} Power(s) registered · {nskill} skill(s) · {nfile} file(s)")
         if nfile > FILE_WARN * 2:
-            print(f"⚠️  파일이 {nfile}개입니다. Kiro 는 스킬 트리의 모든 파일마다 fd 를 열어두므로"
-                  f"(kirodotdev/Kiro#10625) `spawn EBADF` 로 셸이 멈출 수 있습니다.")
+            print(f"⚠️  {nfile} files. Kiro keeps a file descriptor open per file under a skill tree "
+                  f"(kirodotdev/Kiro#10625), which can stall the shell with `spawn EBADF` at this scale.")
     if a.smoke and not a.dry_run and not a.out:
         print("\n== smoke test (kiro-cli --v3)")
         smoke([s["name"] for s in picked])

--- a/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/scripts/kiro-port.py
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/scripts/kiro-port.py
@@ -1,0 +1,811 @@
+#!/usr/bin/env python3
+"""Claude Code / Codex 마켓플레이스로 설치한 플러그인을 Kiro Power로 이식한다.
+
+    kiro-port.py scan                      # CC·Codex에 설치된 플러그인 목록
+    kiro-port.py port <name>[@<market>]... # 변환 + ~/.kiro 에 설치·등록
+    kiro-port.py port --all
+    kiro-port.py unport <name>...          # 이식한 Power 제거
+옵션: --dry-run  --out DIR(설치하지 않고 저장소만 생성)  --smoke(kiro-cli v3로 로드 확인)
+
+원칙: 본문은 바이트 단위로 그대로. 바뀌는 것은 포장(plugin.json, 머리말 한 줄, 훅 스키마)과
+위치만. 사람이 정해야 할 것(keywords 등)은 REPORT에 남긴다. 표준 밖 항목은 지우지 않고
+dev.kiro/ 및 ~/.kiro/hooks, ~/.kiro/agents 로 옮긴다.
+"""
+import argparse
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+HOME = Path.home()
+KIRO = Path(os.environ.get("KIRO_HOME", HOME / ".kiro"))
+PLUGIN_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
+MCP_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json"
+HOOK_EVENTS = {"PreToolUse", "PostToolUse", "UserPromptSubmit", "Stop", "SessionStart"}
+# 이벤트명은 그대로 옮긴다. kiro.dev/docs/hooks/ 는 PromptSubmit/AgentStop 이라 적지만, 실제 `kiro-cli
+# --v3` 인터랙티브 세션에 두 이름을 나란히 걸어 직접 확인한 결과 발동하는 건 원래 이름
+# (UserPromptSubmit/Stop) 쪽이었다 — 문서가 실제 CLI 동작과 다르다.
+HOOK_TOOL_MAP = {"Bash": "execute_bash", "Read": "fs_read", "Write": "fs_write", "Edit": "fs_write"}
+CMD_DROP_KEYS = {"allowed-tools", "argument-hint"}
+# Kiro 는 스킬 트리의 모든 파일마다 fd 를 열고 닫지 않아(kirodotdev/Kiro#10625) 파일이 많으면
+# 확장 호스트의 fd 가 고갈되고 `spawn EBADF` 로 셸이 죽는다. 실행에 불필요한 트리는 옮기지 않는다.
+EXCLUDE = shutil.ignore_patterns(
+    ".git", "node_modules", ".venv", "venv", "__pycache__", ".pytest_cache", ".mypy_cache",
+    "dist", "build", ".next", ".turbo", "target", "*.log", "*.map", ".DS_Store")
+FILE_WARN = 2000  # 이보다 파일이 많으면 경고
+AGENT_DROP_KEYS = {"tools", "model", "mcpServers", "hooks", "permissionMode", "color", "effort",
+                   "initialPrompt", "disallowedTools", "skills", "memory", "background", "isolation", "maxTurns"}
+MANIFEST = Path(os.environ.get("KIRO_HOME", HOME / ".kiro")) / ".kiro-port-manifest.json"
+
+
+def classify(src: Path) -> tuple[str, dict]:
+    """플러그인을 skills(스킬만) / plugin(복합) / guidance(지침) 로 분류.
+
+    Power 로 감쌀 필요가 있는지 판단하기 위한 것. 스킬만 있으면 Kiro 도 Agent Skills 표준을
+    읽으므로 폴더 복사로 충분하고, Power 로 만들면 keywords 활성화 단계가 더 붙는다.
+    """
+    n = {
+        "skills": len([d for d in (src / "skills").iterdir() if (d / "SKILL.md").exists()])
+                  if (src / "skills").is_dir() else 0,
+        "commands": len(list((src / "commands").iterdir())) if (src / "commands").is_dir() else 0,
+        "agents": len(list((src / "agents").glob("*.md"))) if (src / "agents").is_dir() else 0,
+        "hooks": 0,
+        "mcp": 1 if (src / ".mcp.json").exists() else 0,
+    }
+    mf = next((p for p in (src / ".claude-plugin/plugin.json", src / "plugin.json") if p.exists()), None)
+    m = json.loads(mf.read_text()) if mf else {}
+    if (src / "hooks/hooks.json").exists() or isinstance(m.get("hooks"), str):
+        n["hooks"] = 1
+    # 훅과 에이전트는 어차피 Power 밖(~/.kiro/hooks, ~/.kiro/agents)에 설치되므로 Power 를 요구하지 않는다.
+    # 검증: superpowers 를 Power 등록 해제하고 스킬만 전역에 둬도 SessionStart 훅이 그대로 발화한다.
+    # Power 가 반드시 필요한 것은 mcp.json(Power 활성화 시 연결)과, 스킬로 바꿀 commands 다.
+    if n["commands"] or n["mcp"]:
+        return "plugin", n
+    if n["skills"]:
+        return "skills", n
+    if n["hooks"] or n["agents"]:
+        return "sidecar", n   # 스킬 없이 훅/에이전트만 — Power 껍데기만 필요
+    return "guidance", n
+
+
+def global_skill_count() -> int:
+    d = KIRO / "skills"
+    return len([x for x in d.iterdir() if (x / "SKILL.md").exists()]) if d.is_dir() else 0
+
+
+def recommend(kind: str) -> str:
+    """분류에 따라 설치 방식을 권한다. 스킬만 있으면 Power 로 감쌀 이유가 없다."""
+    return {"plugin": "power", "guidance": "steering", "skills": "skills", "sidecar": "power"}[kind]
+
+
+# ------------------------------------------------------------------ 설치 상태 읽기
+
+def scan_sources() -> list[dict]:
+    """CC와 Codex가 로컬에 설치해 둔 플러그인 디렉터리 목록."""
+    out = []
+    cc = HOME / ".claude/plugins/installed_plugins.json"
+    if cc.exists():
+        data = json.loads(cc.read_text())
+        for key, installs in data.get("plugins", {}).items():
+            name, _, market = key.partition("@")
+            for inst in installs:
+                p = Path(inst["installPath"])
+                if p.is_dir():
+                    out.append({"tool": "claude", "name": name, "market": market, "path": p,
+                                "version": inst.get("version", ""), "scope": inst.get("scope", ""),
+                                "project": inst.get("projectPath", "")})
+    # Codex: config.toml 의 [marketplaces.*] + [plugins."name@market"] 가 설치 상태
+    cfg_p = HOME / ".codex/config.toml"
+    if cfg_p.exists():
+        cfg = tomllib.loads(cfg_p.read_text())
+        roots = {}
+        for mk, m in cfg.get("marketplaces", {}).items():
+            src = m.get("source", "")
+            root = Path(src) if m.get("source_type") == "local" or src.startswith("/") else HOME / ".codex/.tmp/marketplaces" / mk
+            roots[mk] = root
+        for key, p in cfg.get("plugins", {}).items():
+            name, _, mk = key.partition("@")
+            root = roots.get(mk)
+            if not root or not p.get("enabled", True):
+                continue
+            if mk.startswith("openai-"):  # ChatGPT/Codex 앱 내장 플러그인 — 런타임 종속, 이식 대상 아님
+                continue
+            # 설치본은 ~/.codex/plugins/cache/<market>/<name>/<version>/ (최신 것 하나)
+            vers = sorted((HOME / ".codex/plugins/cache" / mk / name).glob("*/"), key=os.path.getmtime)
+            if vers:
+                cands = [{"name": name, "path": vers[-1], "version": vers[-1].name}]
+            else:  # 캐시가 없으면 마켓플레이스 스냅샷의 로컬 소스
+                cands = [c for c in marketplace_plugins(root) if c["name"] == name]
+            for cand in cands:
+                out.append({"tool": "codex", "name": name, "market": mk, "path": cand["path"],
+                            "version": cand.get("version", ""), "scope": "user", "project": ""})
+    return out
+
+
+def marketplace_plugins(root: Path, fetch: bool = False, only: set | None = None) -> list[dict]:
+    """마켓플레이스 저장소(.claude-plugin/marketplace.json) 안의 플러그인 목록.
+    항목 `source` 가 문자열이면 저장소 안의 경로, dict 면 다른 git 저장소를 가리킨다
+    (`url` / `git-subdir` / `github`). fetch=True 면 그 저장소도 받아온다.
+    marketplace.json 이 없고 저장소 자체가 플러그인이면 그 하나."""
+    mj = root / ".claude-plugin/marketplace.json"
+    items = []
+    if mj.exists():
+        for e in json.loads(mj.read_text()).get("plugins", []):
+            src, p = e.get("source"), None
+            if isinstance(src, str):
+                p = (root / src).resolve()
+                p = p if p.is_dir() else None
+            elif isinstance(src, dict):
+                if not fetch or (only is not None and e["name"] not in only):
+                    # 원격 저장소는 지목된 것만 받아온다 (대형 마켓플레이스는 항목이 수천 개)
+                    items.append({"name": e["name"], "path": None, "version": str(e.get("version", "")),
+                                  "description": e.get("description", ""), "remote": src})
+                    continue
+                repo = src.get("url") or src.get("repo") or ""
+                if repo:
+                    try:
+                        p = fetch_source(repo, ref=src.get("ref")) / (src.get("path") or "")
+                    except subprocess.CalledProcessError:
+                        p = None
+                    p = p if p and p.is_dir() else None
+            if p:
+                items.append({"name": e["name"], "path": p, "version": str(e.get("version", "")),
+                              "description": e.get("description", "")})
+    elif (root / ".claude-plugin/plugin.json").exists() or (root / "plugin.json").exists():
+        m = json.loads(next(p for p in (root / ".claude-plugin/plugin.json", root / "plugin.json") if p.exists()).read_text())
+        items.append({"name": m.get("name", root.name), "path": root, "version": str(m.get("version", "")),
+                      "description": m.get("description", "")})
+    return items
+
+
+def fetch_source(src: str, ref: str | None = None) -> Path:
+    """로컬 경로 | owner/repo | git URL → 로컬 디렉터리 (git 은 얕게 클론, 캐시 재사용)."""
+    p = Path(src).expanduser()
+    if p.is_dir():
+        return p.resolve()
+    url = src if "://" in src or src.startswith("git@") else f"https://github.com/{src}.git"
+    dst = HOME / ".cache/kiro-port" / re.sub(r"[^\w.-]", "_", f"{src}@{ref}" if ref else src)
+    if dst.is_dir():
+        return dst
+    cmd = ["git", "clone", "-q", "--depth", "1"] + (["--branch", ref] if ref else []) + [url, str(dst)]
+    subprocess.run(cmd, check=True, capture_output=True)
+    return dst
+
+
+# ------------------------------------------------------------------ frontmatter (YAML 부분집합)
+
+def split_frontmatter(text: str):
+    """(머리말 줄 목록, 본문) — 본문은 바이트 그대로 보존하기 위해 문자열로 반환."""
+    if not text.startswith("---"):
+        return [], text
+    end = text.find("\n---", 3)
+    if end < 0:
+        return [], text
+    fm = text[4:end].split("\n")
+    body = text[end + 4:]
+    return fm, body
+
+
+def fm_blocks(lines: list[str]) -> list[tuple[str, list[str]]]:
+    """머리말을 (키, 원문 줄들) 블록으로. 들여쓴 연속 줄은 앞 키에 붙인다."""
+    blocks, cur = [], None
+    for ln in lines:
+        m = re.match(r"^([\w-]+)\s*:", ln)
+        if m:
+            cur = (m.group(1), [ln])
+            blocks.append(cur)
+        elif cur:
+            cur[1].append(ln)
+    return blocks
+
+
+def rebuild_fm(blocks: list[tuple[str, list[str]]], body: str) -> str:
+    lines = [ln for _, ls in blocks for ln in ls]
+    return "---\n" + "\n".join(lines) + "\n---" + body
+
+
+# ------------------------------------------------------------------ 변환
+
+class Port:
+    def __init__(self, src: Path, power_dir: Path, report: list[str]):
+        self.src, self.dst, self.report = src, power_dir, report
+        self.root_token = "${CLAUDE_PLUGIN_ROOT}"
+
+    def sub_root(self, s: str) -> str:
+        # 허용되는 유일한 본문 수정: 설치 위치가 확정되므로 절대경로로 치환
+        return s.replace(self.root_token, str(self.dst))
+
+    def manifest(self) -> dict:
+        for p in (self.src / ".claude-plugin/plugin.json", self.src / ".codex-plugin/plugin.json",
+                  self.src / "plugin.json"):
+            if p.exists():
+                return json.loads(p.read_text())
+        return {}
+
+    def run(self, name: str, version_hint: str) -> None:
+        m = self.manifest()
+        if m.get("name") and m["name"] != name:
+            # 매니페스트 name 과 등록 이름(디렉터리)이 다르면 Kiro 가 Power 목록 전체를 조용히 버린다.
+            # 등록 이름을 진실로 삼고 원래 값을 보고서에 남긴다.
+            self.report.append(f"- ⚠️ 원본 매니페스트 `name`은 `{m['name']}` 이지만 Power 이름은 `{name}` 로 맞춤 "
+                               f"(마켓플레이스 항목 이름과 매니페스트가 다른 경우. Kiro 는 이름 중복·불일치 시 로드하지 않음)")
+        # 1) 원본 복사 (CC 포맷 그대로 보존 → 같은 디렉터리를 CC도 계속 읽을 수 있음).
+        #    node_modules 등은 제외한다 — fd 누출로 Kiro 확장 호스트를 죽인다(#10625).
+        #    심볼릭 링크는 내용을 그대로 복사한다(symlinks=False) — 마켓플레이스 내부에서
+        #    플러그인 밖을 가리키는 상대 심볼릭 링크(예: ../../../.claude/commands/x.md)가
+        #    옮겨진 위치에서는 깨지기 때문.
+        shutil.copytree(self.src, self.dst, symlinks=False, ignore=EXCLUDE)
+        skipped = [p.name for p in self.src.iterdir()
+                   if p.is_dir() and p.name in ("node_modules", ".venv", "venv", "dist", "build", "target")]
+        if skipped:
+            self.report.append(f"- 복사 제외: {skipped} (런타임 의존성/빌드 산출물. 필요하면 원본에서 다시 설치)")
+        nfiles = sum(1 for p in self.dst.rglob("*") if p.is_file())
+        if nfiles > FILE_WARN:
+            self.report.append(f"- ⚠️ 파일 {nfiles}개. Kiro 는 스킬 트리의 모든 파일마다 fd 를 열어두므로"
+                               f"(kirodotdev/Kiro#10625) 이 정도면 `spawn EBADF` 로 셸이 멈출 수 있다")
+        skills = self.dst / "skills"
+        skill_names = [d.name for d in skills.iterdir() if (d / "SKILL.md").exists()] if skills.is_dir() else []
+        # 2) skills/ 본문의 ${CLAUDE_PLUGIN_ROOT}만 치환
+        for f in skills.rglob("*") if skills.is_dir() else []:
+            if f.is_file() and f.suffix in (".md", ".sh", ".py", ".json", ".yaml", ".yml"):
+                t = f.read_text(errors="replace")
+                if self.root_token in t:
+                    f.write_text(self.sub_root(t))
+                    self.report.append(f"- `{f.relative_to(self.dst)}`: `${{CLAUDE_PLUGIN_ROOT}}` → 설치 경로로 치환")
+        # 3) commands/*.md → skills/<name>/SKILL.md
+        cmd_dir = self.dst / "commands"
+        for cmd in sorted(cmd_dir.glob("*.md")) if cmd_dir.is_dir() else []:
+            self.command_to_skill(cmd, skill_names)
+        others = [p.name for p in cmd_dir.iterdir() if p.is_file() and p.suffix != ".md"] if cmd_dir.is_dir() else []
+        if others:
+            self.report.append(f"- ❌ `.md` 아닌 command 는 변환하지 않음: {others}")
+        # 4) plugin.json (루트)
+        pj = {"$schema": PLUGIN_SCHEMA, "name": name,
+              "version": str(m.get("version") or version_hint or "1.0.0"),
+              "description": m.get("description", "")}
+        for k in ("author", "license", "homepage", "repository"):
+            if k in m:
+                pj[k] = m[k]
+        pj["keywords"] = sorted(set([pj["name"]] + skill_names))
+        (self.dst / "plugin.json").write_text(json.dumps(pj, ensure_ascii=False, indent=2) + "\n")
+        self.report.append(f"- `plugin.json` 생성. `keywords`는 플러그인·스킬 **이름에서만** 추출: "
+                           f"{pj['keywords']} — 활성화 트리거이므로 필요하면 직접 수정")
+        if not m.get("version"):
+            self.report.append("- 원본에 `version` 없음 → `1.0.0`")
+        # 5) .mcp.json → mcp.json
+        mcp_src = self.dst / ".mcp.json"
+        if mcp_src.exists():
+            raw = json.loads(self.sub_root(mcp_src.read_text()))
+            servers = raw.get("mcpServers", raw)
+            (self.dst / "mcp.json").write_text(json.dumps(
+                {"$schema": MCP_SCHEMA, "mcpServers": servers}, ensure_ascii=False, indent=2) + "\n")
+            self.report.append(f"- `mcp.json` 생성 (서버 정의 무수정): {list(servers)}")
+            # 검증(kiro-cli 2.21.0): Power 의 mcp.json 에서 stdio 서버는 정상 등록되지만
+            # 원격 http/sse 서버는 조용히 무시된다(오류도 없음).
+            remote = [n for n, s in servers.items()
+                      if isinstance(s, dict) and s.get("type") in ("http", "sse", "streamable-http")]
+            if remote:
+                self.report.append(
+                    f"- ❌ 원격 MCP 서버 {remote} 는 Power 에서 로드되지 않습니다 (오류도 표시되지 않음). "
+                    f"쓰려면 정의를 `~/.kiro/settings/mcp.json` 에 직접 옮기세요. stdio 서버는 정상 동작합니다")
+        # 6) hooks → dev.kiro/hooks/<name>.json
+        hooks_file = self.dst / "hooks/hooks.json"
+        if not hooks_file.exists() and isinstance(m.get("hooks"), str):
+            hooks_file = self.dst / m["hooks"]
+        if hooks_file.exists():
+            self.convert_hooks(hooks_file, pj["name"])
+        # 7) agents → dev.kiro/agents/<name>.md
+        for ag in sorted((self.dst / "agents").glob("*.md")) if (self.dst / "agents").is_dir() else []:
+            self.convert_agent(ag)
+
+    def command_to_skill(self, cmd: Path, skill_names: list[str]) -> None:
+        sname = cmd.stem
+        target = self.dst / "skills" / sname / "SKILL.md"
+        if sname in skill_names:
+            self.report.append(f"- ⚠️ command `{sname}` 은 같은 이름의 skill 이 있어 건너뜀")
+            return
+        text = cmd.read_text(errors="replace")
+        fm, body = split_frontmatter(text)
+        blocks = fm_blocks(fm)
+        kept = [(k, ls) for k, ls in blocks if k not in CMD_DROP_KEYS]
+        dropped = [k for k, _ in blocks if k in CMD_DROP_KEYS]
+        if not any(k == "name" for k, _ in kept):
+            kept.insert(0, ("name", [f"name: {sname}"]))
+        if not any(k == "description" for k, _ in kept):
+            kept.append(("description", [f"description: {sname}"]))
+            self.report.append(f"- command `{sname}`: `description` 없어 이름으로 채움 — 확인 필요")
+        target.parent.mkdir(parents=True)
+        target.write_text(rebuild_fm(kept, self.sub_root(body)))
+        assert split_frontmatter(target.read_text())[1] == self.sub_root(body), "본문 불일치"
+        note = f" (머리말에서 제거: {', '.join(dropped)})" if dropped else ""
+        self.report.append(f"- command `{sname}.md` → `skills/{sname}/SKILL.md`, 본문 동일{note}")
+        skill_names.append(sname)
+
+    def convert_hooks(self, hooks_file: Path, pname: str) -> None:
+        """Claude Code hooks.json → Kiro v1 스키마.
+
+        Kiro 가 모르는 필드(`if`, `asyncRewake`, `timeout` 등)는 버리지 않고 보고서에 남긴다.
+        특히 `if` 는 같은 command 를 조건별로 여러 번 등록하는 데 쓰이므로, 이걸 잃으면
+        결과물이 '같은 훅의 중복'처럼 보이고 조건 분기가 조용히 사라진다.
+        """
+        raw = json.loads(hooks_file.read_text())
+        raw_hooks = raw.get("hooks", {})
+        if isinstance(raw_hooks, list):
+            # 일부 플러그인은 {event,command,...} 평면 리스트로 쓴다(중첩 matcher/hooks 배열이 아님).
+            # 이하 로직이 기대하는 {event: [{matcher, hooks:[{type,command,...}]}]} 형태로 맞춘다.
+            grouped: dict = {}
+            for item in raw_hooks:
+                ev = item["event"]
+                h = {k: v for k, v in item.items() if k != "event"}
+                h.setdefault("type", "command")
+                grouped.setdefault(ev, []).append({"hooks": [h]})
+            raw_hooks = grouped
+        out, skipped, dropped = [], [], []
+        for event, entries in raw_hooks.items():
+            if event not in HOOK_EVENTS:
+                skipped.append(event)
+                continue
+            for i, entry in enumerate(entries):
+                matcher = entry.get("matcher")
+                if matcher:
+                    parts = [HOOK_TOOL_MAP.get(p, p) for p in re.split(r"\|", matcher)]
+                    matcher = "|".join(dict.fromkeys(parts))
+                for j, h in enumerate(entry.get("hooks", [])):
+                    if h.get("type", "command") != "command":
+                        skipped.append(f"{event}[{i}].hooks[{j}] type={h.get('type')}")
+                        continue
+                    cmd = f'CLAUDE_PLUGIN_ROOT="{self.dst}" ' + self.sub_root(h["command"])
+                    # `shell` 은 이 명령을 어떤 셸로 돌리라는 지시다. Kiro 훅에는 대응 필드가 없으므로
+                    # 명령 자체를 그 셸로 감싼다. 버리면 `.cmd` 같은 파일이 직접 실행돼 실패한다.
+                    sh = h.get("shell")
+                    if sh:
+                        cmd = f"{sh} -c {shlex.quote(cmd)}"
+                    # Kiro 에 대응 필드가 없는 것들. 이름에 실어 구분을 남기고 보고서에 적는다.
+                    extra = {k: v for k, v in h.items() if k not in ("type", "command", "shell")}
+                    label = re.sub(r"[^\w.-]+", "-", str(extra.get("if", ""))).strip("-").lower()
+                    name = f"{pname}-{event.lower()}-{i}-{j}" + (f"-{label}" if label else "")
+                    hook = {"name": name[:80], "trigger": event,
+                            "action": {"type": "command", "command": cmd}}
+                    if matcher:
+                        hook["matcher"] = matcher
+                    out.append(hook)
+                    if extra:
+                        dropped.append((name[:80], extra))
+        if out:
+            d = self.dst / "dev.kiro/hooks"
+            d.mkdir(parents=True, exist_ok=True)
+            (d / f"{pname}.json").write_text(json.dumps({"version": "v1", "hooks": out}, ensure_ascii=False, indent=2) + "\n")
+            self.report.append(f"- hooks {len(out)}개 → `dev.kiro/hooks/{pname}.json` (설치 시 `~/.kiro/hooks/`로 복사)")
+            self.report.append(
+                "  ⚠️ `kiro-cli --v3`의 인터랙티브 세션에서만 발동한다(직접 확인). 클래식 모드(`kiro-cli`, "
+                "`--v3` 없이)나 `--no-interactive` 헤드리스 세션에서는 훅이 로드되지 않아 `/hooks`가 0으로 "
+                "표시된다."
+            )
+        # if 를 잃은 훅들이 같은 trigger+matcher 를 공유하면, 서로 다른 조건에서 한 번씩 돌던 것이
+        # 조건 없이 전부 같은 자리에 겹쳐 매 호출마다 그 개수만큼 반복 실행된다. 이 배수를 알려준다.
+        if_dropped = [h for h in out if any(n == h["name"] for n, e in dropped if "if" in e)]
+        overlap = {}
+        for h in if_dropped:
+            key = (h["trigger"], h.get("matcher"), h["action"]["command"])
+            overlap.setdefault(key, []).append(h["name"])
+        for name, extra in dropped:
+            keys = ", ".join(f"`{k}`" for k in extra)
+            self.report.append(f"- ❌ `{name}`: Kiro 에 대응 없는 필드를 옮기지 못했습니다 — {keys}")
+            if "if" in extra:
+                n_same = next((len(v) for v in overlap.values() if name in v), 1)
+                self.report.append(f"    원본은 `{extra['if']}` 일 때만 실행됩니다. Kiro 훅에는 조건 필드가 없어 "
+                                   f"**매처에 걸리는 모든 호출에서 실행**됩니다" +
+                                   (f" — 같은 명령이 이 자리에 {n_same}개 겹쳐 있어, 호출 한 번에 {n_same}번 돕니다"
+                                    if n_same > 1 else ""))
+        if skipped:
+            self.report.append(f"- ❌ 대응 없는 훅은 변환하지 않음: {skipped}")
+
+    def convert_agent(self, ag: Path) -> None:
+        fm, body = split_frontmatter(ag.read_text(errors="replace"))
+        blocks = fm_blocks(fm)
+        kept = [(k, ls) for k, ls in blocks if k not in AGENT_DROP_KEYS]
+        dropped = [k for k, _ in blocks if k in AGENT_DROP_KEYS]
+        d = self.dst / "dev.kiro/agents"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / ag.name).write_text(rebuild_fm(kept, self.sub_root(body)))
+        note = f" (머리말 제거: {', '.join(dropped)} — Kiro md 에이전트에 대응 없음)" if dropped else ""
+        self.report.append(f"- agent `{ag.name}` → `dev.kiro/agents/` 본문 동일{note}. 설치 시 `~/.kiro/agents/`로 복사")
+
+
+# ------------------------------------------------------------------ Kiro 설치·등록
+
+def _load(p: Path, default):
+    return json.loads(p.read_text()) if p.exists() else default
+
+
+def _save(p: Path, data) -> None:
+    if p.exists():
+        shutil.copy(p, p.with_suffix(p.suffix + ".bak"))
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n")
+
+
+def _manifest_put(name: str, entry: dict) -> None:
+    m = _load(MANIFEST, {})
+    m[name] = entry
+    _save(MANIFEST, m)
+
+
+def install_skills_only(power_dir: Path, report: list[str], name: str) -> None:
+    """스킬은 ~/.kiro/skills/ 에, 훅·에이전트는 Power 밖 제자리에 둔다.
+
+    Power 로 감싸지 않으므로 스킬이 슬래시(`/스킬이름`)로 호출된다. 훅은 ~/.kiro/hooks/ 에
+    설치되면 Power 등록과 무관하게 발화하므로 함께 살린다(검증: superpowers).
+    """
+    dst_root = KIRO / "skills"
+    dst_root.mkdir(parents=True, exist_ok=True)
+    placed = []
+    skill_dirs = sorted((power_dir / "skills").iterdir())
+    for sk in skill_dirs:
+        if not (sk / "SKILL.md").exists():
+            continue
+        dst = dst_root / sk.name
+        if dst.exists():
+            report.append(f"- ⚠️ `{dst}` 이미 있어 건너뜀 (같은 이름의 스킬)")
+            continue
+        shutil.copytree(sk, dst)
+        placed.append(sk.name)
+    report.append(f"- 스킬 {len(placed)}개 → `{dst_root}` : {placed}")
+    # 스킬이 아닌 형제 폴더(SKILL.md 없음)를 한 스킬이 상대경로(../폴더명/)나
+    # ${CLAUDE_PLUGIN_ROOT}/skills/폴더명 으로 참조하면, 그 폴더도 같이 옮겨야 링크가 안 깨진다.
+    # 평평한 skills/ 구조라 상대경로는 그대로 살아있다 — 폴더 자체만 옮기면 된다.
+    shared_dirs = [d for d in skill_dirs if d.is_dir() and not (d / "SKILL.md").exists()]
+    shared_copied = []
+    for shared in shared_dirs:
+        referenced = any(
+            shared.name in (dst_root / p / "SKILL.md").read_text(errors="ignore")
+            for p in placed
+        )
+        if not referenced:
+            continue
+        dst = dst_root / shared.name
+        if dst.exists():
+            report.append(f"- ⚠️ `{dst}` 이미 있어 공유 폴더를 건너뜀 (참조하는 스킬이 깨질 수 있음)")
+            continue
+        shutil.copytree(shared, dst)
+        shared_copied.append(shared.name)
+    if shared_copied:
+        report.append(f"- 스킬이 참조하는 공유 폴더 {len(shared_copied)}개도 함께 옮김: {shared_copied}")
+    total_src = len([sk for sk in (power_dir / "skills").iterdir() if (sk / "SKILL.md").exists()])
+    if total_src and not placed:
+        report.append("- ❌ 스킬을 하나도 옮기지 못했습니다 — 전부 이름이 겹쳐 건너뛰었습니다. "
+                       "폴더 이름이 같아도 내용은 다른 플러그인별 전용 스킬입니다 "
+                       "(예: `api-patterns`는 여러 플러그인이 같은 이름으로 각자 다른 내용을 담음). "
+                       "`--as power`로 다시 옮기면 이름 충돌 없이 Power 안에 별도로 보관됩니다")
+    report.append("- Power 로 만들지 않았습니다. 스킬이 `/이름` 슬래시로 호출되고, Kiro 기본 스킬 매칭도 됩니다")
+    hooks, agents = [], []
+    hook_files = list((power_dir / "dev.kiro/hooks").glob("*.json"))
+    # ${CLAUDE_PLUGIN_ROOT}는 Port.run 2단계에서 이미 power_dir 절대경로로 치환돼 있다.
+    # 스킬 본문이 skills/ 밖(references/, scripts/ 등)을 그 경로로 참조하면, power_dir가
+    # 곧 삭제되므로(호출부에서 rmtree) 훅이 없어도 그 트리를 보존하고 경로를 다시 써야 한다.
+    needs_assets = bool(hook_files) or any(
+        str(power_dir) in (dst_root / p / "SKILL.md").read_text(errors="ignore")
+        for p in placed
+    )
+    asset_root = None
+    if needs_assets:
+        asset_root = KIRO / ".kiro-port-assets" / name
+        if asset_root.exists():
+            shutil.rmtree(asset_root)
+        asset_root.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(power_dir, asset_root, symlinks=True,
+                        ignore=shutil.ignore_patterns("dev.kiro", "PORT-REPORT.md"))
+        report.append(f"- 참조 파일을 `{asset_root}` 에 보존했습니다")
+        for p in placed:
+            skill_md = dst_root / p / "SKILL.md"
+            body = skill_md.read_text(errors="ignore")
+            new_body = body.replace(str(power_dir), str(asset_root))
+            if new_body != body:
+                skill_md.write_text(new_body)
+    for hook in hook_files:
+        dst = KIRO / "hooks" / hook.name
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        body = hook.read_text()
+        if asset_root:
+            body = body.replace(str(power_dir), str(asset_root))
+        dst.write_text(body); hooks.append(hook.name)
+        report.append(f"- 훅 설치: `{dst}` (Power 등록과 무관하게 발화합니다)")
+    for ag in (power_dir / "dev.kiro/agents").glob("*.md"):
+        dst = KIRO / "agents" / ag.name
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if dst.exists():
+            report.append(f"- ⚠️ `{dst}` 이미 있어 건너뜀")
+            continue
+        shutil.copy(ag, dst); agents.append(ag.name)
+        report.append(f"- 에이전트 설치: `{dst}` (`kiro-cli --v3 --agent {ag.stem}` 로 시작해야 적용됩니다)")
+    _manifest_put(name, {"mode": "skills", "skills": placed, "hooks": hooks, "agents": agents})
+
+
+def install_project_local(power_dir: Path, project: Path, report: list[str]) -> None:
+    """Power 대신 프로젝트의 .kiro/ 에 풀어놓는다 (CC의 project 스코프에 대응)."""
+    k = project / ".kiro"
+    for sk in (power_dir / "skills").iterdir() if (power_dir / "skills").is_dir() else []:
+        dst = k / "skills" / sk.name
+        if dst.exists():
+            report.append(f"- ⚠️ `{dst}` 이미 있어 건너뜀")
+            continue
+        shutil.copytree(sk, dst)
+    report.append(f"- 스킬 → `{k / 'skills'}`")
+    for hook in (power_dir / "dev.kiro/hooks").glob("*.json"):
+        (k / "hooks").mkdir(parents=True, exist_ok=True)
+        shutil.copy(hook, k / "hooks" / hook.name)
+        report.append(f"- 훅 → `{k / 'hooks' / hook.name}`")
+    for ag in (power_dir / "dev.kiro/agents").glob("*.md"):
+        (k / "agents").mkdir(parents=True, exist_ok=True)
+        if not (k / "agents" / ag.name).exists():
+            shutil.copy(ag, k / "agents" / ag.name)
+            report.append(f"- 에이전트 → `{k / 'agents' / ag.name}`")
+    mcp = power_dir / "mcp.json"
+    if mcp.exists():
+        target = k / "settings/mcp.json"
+        cur = _load(target, {"mcpServers": {}})
+        cur.setdefault("mcpServers", {}).update(json.loads(mcp.read_text())["mcpServers"])
+        _save(target, cur)
+        report.append(f"- MCP → `{target}` 에 병합")
+    report.append("- 참고: 프로젝트 로컬은 Power가 아니므로 keywords 활성화 없음. 스킬은 Kiro 기본 스킬 매칭으로 동작")
+
+
+def register(name: str, power_dir: Path, report: list[str]) -> None:
+    reg_p = KIRO / "powers/registries/user-added.json"
+    reg = _load(reg_p, {"powers": []})
+    reg["powers"] = [p for p in reg["powers"] if p["name"] != name]
+    reg["powers"].append({"name": name, "description": f"Ported from Claude Code plugin ({power_dir})",
+                          "source": {"type": "local", "path": str(power_dir)}, "autoInstall": False})
+    _save(reg_p, reg)
+    inst_p = KIRO / "powers/installed.json"
+    inst = _load(inst_p, {"version": "1.0.0", "installedPowers": [], "dismissedAutoInstalls": []})
+    if not any(p["name"] == name for p in inst["installedPowers"]):
+        inst["installedPowers"].append({"name": name, "registryId": "user-added"})
+    _save(inst_p, inst)
+    # Power 밖으로 나가야 하는 것들
+    for hook in (power_dir / "dev.kiro/hooks").glob("*.json"):
+        dst = KIRO / "hooks" / hook.name
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(hook, dst)
+        report.append(f"- 훅 설치: `{dst}`")
+    for ag in (power_dir / "dev.kiro/agents").glob("*.md"):
+        dst = KIRO / "agents" / ag.name
+        if dst.exists():
+            report.append(f"- ⚠️ `{dst}` 이미 있어 건너뜀")
+            continue
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(ag, dst)
+        report.append(f"- 에이전트 설치: `{dst}`")
+
+
+def unregister(name: str) -> None:
+    man = _load(MANIFEST, {})
+    ent = man.get(name)
+    if ent and ent.get("mode") == "skills":
+        for sk in ent.get("skills", []):
+            d = KIRO / "skills" / sk
+            if d.is_dir():
+                shutil.rmtree(d)
+        for h in ent.get("hooks", []):
+            (KIRO / "hooks" / h).unlink(missing_ok=True)
+        shutil.rmtree(KIRO / ".kiro-port-assets" / name, ignore_errors=True)
+        for a in ent.get("agents", []):
+            (KIRO / "agents" / a).unlink(missing_ok=True)
+        del man[name]
+        _save(MANIFEST, man)
+        print(f"removed {name} (스킬 {len(ent.get('skills', []))}개)")
+        return
+    if ent:
+        del man[name]
+        _save(MANIFEST, man)
+    power_dir = KIRO / "powers/installed" / name
+    if power_dir.is_dir():
+        for hook in (power_dir / "dev.kiro/hooks").glob("*.json"):
+            (KIRO / "hooks" / hook.name).unlink(missing_ok=True)
+        for ag in (power_dir / "dev.kiro/agents").glob("*.md"):
+            (KIRO / "agents" / ag.name).unlink(missing_ok=True)
+        shutil.rmtree(power_dir)
+    reg_p = KIRO / "powers/registries/user-added.json"
+    reg = _load(reg_p, {"powers": []})
+    reg["powers"] = [p for p in reg["powers"] if p["name"] != name]
+    _save(reg_p, reg)
+    inst_p = KIRO / "powers/installed.json"
+    inst = _load(inst_p, {"installedPowers": []})
+    inst["installedPowers"] = [p for p in inst["installedPowers"] if p["name"] != name]
+    _save(inst_p, inst)
+    print(f"removed {name}")
+
+
+def smoke(names: list[str]) -> None:
+    """kiro-cli v3에 실제 로드되는지 확인. TTY가 필요해 script(1)로 감싼다."""
+    prompt = "Do not use any tools. List the names of all installed powers you can see, one per line, then stop."
+    log = Path("/tmp/kiro-port-smoke.txt")
+    subprocess.run(["script", "-q", str(log), "kiro-cli", "chat", "--v3", "--no-interactive", prompt],
+                   stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=240)
+    seen = log.read_text(errors="replace")
+    for n in names:
+        print(f"  smoke {n}: {'LOADED' if n in seen else 'NOT SEEN'}")
+    pl = sorted((KIRO / "logs").glob("*/powers.log"))
+    if pl:
+        fails = [ln for ln in pl[-1].read_text().splitlines() if "load.failed" in ln]
+        for f in fails:
+            print("  powers.log:", f[:200])
+
+
+# ------------------------------------------------------------------ CLI
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("cmd", choices=["scan", "port", "unport"])
+    ap.add_argument("names", nargs="*")
+    ap.add_argument("--all", action="store_true")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--out", type=Path, help="설치하지 않고 이 디렉터리에 Power 저장소만 생성")
+    ap.add_argument("--smoke", action="store_true")
+    ap.add_argument("--scope", choices=["user", "project", "all"], default="all",
+                    help="CC 설치 스코프 필터. 기본: user 전부 + 현재 디렉터리에 해당하는 project")
+    ap.add_argument("--project-local", action="store_true",
+                    help="Power 대신 현재 디렉터리의 .kiro/ 에 풀어놓기 (project 스코프 대응)")
+    ap.add_argument("--from", dest="src", metavar="SOURCE",
+                    help="설치 기록 대신 마켓플레이스/플러그인 저장소에서 직접: 로컬 경로 | owner/repo | git URL")
+    ap.add_argument("--as", dest="mode", choices=["auto", "skills", "power"], default="auto",
+                    help="설치 방식. auto(기본): 스킬만 있으면 ~/.kiro/skills/, 복합이면 Power")
+    a = ap.parse_args()
+    cwd = Path.cwd().resolve()
+
+    if a.cmd == "unport":
+        for n in a.names:
+            unregister(n)
+        return
+
+    if a.src:
+        root = fetch_source(a.src)
+        # scan 은 목록만 (원격 항목은 받아오지 않음), port 는 지목된 것만 받아온다
+        only = None if a.all else {n.partition("@")[0] for n in a.names}
+        cands = marketplace_plugins(root, fetch=(a.cmd == "port"), only=only)
+        sources = [{"tool": "market", "name": c["name"], "market": Path(a.src).name, "path": c["path"],
+                    "version": c["version"], "scope": "user", "project": "",
+                    "remote": c.get("remote")} for c in cands]
+        if not sources:
+            sys.exit(f"{a.src}: .claude-plugin/marketplace.json 도 plugin.json 도 없음")
+    else:
+        sources = scan_sources()
+    if a.cmd == "scan":
+        LABEL = {"skills": "스킬 폴더 복사", "power": "Power", "steering": "steering 수동 배치"}
+        print(f"{'플러그인':30} {'출처':7} {'구성':34} 권장")
+        for s in sources:
+            if not s.get("path"):
+                r = s.get("remote") or {}
+                print(f"{s['name']:30} {s['market'][:7]:7} 원격: {r.get('url') or r.get('repo','')}")
+                continue
+            kind, n = classify(Path(s["path"]))
+            rec = recommend(kind)
+            comp = " ".join(f"{k[:4]}{v}" for k, v in n.items() if v)
+            proj = "·프로젝트" if s["scope"] == "project" else ""
+            print(f"{s['name']:30} {s['tool']:7} {comp:34} {LABEL[rec]}{proj}")
+        print(f"\n전역 스킬 {global_skill_count()}개 (~/.kiro/skills)")
+        print("구성에 commands·agents·hooks·mcp 가 있으면 Power, 스킬만이면 폴더 복사가 기본입니다. "
+              "`--as skills|power` 로 바꿀 수 있습니다.")
+        return
+
+    def in_scope(s: dict) -> bool:
+        # project 스코프는 그 프로젝트 안에서 실행할 때만 대상 (CC와 같은 가시성)
+        if s["scope"] == "project":
+            here = s.get("project") and cwd.is_relative_to(Path(s["project"]).resolve())
+            return a.scope in ("project", "all") and bool(here)
+        return a.scope in ("user", "all")
+    sources = [s for s in sources if in_scope(s)]
+
+    # 선택: name 또는 name@market. 같은 이름이 여러 곳이면 CC 우선, 최신 순
+    picked = []
+    for key in (["*"] if a.all else a.names):
+        n, _, mk = key.partition("@")
+        cands = [s for s in sources if (key == "*" or s["name"] == n) and (not mk or s["market"] == mk)]
+        unfetched = [s for s in cands if not s.get("path")]
+        cands = [s for s in cands if s.get("path")]
+        for s in unfetched:
+            r = s.get("remote") or {}
+            print(f"   ⚠️ {s['name']}: 원격 저장소를 받지 못했습니다 ({r.get('url') or r.get('repo', '?')})")
+        if not cands:
+            sys.exit(f"not found: {key} (scan 으로 확인)")
+        seen = set()
+        # 같은 이름이 여러 곳이면 CC 설치본 → Codex 설치본 → 마켓플레이스 원본 순
+        for s in sorted(cands, key=lambda s: (s["tool"] != "claude", s["scope"] == "market", s["name"])):
+            if s["name"] not in seen:
+                seen.add(s["name"])
+                picked.append(s)
+
+    if a.project_local:
+        base = cwd / ".kiro/.ported"  # 변환 중간물. 실제 파일은 .kiro/{skills,hooks,agents} 로 분배
+    else:
+        base = a.out or (KIRO / "powers/installed")
+    taken = {p.name for p in (KIRO / "powers/installed").iterdir()} if (KIRO / "powers/installed").is_dir() else set()
+    for s in picked:
+        name = s["name"]
+        kind, ncomp = classify(Path(s["path"]))
+        mode = a.mode if a.mode != "auto" else recommend(kind)
+        if a.project_local:
+            mode = "project"
+        if mode == "steering":
+            print(f"\n== {name}  → 옮기지 않았습니다")
+            print(f"   스킬·명령·훅·MCP 가 없어 플러그인이라기보다 지침 문서입니다. Kiro 에서는 "
+                  f"`~/.kiro/steering/` 에 `inclusion: always` 머리말을 붙여 두는 자리가 맞고, "
+                  f"Power 로 만들면 '항상 적용'이 '키워드 조건부'로 바뀌어 의도가 달라집니다.\n"
+                  f"   원본: {s['path']}")
+            continue
+        if mode == "skills":
+            # 훅·에이전트는 Power 밖에 설치되므로 skills 모드에서도 함께 살린다.
+            lost = [k for k in ("commands", "mcp") if ncomp[k]]
+            if lost:  # 사용자가 --as skills 를 강제한 경우
+                print(f"   ⚠️ `{name}` 은 {lost} 도 가지고 있습니다. 스킬만 복사하면 이건 옮겨지지 "
+                      f"않습니다. 전부 옮기려면 `--as power` 를 쓰세요.")
+        # Power 이름은 Kiro 전체에서 유일해야 한다 (중복이면 Power 목록 전체가 로드되지 않는다)
+        if name in taken and not (KIRO / "powers/installed" / name / "PORT-REPORT.md").exists():
+            alt = f"{name}-{s['market']}".replace("@", "-")[:64]
+            print(f"   ⚠️ `{name}` 은 이미 다른 Power가 쓰는 이름 → `{alt}` 로 설치")
+            name = alt
+        taken.add(name)
+        power_dir = base / name
+        where = (f"{cwd}/.kiro/" if mode == "project" else
+                 f"{KIRO}/skills/" if mode == "skills" else power_dir)
+        why = {"skills": "스킬만 있어 Power 로 감싸지 않음", "power": f"{kind} 구성", "project": "프로젝트 로컬"}[mode]
+        print(f"\n== {name}  ({s['tool']} · {s['market']} · {s['scope']})  →  {where}  [{why}]")
+        if a.dry_run:
+            continue
+        if power_dir.exists():
+            if not (power_dir / "PORT-REPORT.md").exists():
+                print(f"   ⛔ `{power_dir}` 는 이 도구가 만든 Power가 아닙니다 (이미 설치된 Power). 건너뜀. "
+                      f"교체하려면 먼저 Kiro에서 제거하세요.")
+                continue
+            shutil.rmtree(power_dir)
+        report = [f"# Port report — {name}", f"source: `{s['path']}` ({s['tool']} marketplace `{s['market']}`, scope {s['scope']})", ""]
+        Port(s["path"], power_dir, report).run(name, s["version"])
+        if mode == "project":
+            install_project_local(power_dir, cwd, report)
+        elif mode == "skills" and not a.out:
+            install_skills_only(power_dir, report, name)
+            shutil.rmtree(power_dir)  # 중간 산출물은 남기지 않는다
+        elif not a.out:
+            if s["scope"] == "project":
+                report.append(f"- ⚠️ 원본은 `{s['project']}` 프로젝트 스코프였으나 Power는 전역 설치됨. "
+                              f"프로젝트에만 두려면 그 디렉터리에서 `--project-local`")
+            register(name, power_dir, report)
+        report.append("")
+        report.append("## 사람이 확인할 것")
+        if mode == "skills":
+            lost = [k for k in ("commands", "mcp") if ncomp[k]]
+            if lost:
+                report.append(f"- ❌ {lost} 는 옮겨지지 않았습니다 — Power 만 담을 수 있습니다 (`--as power`)")
+            report += [f"- 스킬은 `{KIRO}/skills/` 에 있습니다. 이름이 겹치면 건너뛰었으니 위 ⚠️ 를 확인하세요",
+                       "- keywords 자동 활성화가 필요하면 `--as power` 로 다시 옮기세요"]
+        else:
+            report += ["- `plugin.json`의 `keywords` — 이름에서 기계적으로 뽑았음. 이 Power가 켜져야 하는 상황의 단어로 다듬기",
+                       "- 훅이 있었다면 `~/.kiro/hooks/`에 복사됐는지, 도구명 매핑이 맞는지",
+                       "- 에이전트는 `~/.kiro/agents/`에 마크다운 그대로. 도구 제한(`tools`)은 제거됨"]
+        if power_dir.exists():
+            (power_dir / "PORT-REPORT.md").write_text("\n".join(report) + "\n")
+        else:  # skills 모드는 Power 디렉터리를 남기지 않으므로 별도 보관
+            rp = KIRO / ".kiro-port-reports" / f"{name}.md"
+            rp.parent.mkdir(parents=True, exist_ok=True)
+            rp.write_text("\n".join(report) + "\n")
+        print("\n".join(report[3:]))
+    if not a.dry_run and not a.out and not a.project_local:
+        reg = [p["name"] for p in _load(KIRO / "powers/installed.json", {"installedPowers": []})["installedPowers"]]
+        nskill = sum(1 for n in reg for _ in (KIRO / "powers/installed" / n / "skills").glob("*/SKILL.md"))
+        nfile = sum(1 for n in reg for p in (KIRO / "powers/installed" / n).rglob("*") if p.is_file())
+        print(f"\n등록 Power {len(reg)}개 · 스킬 {nskill}개 · 파일 {nfile}개")
+        if nfile > FILE_WARN * 2:
+            print(f"⚠️  파일이 {nfile}개입니다. Kiro 는 스킬 트리의 모든 파일마다 fd 를 열어두므로"
+                  f"(kirodotdev/Kiro#10625) `spawn EBADF` 로 셸이 멈출 수 있습니다.")
+    if a.smoke and not a.dry_run and not a.out:
+        print("\n== smoke test (kiro-cli --v3)")
+        smoke([s["name"] for s in picked])
+
+
+if __name__ == "__main__":
+    main()

--- a/ai-coding-assistants/agent-plugins/plugin-importer/tests/regression-test.py
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/tests/regression-test.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""Regression tests for kiro-port.py. Ports typed fixtures under an isolated KIRO_HOME and checks the result.
+
+    python3 tests/regression-test.py            # everything
+    python3 tests/regression-test.py -k hook    # only tests with "hook" in the name
+
+No framework, no network. Doesn't launch a real Kiro — the script honours KIRO_HOME, so everything
+lands in a temp directory that is deleted afterwards.
+"""
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).parent
+PORT = HERE.parent / "skills/import-plugins/scripts/kiro-port.py"
+FAIL: list[str] = []
+PASS: list[str] = []
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    (PASS if ok else FAIL).append(name)
+    print(f"  {'ok  ' if ok else 'FAIL'} {name}" + (f" — {detail}" if detail and not ok else ""))
+
+
+# ------------------------------------------------------------------ fixtures
+
+def fx_skills_only(root: Path) -> Path:
+    """Skills-only plugin -> should land globally."""
+    d = root / "fx-skills"
+    (d / ".claude-plugin").mkdir(parents=True)
+    (d / ".claude-plugin/plugin.json").write_text(json.dumps(
+        {"name": "fx-skills", "version": "2.1.0", "description": "skills only"}) + "\n")
+    for n in ("alpha", "beta"):
+        (d / "skills" / n).mkdir(parents=True)
+        (d / "skills" / n / "SKILL.md").write_text(
+            f"---\nname: {n}\ndescription: Fixture skill {n}.\n---\n\nBody of {n}. Keep me byte-identical.\n")
+    return d
+
+
+def fx_commands(root: Path) -> Path:
+    """Plugin with a command -> a Power. allowed-tools/argument-hint should be dropped."""
+    d = root / "fx-cmd"
+    (d / ".claude-plugin").mkdir(parents=True)
+    (d / ".claude-plugin/plugin.json").write_text(json.dumps({"name": "fx-cmd", "description": "cmd"}) + "\n")
+    (d / "commands").mkdir()
+    (d / "commands/deploy.md").write_text(
+        "---\nallowed-tools: Bash(git *)\nargument-hint: \"[env]\"\ndescription: Deploy it\n---\n\n"
+        "Run the deploy. Body must not change.\n")
+    (d / "commands/skip.toml").write_text("# not markdown\n")
+    return d
+
+
+def fx_hooks(root: Path) -> Path:
+    """Conditional hooks — if/timeout should be reported, and names should stay distinct."""
+    d = root / "fx-hook"
+    (d / ".claude-plugin").mkdir(parents=True)
+    (d / ".claude-plugin/plugin.json").write_text(json.dumps({"name": "fx-hook", "description": "hooks"}) + "\n")
+    (d / "hooks").mkdir()
+    (d / "hooks/run.sh").write_text("#!/bin/sh\necho hi\n")
+    (d / "hooks/run.cmd").write_text("echo cmd-ok\n")
+    (d / "hooks/hooks.json").write_text(json.dumps({"hooks": {
+        "PostToolUse": [{"matcher": "Bash", "hooks": [
+            {"type": "command", "command": 'sh "${CLAUDE_PLUGIN_ROOT}/hooks/run.sh"', "if": "Bash(git commit:*)"},
+            {"type": "command", "command": 'sh "${CLAUDE_PLUGIN_ROOT}/hooks/run.sh"', "if": "Bash(git push:*)"}]}],
+        "PreToolUse": [{"matcher": "Write|Edit", "hooks": [
+            {"type": "command", "command": 'sh "${CLAUDE_PLUGIN_ROOT}/hooks/run.sh"', "timeout": 10}]}],
+        "SessionStart": [{"hooks": [
+            {"type": "command", "command": '"${CLAUDE_PLUGIN_ROOT}/hooks/run.cmd" go', "shell": "bash"}]}],
+        "SessionEnd": [{"hooks": [{"type": "command", "command": "true"}]}],
+    }}) + "\n")
+    (d / "skills/only").mkdir(parents=True)
+    (d / "skills/only/SKILL.md").write_text("---\nname: only\ndescription: Fixture.\n---\n\nBody.\n")
+    return d
+
+
+def fx_flat_hooks(root: Path) -> Path:
+    """hooks.json written as a flat list of {event, command} objects — the other schema in the wild."""
+    d = root / "fx-flathook"
+    (d / ".claude-plugin").mkdir(parents=True)
+    (d / ".claude-plugin/plugin.json").write_text(json.dumps({"name": "fx-flathook", "description": "flat"}) + "\n")
+    (d / "hooks").mkdir()
+    (d / "hooks/hooks.json").write_text(json.dumps({"hooks": [
+        {"event": "Stop", "command": "echo stop"},
+        {"event": "UserPromptSubmit", "command": "echo prompt"}]}) + "\n")
+    return d
+
+
+def fx_mcp(root: Path) -> Path:
+    """One stdio server plus one remote http server — the remote one should be flagged."""
+    d = root / "fx-mcp"
+    (d / ".claude-plugin").mkdir(parents=True)
+    (d / ".claude-plugin/plugin.json").write_text(json.dumps({"name": "fx-mcp", "description": "mcp"}) + "\n")
+    (d / ".mcp.json").write_text(json.dumps({
+        "local": {"type": "stdio", "command": "uvx", "args": ["x"]},
+        "remote": {"type": "http", "url": "https://example.invalid/mcp"}}) + "\n")
+    return d
+
+
+def fx_agents(root: Path) -> Path:
+    """Agent — tools/model should be dropped, body kept."""
+    d = root / "fx-agent"
+    (d / ".claude-plugin").mkdir(parents=True)
+    (d / ".claude-plugin/plugin.json").write_text(json.dumps({"name": "fx-agent", "description": "agents"}) + "\n")
+    (d / "agents").mkdir()
+    (d / "agents/rev.md").write_text(
+        "---\nname: rev\ndescription: Reviewer.\ntools: Read, Grep\nmodel: opus\n---\n\nYou are rev. Keep body.\n")
+    (d / "skills/s1").mkdir(parents=True)
+    (d / "skills/s1/SKILL.md").write_text("---\nname: s1\ndescription: Fixture.\n---\n\nBody.\n")
+    return d
+
+
+def fx_bulk(root: Path) -> Path:
+    """Plugin with a large excluded tree (node_modules) — should not get copied."""
+    d = root / "fx-bulk"
+    (d / ".claude-plugin").mkdir(parents=True)
+    (d / ".claude-plugin/plugin.json").write_text(json.dumps({"name": "fx-bulk", "description": "bulk"}) + "\n")
+    (d / "skills/s1").mkdir(parents=True)
+    (d / "skills/s1/SKILL.md").write_text("---\nname: s1\ndescription: Fixture.\n---\n\nBody.\n")
+    for i in range(50):
+        (d / "node_modules" / f"pkg{i}").mkdir(parents=True)
+        (d / "node_modules" / f"pkg{i}" / "index.js").write_text("//\n")
+    return d
+
+
+def fx_guidance(root: Path) -> Path:
+    """Guidance only — should not be moved, just pointed at steering."""
+    d = root / "fx-guide"
+    (d / ".claude-plugin").mkdir(parents=True)
+    (d / ".claude-plugin/plugin.json").write_text(json.dumps({"name": "fx-guide", "description": "guide"}) + "\n")
+    (d / "CLAUDE.md").write_text("# guidance\nAlways be nice.\n")
+    return d
+
+
+def fx_marketplace(root: Path, plugins: list[Path], entries: list[dict] | None = None) -> Path:
+    """A local marketplace holding the fixtures. `entries` overrides the generated plugin list."""
+    mk = root / "market"
+    (mk / ".claude-plugin").mkdir(parents=True)
+    for p in plugins:
+        shutil.copytree(p, mk / p.name)
+    if entries is None:
+        entries = [{"name": p.name, "source": f"./{p.name}", "description": p.name} for p in plugins]
+    (mk / ".claude-plugin/marketplace.json").write_text(json.dumps({
+        "name": "fx", "owner": {"name": "t"}, "plugins": entries}) + "\n")
+    return mk
+
+
+# ------------------------------------------------------------------ run helper
+
+def run(kiro_home: Path, *args: str, cwd: Path | None = None) -> tuple[int, str]:
+    env = dict(os.environ, KIRO_HOME=str(kiro_home))
+    r = subprocess.run([sys.executable, str(PORT), *args], capture_output=True, text=True, env=env,
+                       timeout=300, cwd=str(cwd) if cwd else None)
+    return r.returncode, r.stdout + r.stderr
+
+
+def same_body(a: Path, b: Path) -> bool:
+    def body(p: Path) -> str:
+        t = p.read_text()
+        if t.startswith("---"):
+            e = t.find("\n---", 3)
+            return t[e + 4:] if e > 0 else t
+        return t
+    return body(a) == body(b)
+
+
+# ------------------------------------------------------------------ tests
+
+def test_skills_only(root, kh, mk):
+    print("\n[skills-only] a skills-only plugin goes globally, no Power gets built")
+    rc, out = run(kh, "port", "--from", str(mk), "fx-skills")
+    check("exit code 0", rc == 0, out[-400:])
+    check("no Power created", not (kh / "powers/installed/fx-skills").exists())
+    check("2 global skills", len(list((kh / "skills").glob("*/SKILL.md"))) >= 2)
+    check("body unchanged", same_body(root / "fx-skills/skills/alpha/SKILL.md", kh / "skills/alpha/SKILL.md"))
+    man = json.loads((kh / ".kiro-port-manifest.json").read_text())
+    check("manifest mode=skills", man.get("fx-skills", {}).get("mode") == "skills")
+    rc, _ = run(kh, "unport", "fx-skills")
+    check("unport removes the skill", not (kh / "skills/alpha").exists())
+
+
+def test_commands(root, kh, mk):
+    print("\n[commands] commands become skills, allowed-tools/argument-hint dropped, .toml reported")
+    rc, out = run(kh, "port", "--from", str(mk), "fx-cmd")
+    sk = kh / "powers/installed/fx-cmd/skills/deploy/SKILL.md"
+    check("Power created", sk.exists(), out[-400:])
+    if sk.exists():
+        fm = sk.read_text().split("---")[1]
+        check("name added", "name: deploy" in fm)
+        check("allowed-tools dropped", "allowed-tools" not in fm)
+        check("argument-hint dropped", "argument-hint" not in fm)
+        check("body unchanged", same_body(root / "fx-cmd/commands/deploy.md", sk))
+    check(".toml reported as unconverted", "toml" in out)
+    check("version defaults to 1.0.0 when missing", '"version": "1.0.0"' in (kh / "powers/installed/fx-cmd/plugin.json").read_text())
+    run(kh, "unport", "fx-cmd")
+
+
+def test_hooks(root, kh, mk):
+    print("\n[hooks] per-condition hook names stay distinct, lost fields reported, SessionEnd skipped")
+    rc, out = run(kh, "port", "--from", str(mk), "fx-hook")
+    hf = kh / "hooks/fx-hook.json"
+    check("hook file installed", hf.exists(), out[-500:])
+    if hf.exists():
+        hooks = json.loads(hf.read_text())["hooks"]
+        names = [h["name"] for h in hooks]
+        check("condition folded into the name", any("git-commit" in n for n in names) and any("git-push" in n for n in names),
+              str(names))
+        check("no duplicate names", len(names) == len(set(names)))
+        matchers = [h.get("matcher") for h in hooks]
+        check("tool-name mapping (execute_bash)", "execute_bash" in str(matchers))
+        check("Write|Edit → fs_write", "fs_write" in str(matchers))
+        ss = [h for h in hooks if h["trigger"] == "SessionStart"]
+        check("shell field wrapped as bash -c", bool(ss) and ss[0]["action"]["command"].startswith("bash -c "),
+              str(ss[0]["action"]["command"][:60]) if ss else "no SessionStart hook")
+        check("shell isn't reported as a loss", "`shell`" not in out)
+        check("event names kept as-is", {h["trigger"] for h in hooks} <= {"PreToolUse", "PostToolUse", "SessionStart"})
+    check("if field loss reported", "`if`" in out)
+    check("timeout loss reported", "timeout" in out)
+    check("SessionEnd exclusion reported", "SessionEnd" in out)
+    run(kh, "unport", "fx-hook")
+    check("unport removes the hook", not hf.exists())
+
+
+def test_flat_hooks(root, kh, mk):
+    print("\n[hooks] flat-list hooks.json is accepted, event names not renamed")
+    rc, out = run(kh, "port", "--from", str(mk), "fx-flathook")
+    hf = kh / "hooks/fx-flathook.json"
+    check("flat list converted", hf.exists(), out[-400:])
+    if hf.exists():
+        trig = sorted(h["trigger"] for h in json.loads(hf.read_text())["hooks"])
+        check("Stop and UserPromptSubmit kept verbatim", trig == ["Stop", "UserPromptSubmit"], str(trig))
+    run(kh, "unport", "fx-flathook")
+
+
+def test_mcp(root, kh, mk):
+    print("\n[mcp] server definitions unchanged, remote http flagged")
+    rc, out = run(kh, "port", "--from", str(mk), "fx-mcp")
+    mj = kh / "powers/installed/fx-mcp/mcp.json"
+    check("mcp.json generated", mj.exists(), out[-400:])
+    if mj.exists():
+        d = json.loads(mj.read_text())
+        check("has $schema", d.get("$schema", "").endswith("mcp.schema.json"))
+        check("wrapped in mcpServers", set(d.get("mcpServers", {})) == {"local", "remote"})
+        check("server definition unchanged", d["mcpServers"]["local"]["command"] == "uvx")
+    check("remote MCP warning", "Remote MCP" in out and "remote" in out)
+    run(kh, "unport", "fx-mcp")
+
+
+def test_agents(root, kh, mk):
+    print("\n[agents] body kept, tools/model dropped and reported")
+    rc, out = run(kh, "port", "--from", str(mk), "fx-agent")
+    ag = kh / "agents/rev.md"
+    check("agent installed", ag.exists(), out[-400:])
+    if ag.exists():
+        fm = ag.read_text().split("---")[1]
+        check("tools dropped", "tools:" not in fm)
+        check("model dropped", "model:" not in fm)
+        check("body unchanged", same_body(root / "fx-agent/agents/rev.md", ag))
+    check("dropped fields reported", "tools" in out and "model" in out)
+    run(kh, "unport", "fx-agent")
+    check("unport removes the agent", not ag.exists())
+
+
+def test_bulk(root, kh, mk):
+    print("\n[bulk] node_modules is not copied (avoids fd exhaustion)")
+    rc, out = run(kh, "port", "--from", str(mk), "fx-bulk")
+    check("node_modules excluded", not any((kh / "skills").rglob("node_modules")))
+    check("exclusion reported", "node_modules" in out)
+    run(kh, "unport", "fx-bulk")
+
+
+def test_guidance(root, kh, mk):
+    print("\n[guidance] guidance-only is not moved, just pointed at steering")
+    rc, out = run(kh, "port", "--from", str(mk), "fx-guide")
+    check("not moved", not (kh / "powers/installed/fx-guide").exists(), out[-300:])
+    check("steering path mentioned", "steering" in out)
+
+
+def test_overrides(root, kh, mk):
+    print("\n[--as] the override flag flips the classification")
+    run(kh, "port", "--from", str(mk), "fx-skills", "--as", "power")
+    check("--as power creates a Power", (kh / "powers/installed/fx-skills").exists())
+    run(kh, "unport", "fx-skills")
+    run(kh, "port", "--from", str(mk), "fx-cmd", "--as", "skills")
+    check("--as skills places it globally", (kh / "skills/deploy").exists())
+    rc, out = run(kh, "port", "--from", str(mk), "fx-mcp", "--as", "skills")
+    check("--as skills on a mixed plugin warns", "mcp" in out.lower())
+    check("--as skills on a plugin with no skills/ doesn't crash", rc == 0 and "Traceback" not in out, out[-400:])
+    check("no staging directory left behind", not (kh / "powers/installed/fx-mcp").exists())
+    run(kh, "unport", "fx-cmd")
+    run(kh, "unport", "fx-mcp")
+
+
+def test_guards(root, kh, mk):
+    print("\n[guards] won't overwrite an existing Power, avoids name clashes")
+    (kh / "powers/installed/preexisting").mkdir(parents=True, exist_ok=True)
+    (kh / "powers/installed/preexisting/plugin.json").write_text('{"name":"preexisting"}')
+    p = root / "preexisting"
+    (p / ".claude-plugin").mkdir(parents=True, exist_ok=True)
+    (p / ".claude-plugin/plugin.json").write_text(json.dumps({"name": "preexisting", "description": "x"}))
+    (p / "commands").mkdir(exist_ok=True)
+    (p / "commands/c.md").write_text("---\ndescription: c\n---\n\nbody\n")
+    mk2 = fx_marketplace(root / "m2", [p])
+    rc, out = run(kh, "port", "--from", str(mk2), "preexisting")
+    check("existing Power protected", "⛔" in out or "this tool created" in out or (kh / "powers/installed/preexisting-market").exists(),
+          out[-300:])
+
+
+def test_untrusted_names(root, kh, mk):
+    print("\n[untrusted] marketplace entries can't name paths outside ~/.kiro or the repo")
+    escape_abs = root / "escaped-abs"          # an absolute path an attacker might target
+    outside = root / "outside-repo"            # a plugin dir outside the marketplace repo
+    (outside / ".claude-plugin").mkdir(parents=True)
+    (outside / ".claude-plugin/plugin.json").write_text(json.dumps({"name": "ok-name", "description": "x"}))
+    (outside / "skills/leak").mkdir(parents=True)
+    (outside / "skills/leak/SKILL.md").write_text("---\nname: leak\ndescription: x\n---\n\nleaked\n")
+    mk3 = fx_marketplace(root / "m3", [root / "fx-skills"], entries=[
+        {"name": str(escape_abs), "source": "./fx-skills", "description": "absolute name"},
+        {"name": "../escaped-rel", "source": "./fx-skills", "description": "traversal name"},
+        {"name": "ok-name", "source": "../outside-repo", "description": "source outside the repo"},
+        {"name": "bad name;rm", "source": "./fx-skills", "description": "shell chars"},
+    ])
+    rc, out = run(kh, "port", "--from", str(mk3), "--all")
+    check("absolute-path name not created", not escape_abs.exists())
+    check("traversal name not created", not (kh.parent / "escaped-rel").exists() and not (kh / "escaped-rel").exists())
+    check("nothing leaked from outside the repo", not (kh / "skills/leak").exists()
+          and not (kh / "powers/installed/ok-name").exists())
+    check("unsafe names reported", "unsafe name" in out, out[-600:])
+    check("outside source reported", "outside the marketplace repo" in out, out[-600:])
+    check("nothing installed", not any((kh / "powers/installed").iterdir()) and not list((kh / "skills").glob("*/SKILL.md")))
+
+
+def test_project_local(root, kh, mk):
+    print("\n[--project-local] writes into ./.kiro, records it, and unport removes exactly that")
+    proj = root / "proj"
+    proj.mkdir()
+    rc, out = run(kh, "port", "--from", str(mk), "fx-hook", "--project-local", cwd=proj)
+    k = proj / ".kiro"
+    check("exit code 0", rc == 0, out[-400:])
+    check("skill in project", (k / "skills/only/SKILL.md").exists())
+    check("hook in project", (k / "hooks/fx-hook.json").exists())
+    check("hook script preserved in project", (k / ".kiro-port-assets/fx-hook/hooks/run.sh").exists())
+    if (k / "hooks/fx-hook.json").exists():
+        check("hook command points at preserved copy", ".ported" not in (k / "hooks/fx-hook.json").read_text())
+    check("staging removed", not (k / ".ported").exists())
+    check("nothing written to global KIRO_HOME", not (kh / "hooks/fx-hook.json").exists()
+          and not (kh / "skills/only").exists())
+    man = k / ".kiro-port-manifest.json"
+    check("project manifest written", man.exists() and json.loads(man.read_text()).get("fx-hook", {}).get("mode") == "project")
+    rc, out = run(kh, "port", "--from", str(mk), "fx-mcp", "--project-local", cwd=proj)
+    mcp = k / "settings/mcp.json"
+    check("mcp merged into project settings", mcp.exists() and {"local", "remote"} <= set(json.loads(mcp.read_text())["mcpServers"]),
+          out[-300:])
+    rc, out = run(kh, "unport", "fx-hook", cwd=proj)
+    check("unport exit 0", rc == 0, out)
+    check("skill removed", not (k / "skills/only").exists())
+    check("hook removed", not (k / "hooks/fx-hook.json").exists())
+    check("preserved copy removed", not (k / ".kiro-port-assets/fx-hook").exists())
+    rc, out = run(kh, "unport", "fx-mcp", cwd=proj)
+    check("mcp keys removed", not json.loads(mcp.read_text())["mcpServers"], mcp.read_text())
+    check("project manifest gone when empty", not man.exists())
+    rc, out = run(kh, "unport", "fx-hook", cwd=proj)
+    check("unport of unknown name exits non-zero", rc != 0, f"rc={rc}")
+    check("unport of unknown name says so", "nothing to remove" in out, out[-300:])
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("-k", dest="filt", default="")
+    a = ap.parse_args()
+    tmp = Path(tempfile.mkdtemp(prefix="kiro-port-regress-"))
+    root, kh = tmp / "fixtures", tmp / "kiro-home"
+    root.mkdir(); (kh / "skills").mkdir(parents=True); (kh / "powers/installed").mkdir(parents=True)
+    (kh / "powers/registries").mkdir(parents=True)
+    (kh / "powers/installed.json").write_text('{"version":"1.0.0","installedPowers":[],"dismissedAutoInstalls":[]}')
+    (kh / "powers/registries/user-added.json").write_text('{"powers":[],"version":"1.0.0"}')
+    plugins = [f(root) for f in (fx_skills_only, fx_commands, fx_hooks, fx_flat_hooks, fx_mcp, fx_agents, fx_bulk, fx_guidance)]
+    mk = fx_marketplace(root / "m1", plugins)
+    tests = [test_skills_only, test_commands, test_hooks, test_flat_hooks, test_mcp, test_agents,
+             test_bulk, test_guidance, test_overrides, test_untrusted_names, test_project_local, test_guards]
+    print(f"isolated environment: {kh}")
+    for t in tests:
+        if a.filt and a.filt not in t.__name__:
+            continue
+        try:
+            t(root, kh, mk)
+        except Exception as e:  # a test that errors out also counts as a failure
+            check(f"{t.__name__} run", False, repr(e))
+    print(f"\npassed {len(PASS)} · failed {len(FAIL)}")
+    if FAIL:
+        print("failures:")
+        for f in FAIL:
+            print("  -", f)
+    shutil.rmtree(tmp, ignore_errors=True)
+    sys.exit(1 if FAIL else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `plugin-importer`, an [Agent Plugins 1.0.0](https://agent-plugins.org/) plugin for Kiro that brings plugins already installed through Claude Code or Codex into Kiro with their contents unchanged, or imports directly from a marketplace GitHub URL.
- Skill-bearing plugins land in `~/.kiro/skills/` with their hooks and agents alongside; plugins with `commands/` or MCP servers become Powers.
- Adds an index entry for it in `ai-coding-assistants/agent-plugins/README.md`.

## Test plan
- [x] `python3 tests/regression-test.py` from the plugin directory — 71 checks against synthetic fixtures in an isolated `KIRO_HOME`, stdlib only, no network
- [x] Ported and exercised real Claude Code / Codex marketplace plugins in a live `kiro-cli --v3` session