### PR TITLE
plugin-importer: CLI-only install, MCP registration, keep Agent Plugin manifests

### DIFF
--- a/ai-coding-assistants/agent-plugins/plugin-importer/CHANGELOG.md
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.1.0
 
+- `--slash` exposes a Power's skills as `/name` slash commands by symlinking each one into
+  `~/.kiro/skills/`. Kiro follows the link, so nothing is copied and the Power's keyword activation
+  keeps working alongside. Names already taken in `~/.kiro/skills/` are skipped and reported;
+  `unport` removes only the links it made.
 - A source that is already an Agent Plugin (root `plugin.json` with `$schema`) keeps its own
   manifest — the author's `keywords` and `version` are no longer replaced by name-derived ones — and
   its bodies are not run through `${CLAUDE_PLUGIN_ROOT}` substitution. This is also how the

--- a/ai-coding-assistants/agent-plugins/plugin-importer/CHANGELOG.md
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 1.1.0
 
+- A source that is already an Agent Plugin (root `plugin.json` with `$schema`) keeps its own
+  manifest — the author's `keywords` and `version` are no longer replaced by name-derived ones — and
+  its bodies are not run through `${CLAUDE_PLUGIN_ROOT}` substitution. This is also how the
+  converter installs itself from a clone: `port --from . plugin-importer --as power`.
+- `stdio` MCP servers from a Power's `mcp.json` are registered in `~/.kiro/settings/mcp.json` under
+  `powers.mcpServers` as `power-<power>-<server>`, which is what kiro-cli actually reads; `unport`
+  removes them. Remote servers are skipped and reported.
 - Marketplace metadata is treated as untrusted. An entry's `name` must be a single path segment
   (`[\w.-]{1,64}`); a string `source` or a remote `path` must resolve inside its repository.
   Entries that fail either check are skipped with a warning, and the install directory is checked

--- a/ai-coding-assistants/agent-plugins/plugin-importer/README.ko.md
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/README.ko.md
@@ -93,7 +93,9 @@ git 저장소를 가리켜도 따라갑니다. 원하는 것을 이름으로 지
 | 스킬 없이 훅·에이전트만 | Power | 담을 자리가 필요해서입니다 |
 | 마크다운 지침뿐 | 옮기지 않고 `~/.kiro/steering/` 경로만 안내 | Power는 조건부, steering은 항상 적용이라 성격이 다릅니다 |
 
-`--as skills` 와 `--as power` 로 뒤집을 수 있습니다. 지침 파일은 자동 변환하지 않습니다. `inclusion: always`
+`--as skills` 와 `--as power` 로 뒤집을 수 있습니다. Power 안 스킬은 슬래시 명령이 아닙니다. Claude Code 번들에서
+`/명령`으로 하나씩 골라 쓰던 것처럼 `/이름`으로도 부르고 싶으면 `--slash` 를 붙이세요 — 스킬을 복사하지 않고
+`~/.kiro/skills/` 에 링크만 놓습니다. 지침 파일은 자동 변환하지 않습니다. `inclusion: always`
 가 붙은 steering 파일이 원래 지침처럼 항상 적용된다는 점에서 더 가깝습니다.
 
 본문은 바이트 단위로 복사되고, 하나라도 다르면 이식이 중단됩니다. 원본 `.claude-plugin/`·`commands/`·

--- a/ai-coding-assistants/agent-plugins/plugin-importer/README.ko.md
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/README.ko.md
@@ -24,8 +24,17 @@ cd sample-apj-sup-sa
 git sparse-checkout set ai-coding-assistants/agent-plugins/plugin-importer
 ```
 
-Kiro **Powers** 패널 → **Add Custom Power** → **Import power from a folder** →
-`ai-coding-assistants/agent-plugins/plugin-importer` 선택. 이 디렉터리의 GitHub 주소를 붙여 넣어도 됩니다.
+그다음 아래 둘 중 하나로 Power로 등록합니다.
+
+- **Kiro IDE**: **Powers** 패널 → **Add Custom Power** → **Import power from a folder** →
+  `ai-coding-assistants/agent-plugins/plugin-importer` 선택. 이 디렉터리의 GitHub 주소를 붙여 넣어도 됩니다.
+- **Kiro CLI만 쓰는 경우** (CLI에는 Power 추가 명령이 없습니다): 변환기가 자기 자신을 설치합니다.
+
+  ```bash
+  cd ai-coding-assistants/agent-plugins/plugin-importer
+  python3 skills/import-plugins/scripts/kiro-port.py port --from . plugin-importer --as power
+  ```
+
 Power는 세션 시작 시 로드되므로 설치 후 새 세션을 여세요.
 
 **Kiro는 `kiro-cli --v3`로 실행하세요.** 클래식 모드나 `--no-interactive`에서도 Power·스킬은 정상 로드되지만,

--- a/ai-coding-assistants/agent-plugins/plugin-importer/README.md
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/README.md
@@ -101,7 +101,9 @@ only where nothing else can carry the component.
 | hooks or agents but no skills | a Power | Somewhere to hold them |
 | Markdown guidance only | nothing moved; `~/.kiro/steering/` path only | A Power is conditional; steering is always-on — different jobs |
 
-`--as skills` and `--as power` override this. Guidance files are never converted automatically — a
+`--as skills` and `--as power` override this. A Power's skills are not slash commands; if you want
+`/name` for them as well — the way a Claude Code bundle let you pick one command — add `--slash`, which
+links each skill into `~/.kiro/skills/` without copying it. Guidance files are never converted automatically — a
 steering file with `inclusion: always` is the closer match, since it stays always-on the way the
 guidance did.
 

--- a/ai-coding-assistants/agent-plugins/plugin-importer/README.md
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/README.md
@@ -26,8 +26,17 @@ cd sample-apj-sup-sa
 git sparse-checkout set ai-coding-assistants/agent-plugins/plugin-importer
 ```
 
-Kiro **Powers** panel → **Add Custom Power** → **Import power from a folder** → select
-`ai-coding-assistants/agent-plugins/plugin-importer`. Pasting this directory's GitHub URL works too.
+Then either of these registers it as a Power:
+
+- **Kiro IDE**: **Powers** panel → **Add Custom Power** → **Import power from a folder** → select
+  `ai-coding-assistants/agent-plugins/plugin-importer`. Pasting this directory's GitHub URL works too.
+- **Kiro CLI only** (there is no `/powers add` in the CLI): let the converter install itself.
+
+  ```bash
+  cd ai-coding-assistants/agent-plugins/plugin-importer
+  python3 skills/import-plugins/scripts/kiro-port.py port --from . plugin-importer --as power
+  ```
+
 Start a new session afterwards; Powers load at session start.
 
 **Run Kiro with `kiro-cli --v3`.** Classic mode and `--no-interactive` sessions load Powers and skills

--- a/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/SKILL.md
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/SKILL.md
@@ -54,7 +54,9 @@ Follow the recommendation from `scan` unless the user wants otherwise:
 | Markdown guidance only | nothing is moved; report the `~/.kiro/steering/` path and stop |
 
 `--as skills` and `--as power` override it. `--as skills` on a plugin with commands or MCP drops
-those, and the script says so. `--project-local` writes into the current project's `.kiro/` instead of
+those, and the script says so. `--slash` also exposes a Power's skills as `/name` slash commands
+(symlinks under `~/.kiro/skills/`) — use it when the user wants to pick one skill out of a bundle
+the way they did with `/command` in Claude Code, or asks for slash commands. `--project-local` writes into the current project's `.kiro/` instead of
 installing globally. `--out DIR` only generates, which is how you turn a marketplace into a
 Kiro-installable monorepo. `--smoke` checks that Kiro loads the result.
 

--- a/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/references/kiro-mapping.md
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/references/kiro-mapping.md
@@ -80,9 +80,13 @@ Fields Kiro has no equivalent for are reported rather than guessed at:
   headless sessions load the same `~/.kiro/hooks/*.json` file but `/hooks` reports 0 and nothing runs.
   If a hook seems to do nothing, check which mode the session was actually started in before assuming
   the conversion is wrong.
-- **Remote MCP servers in a Power are ignored.** `stdio` servers register with their tools; `http` and
-  `sse` servers produce nothing and no error. Their definition has to move to
-  `~/.kiro/settings/mcp.json`.
+- **kiro-cli does not read a Power's `mcp.json` on its own.** The IDE installer copies each server
+  into `~/.kiro/settings/mcp.json` under `powers.mcpServers` as `power-<power>-<server>`; without
+  that entry the Power activates but "reports no tools". `port` writes those entries itself so a
+  CLI-only install works, and `unport` removes them.
+- **Remote MCP servers in a Power are ignored.** Only `stdio` servers (ones with a `command`) are
+  registered; `http` and `sse` servers are skipped and reported. To use one, add it by hand to
+  `~/.kiro/settings/mcp.json` at the top level.
 - **Markdown agents do not appear in `kiro-cli agent list`, and `--agent <name>` cannot load one either**
   (`Error: no agent with name <name> found` — the classic agent registry is JSON-only). In `--v3` (KAS)
   sessions, `~/.kiro/agents/*.md` is loaded separately as a "user profile"; a plain-language request

--- a/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/references/kiro-mapping.md
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/references/kiro-mapping.md
@@ -75,7 +75,9 @@ Fields Kiro has no equivalent for are reported rather than guessed at:
 
 - **A skill inside a Power is not a slash command.** `/name` works for a skill in `~/.kiro/skills/`;
   the same file inside a Power is not recognised. Ask for it by name instead ("run the X skill").
-  This is why skill-bearing plugins go to `~/.kiro/skills/` by default.
+  This is why skill-bearing plugins go to `~/.kiro/skills/` by default. Kiro does follow a symlink
+  in `~/.kiro/skills/`, which is what `--slash` uses: one link per skill pointing into the Power,
+  so `/name` appears while the body stays in one place.
 - **Hooks only fire in `kiro-cli --v3` interactive sessions.** Classic mode and `--no-interactive`
   headless sessions load the same `~/.kiro/hooks/*.json` file but `/hooks` reports 0 and nothing runs.
   If a hook seems to do nothing, check which mode the session was actually started in before assuming

--- a/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/scripts/kiro-port.py
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/scripts/kiro-port.py
@@ -688,7 +688,7 @@ def unregister_project(name: str, project: Path) -> bool:
     return True
 
 
-def register(name: str, power_dir: Path, report: list[str]) -> None:
+def register(name: str, power_dir: Path, report: list[str], slash: bool = False) -> None:
     reg_p = KIRO / "powers/registries/user-added.json"
     reg = _load(reg_p, {"powers": []})
     reg["powers"] = [p for p in reg["powers"] if p["name"] != name]
@@ -734,6 +734,28 @@ def register(name: str, power_dir: Path, report: list[str]) -> None:
         dst.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(ag, dst)
         report.append(f"- Agent installed: `{dst}`")
+    if slash:
+        # Kiro only offers `/name` for skills under ~/.kiro/skills/. A symlink there is enough —
+        # Kiro follows it, the skill body stays in the Power (one copy, no extra fds), and the
+        # Power's own keyword activation keeps working alongside.
+        linked, clashed = [], []
+        (KIRO / "skills").mkdir(parents=True, exist_ok=True)
+        for sk in sorted((power_dir / "skills").iterdir()) if (power_dir / "skills").is_dir() else []:
+            if not (sk / "SKILL.md").exists():
+                continue
+            link = KIRO / "skills" / sk.name
+            if link.is_symlink() and str(os.readlink(link)).startswith(str(power_dir)):
+                link.unlink()  # a link into this same Power from an earlier install — take it over
+            elif link.exists() or link.is_symlink():
+                clashed.append(sk.name)
+                continue
+            link.symlink_to(sk)
+            linked.append(sk.name)
+        if linked:
+            report.append(f"- Slash commands: {['/' + n for n in linked]} → symlinks in `{KIRO / 'skills'}` pointing into the Power")
+        if clashed:
+            report.append(f"- ⚠️ Not exposed as slash commands, a skill with that name already exists: {clashed}")
+        _manifest_put(name, {"mode": "power", "slash": linked})
 
 
 def unregister(name: str, cwd: Path) -> bool:
@@ -771,6 +793,11 @@ def unregister(name: str, cwd: Path) -> bool:
               f"or under {KIRO / 'powers/installed'}")
         return False
     if ent:
+        for sk in ent.get("slash", []):
+            link = KIRO / "skills" / sk
+            # only ever remove a symlink that points into this Power — never a real skill directory
+            if link.is_symlink() and str(link.resolve()).startswith(str(power_dir.resolve())):
+                link.unlink()
         del man[name]
         _save(MANIFEST, man)
     if power_dir.is_dir():
@@ -830,6 +857,8 @@ def main() -> None:
                     help="skip install records and go straight to a marketplace/plugin repo: local path | owner/repo | git URL")
     ap.add_argument("--as", dest="mode", choices=["auto", "skills", "power"], default="auto",
                     help="install mode. auto (default): skills-only goes to ~/.kiro/skills/, mixed goes to a Power")
+    ap.add_argument("--slash", action="store_true",
+                    help="also expose a Power's skills as /name slash commands (symlinks under ~/.kiro/skills/)")
     a = ap.parse_args()
     cwd = Path.cwd().resolve()
 
@@ -959,7 +988,7 @@ def main() -> None:
             if s["scope"] == "project":
                 report.append(f"- ⚠️ Source was project-scoped to `{s['project']}` but the Power installed globally. "
                               f"Run `--project-local` from that directory to keep it project-only")
-            register(name, power_dir, report)
+            register(name, power_dir, report, slash=a.slash)
         report.append("")
         report.append("## Worth checking by hand")
         if mode == "skills":

--- a/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/scripts/kiro-port.py
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/scripts/kiro-port.py
@@ -280,8 +280,12 @@ class Port:
                                f"(kirodotdev/Kiro#10625); this many can stall the shell with `spawn EBADF`")
         skills = self.dst / "skills"
         skill_names = [d.name for d in skills.iterdir() if (d / "SKILL.md").exists()] if skills.is_dir() else []
-        # 2) Substitute ${CLAUDE_PLUGIN_ROOT} inside skills/ bodies only
-        for f in skills.rglob("*") if skills.is_dir() else []:
+        # 2) Substitute ${CLAUDE_PLUGIN_ROOT} inside skills/ bodies only. Skipped when the source is
+        #    already an Agent Plugin: those never use the token, and a file that merely mentions it
+        #    (a script or doc) must not be rewritten.
+        root_pj = self.src / "plugin.json"
+        already_ap = root_pj.exists() and "agent-plugins.org" in str(json.loads(root_pj.read_text()).get("$schema", ""))
+        for f in (skills.rglob("*") if skills.is_dir() and not already_ap else []):
             if f.is_file() and f.suffix in (".md", ".sh", ".py", ".json", ".yaml", ".yml"):
                 t = f.read_text(errors="replace")
                 if self.root_token in t:
@@ -295,18 +299,30 @@ class Port:
         if others:
             self.report.append(f"- ❌ Commands that aren't `.md` are not converted: {others}")
         # 4) plugin.json (root)
-        pj = {"$schema": PLUGIN_SCHEMA, "name": name,
-              "version": str(m.get("version") or version_hint or "1.0.0"),
-              "description": m.get("description", "")}
-        for k in ("author", "license", "homepage", "repository"):
-            if k in m:
-                pj[k] = m[k]
-        pj["keywords"] = sorted(set([pj["name"]] + skill_names))
-        (self.dst / "plugin.json").write_text(json.dumps(pj, ensure_ascii=False, indent=2) + "\n")
-        self.report.append(f"- Generated `plugin.json`. `keywords` were derived **from names only**: "
-                           f"{pj['keywords']} — these are activation triggers, edit directly if you need more")
-        if not m.get("version"):
-            self.report.append("- Source had no `version` → defaulted to `1.0.0`")
+        existing = json.loads(root_pj.read_text()) if root_pj.exists() else {}
+        if already_ap:
+            # Already an Agent Plugin: the author's manifest is the source of truth — in particular
+            # their keywords, which are the activation triggers. Only the name is aligned.
+            pj = dict(existing)
+            pj["name"] = name
+            pj.setdefault("version", str(version_hint or "1.0.0"))
+            pj.setdefault("keywords", sorted(set([name] + skill_names)))
+            (self.dst / "plugin.json").write_text(json.dumps(pj, ensure_ascii=False, indent=2) + "\n")
+            self.report.append(f"- Source is already an Agent Plugin — kept its `plugin.json` "
+                               f"({len(pj['keywords'])} keyword(s) as the author set them)")
+        else:
+            pj = {"$schema": PLUGIN_SCHEMA, "name": name,
+                  "version": str(m.get("version") or version_hint or "1.0.0"),
+                  "description": m.get("description", "")}
+            for k in ("author", "license", "homepage", "repository"):
+                if k in m:
+                    pj[k] = m[k]
+            pj["keywords"] = sorted(set([pj["name"]] + skill_names))
+            (self.dst / "plugin.json").write_text(json.dumps(pj, ensure_ascii=False, indent=2) + "\n")
+            self.report.append(f"- Generated `plugin.json`. `keywords` were derived **from names only**: "
+                               f"{pj['keywords']} — these are activation triggers, edit directly if you need more")
+            if not m.get("version"):
+                self.report.append("- Source had no `version` → defaulted to `1.0.0`")
         # 5) .mcp.json → mcp.json
         mcp_src = self.dst / ".mcp.json"
         if mcp_src.exists():
@@ -684,6 +700,26 @@ def register(name: str, power_dir: Path, report: list[str]) -> None:
     if not any(p["name"] == name for p in inst["installedPowers"]):
         inst["installedPowers"].append({"name": name, "registryId": "user-added"})
     _save(inst_p, inst)
+    # MCP servers: kiro-cli doesn't read a Power's mcp.json at runtime — the IDE installer merges it
+    # into ~/.kiro/settings/mcp.json under powers.mcpServers as `power-<power>-<server>`. Without
+    # that entry the Power activates but "reports no tools". Done here so a CLI-only install works.
+    # Only stdio servers: Kiro never starts remote (http/sse) ones from a Power.
+    mcp = power_dir / "mcp.json"
+    if mcp.exists():
+        settings = KIRO / "settings/mcp.json"
+        cur = _load(settings, {})
+        ps = cur.setdefault("powers", {}).setdefault("mcpServers", {})
+        added = []
+        for key, srv in json.loads(mcp.read_text()).get("mcpServers", {}).items():
+            if not srv.get("command"):
+                continue
+            ent = {k: v for k, v in srv.items() if k != "type"}
+            ent.setdefault("disabled", False)
+            ps[f"power-{name}-{key}"] = ent
+            added.append(key)
+        if added:
+            _save(settings, cur)
+            report.append(f"- MCP server(s) registered in `{settings}` (powers.mcpServers): {added} — starts when the Power activates")
     # Things that have to live outside the Power
     for hook in (power_dir / "dev.kiro/hooks").glob("*.json"):
         dst = KIRO / "hooks" / hook.name
@@ -747,6 +783,15 @@ def unregister(name: str, cwd: Path) -> bool:
     _save(reg_p, reg)
     inst["installedPowers"] = [p for p in inst["installedPowers"] if p.get("name") != name]
     _save(inst_p, inst)
+    settings = KIRO / "settings/mcp.json"
+    if settings.exists():
+        cur = _load(settings, {})
+        ps = cur.get("powers", {}).get("mcpServers", {})
+        mine = [k for k in ps if k.startswith(f"power-{name}-")]
+        for k in mine:
+            del ps[k]
+        if mine:
+            _save(settings, cur)
     print(f"removed {name}")
     return True
 

--- a/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/scripts/kiro-port.py
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/skills/import-plugins/scripts/kiro-port.py
@@ -44,6 +44,13 @@ FILE_WARN = 2000  # warn past this many files
 AGENT_DROP_KEYS = {"tools", "model", "mcpServers", "hooks", "permissionMode", "color", "effort",
                    "initialPrompt", "disallowedTools", "skills", "memory", "background", "isolation", "maxTurns"}
 MANIFEST = Path(os.environ.get("KIRO_HOME", HOME / ".kiro")) / ".kiro-port-manifest.json"
+# kiro-cli's own slash commands (from `/help`, kiro-cli 2.21.1). A skill whose `name:` matches one
+# of these is shadowed in the slash list — the built-in wins — so --slash warns about it.
+KIRO_BUILTIN_SLASH = {
+    "agent", "changelog", "chat", "clear", "code", "compact", "config", "context", "copy", "editor",
+    "effort", "exit", "feedback", "help", "hooks", "knowledge", "mcp", "model", "paste", "plan",
+    "powers", "prompts", "quit", "reply", "rewind", "session-id", "sessions", "settings", "spawn",
+    "spec", "switch", "tangent", "title", "tools", "transcript", "upgrade-agent"}
 
 
 def classify(src: Path) -> tuple[str, dict]:
@@ -738,7 +745,7 @@ def register(name: str, power_dir: Path, report: list[str], slash: bool = False)
         # Kiro only offers `/name` for skills under ~/.kiro/skills/. A symlink there is enough —
         # Kiro follows it, the skill body stays in the Power (one copy, no extra fds), and the
         # Power's own keyword activation keeps working alongside.
-        linked, clashed = [], []
+        linked, slash_names, clashed, shadowed = [], [], [], []
         (KIRO / "skills").mkdir(parents=True, exist_ok=True)
         for sk in sorted((power_dir / "skills").iterdir()) if (power_dir / "skills").is_dir() else []:
             if not (sk / "SKILL.md").exists():
@@ -751,8 +758,17 @@ def register(name: str, power_dir: Path, report: list[str], slash: bool = False)
                 continue
             link.symlink_to(sk)
             linked.append(sk.name)
+            # Kiro names the slash command after the SKILL.md `name:` field, not the directory
+            mt = re.search(r"^name:\s*(\S+)", (sk / "SKILL.md").read_text(errors="ignore"), re.M)
+            sname = mt.group(1) if mt else sk.name
+            slash_names.append(sname)
+            if sname in KIRO_BUILTIN_SLASH:
+                shadowed.append(sname)
         if linked:
-            report.append(f"- Slash commands: {['/' + n for n in linked]} → symlinks in `{KIRO / 'skills'}` pointing into the Power")
+            report.append(f"- Slash commands: {['/' + n for n in slash_names]} → symlinks in `{KIRO / 'skills'}` pointing into the Power")
+        if shadowed:
+            report.append(f"- ⚠️ {['/' + n for n in shadowed]} collide with Kiro's own built-in commands and won't show up in the "
+                          f"slash list — Kiro's built-in wins. Still reachable by asking in plain language")
         if clashed:
             report.append(f"- ⚠️ Not exposed as slash commands, a skill with that name already exists: {clashed}")
         _manifest_put(name, {"mode": "power", "slash": linked})

--- a/ai-coding-assistants/agent-plugins/plugin-importer/tests/regression-test.py
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/tests/regression-test.py
@@ -357,6 +357,18 @@ def test_slash(root, kh, mk):
     rc, out = run(kh, "port", "--from", str(mk), "fx-cmd", "--slash")
     check("clashing name not overwritten", not (kh / "skills/deploy").is_symlink() and "mine" in (kh / "skills/deploy/SKILL.md").read_text())
     check("clash reported", "already exists" in out)
+    # slash name comes from SKILL.md `name:`, and built-in collisions are called out
+    p = root / "fx-slashnames"
+    (p / ".claude-plugin").mkdir(parents=True, exist_ok=True)
+    (p / ".claude-plugin/plugin.json").write_text(json.dumps({"name": "fx-slashnames", "description": "x"}))
+    (p / "skills/dirname").mkdir(parents=True, exist_ok=True)
+    (p / "skills/dirname/SKILL.md").write_text("---\nname: real-slash-name\ndescription: x\n---\n\nbody\n")
+    (p / "skills/help").mkdir(parents=True, exist_ok=True)
+    (p / "skills/help/SKILL.md").write_text("---\nname: help\ndescription: x\n---\n\nbody\n")
+    rc, out = run(kh, "port", "--from", str(p), "fx-slashnames", "--as", "power", "--slash")
+    check("report uses the frontmatter name", "/real-slash-name" in out and "/dirname" not in out, out[-500:])
+    check("built-in collision warned", "/help" in out and "built-in" in out, out[-500:])
+    run(kh, "unport", "fx-slashnames")
     run(kh, "unport", "fx-hook")
     check("unport removes the symlink", not link.exists() and not link.is_symlink())
     run(kh, "unport", "fx-cmd")

--- a/ai-coding-assistants/agent-plugins/plugin-importer/tests/regression-test.py
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/tests/regression-test.py
@@ -342,6 +342,28 @@ def test_agent_plugin_source(root, kh, mk):
     run(kh, "unport", "fx-ap")
 
 
+def test_slash(root, kh, mk):
+    print("\n[--slash] a Power's skills are exposed as /name via symlinks, removed on unport")
+    (kh / "skills/deploy").mkdir(parents=True)  # pre-existing real skill with a clashing name
+    (kh / "skills/deploy/SKILL.md").write_text("---\nname: deploy\ndescription: mine\n---\n\nmine\n")
+    # a stale link into the same Power path (left by an earlier install) must be taken over, not treated as a clash
+    (kh / "skills/only").symlink_to(kh / "powers/installed/fx-hook/skills/only")
+    rc, out = run(kh, "port", "--from", str(mk), "fx-hook", "--as", "power", "--slash")
+    link = kh / "skills/only"
+    check("stale link into the same Power is adopted", "/only" in out and "already exists" not in out.split("fx-hook")[-1][:600], out[-400:])
+    check("symlink created", link.is_symlink(), out[-400:])
+    check("symlink points into the Power", link.is_symlink() and (kh / "powers/installed/fx-hook/skills/only").resolve() == link.resolve())
+    check("report lists /only", "/only" in out)
+    rc, out = run(kh, "port", "--from", str(mk), "fx-cmd", "--slash")
+    check("clashing name not overwritten", not (kh / "skills/deploy").is_symlink() and "mine" in (kh / "skills/deploy/SKILL.md").read_text())
+    check("clash reported", "already exists" in out)
+    run(kh, "unport", "fx-hook")
+    check("unport removes the symlink", not link.exists() and not link.is_symlink())
+    run(kh, "unport", "fx-cmd")
+    check("real skill untouched by unport", (kh / "skills/deploy/SKILL.md").exists())
+    shutil.rmtree(kh / "skills/deploy")
+
+
 def test_untrusted_names(root, kh, mk):
     print("\n[untrusted] marketplace entries can't name paths outside ~/.kiro or the repo")
     escape_abs = root / "escaped-abs"          # an absolute path an attacker might target
@@ -414,7 +436,7 @@ def main() -> None:
     fx_agent_plugin(root)
     mk = fx_marketplace(root / "m1", plugins)
     tests = [test_skills_only, test_commands, test_hooks, test_flat_hooks, test_mcp, test_agents,
-             test_bulk, test_guidance, test_overrides, test_agent_plugin_source, test_untrusted_names,
+             test_bulk, test_guidance, test_overrides, test_agent_plugin_source, test_slash, test_untrusted_names,
              test_project_local, test_guards]
     print(f"isolated environment: {kh}")
     for t in tests:

--- a/ai-coding-assistants/agent-plugins/plugin-importer/tests/regression-test.py
+++ b/ai-coding-assistants/agent-plugins/plugin-importer/tests/regression-test.py
@@ -136,6 +136,19 @@ def fx_guidance(root: Path) -> Path:
     return d
 
 
+def fx_agent_plugin(root: Path) -> Path:
+    """Already an Agent Plugin (root plugin.json with $schema) — the author's keywords must survive."""
+    d = root / "fx-ap"
+    d.mkdir(parents=True)
+    (d / "plugin.json").write_text(json.dumps({
+        "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+        "name": "fx-ap", "version": "3.0.0", "description": "already agent plugins",
+        "keywords": ["fx-ap", "플러그인 가져와", "bring plugins", "custom phrase"]}) + "\n")
+    (d / "skills/s1").mkdir(parents=True)
+    (d / "skills/s1/SKILL.md").write_text("---\nname: s1\ndescription: Fixture.\n---\n\nBody.\n")
+    return d
+
+
 def fx_marketplace(root: Path, plugins: list[Path], entries: list[dict] | None = None) -> Path:
     """A local marketplace holding the fixtures. `entries` overrides the generated plugin list."""
     mk = root / "market"
@@ -247,7 +260,13 @@ def test_mcp(root, kh, mk):
         check("wrapped in mcpServers", set(d.get("mcpServers", {})) == {"local", "remote"})
         check("server definition unchanged", d["mcpServers"]["local"]["command"] == "uvx")
     check("remote MCP warning", "Remote MCP" in out and "remote" in out)
+    st = kh / "settings/mcp.json"
+    ps = json.loads(st.read_text()).get("powers", {}).get("mcpServers", {}) if st.exists() else {}
+    check("stdio server registered as power-<name>-<server>", "power-fx-mcp-local" in ps and ps["power-fx-mcp-local"].get("command") == "uvx", str(ps))
+    check("remote server not registered", "power-fx-mcp-remote" not in ps)
     run(kh, "unport", "fx-mcp")
+    ps = json.loads(st.read_text()).get("powers", {}).get("mcpServers", {}) if st.exists() else {}
+    check("unport removes the MCP registration", "power-fx-mcp-local" not in ps)
 
 
 def test_agents(root, kh, mk):
@@ -308,6 +327,19 @@ def test_guards(root, kh, mk):
     rc, out = run(kh, "port", "--from", str(mk2), "preexisting")
     check("existing Power protected", "⛔" in out or "this tool created" in out or (kh / "powers/installed/preexisting-market").exists(),
           out[-300:])
+
+
+def test_agent_plugin_source(root, kh, mk):
+    print("\n[agent-plugin source] a source that is already an Agent Plugin keeps its own plugin.json")
+    rc, out = run(kh, "port", "--from", str(root / "fx-ap"), "fx-ap", "--as", "power")
+    pj = kh / "powers/installed/fx-ap/plugin.json"
+    check("Power created", pj.exists(), out[-400:])
+    if pj.exists():
+        d = json.loads(pj.read_text())
+        check("author's keywords kept", d.get("keywords") == ["fx-ap", "플러그인 가져와", "bring plugins", "custom phrase"], str(d.get("keywords")))
+        check("author's version kept", d.get("version") == "3.0.0")
+    check("report says manifest was kept", "already an Agent Plugin" in out)
+    run(kh, "unport", "fx-ap")
 
 
 def test_untrusted_names(root, kh, mk):
@@ -379,9 +411,11 @@ def main() -> None:
     (kh / "powers/installed.json").write_text('{"version":"1.0.0","installedPowers":[],"dismissedAutoInstalls":[]}')
     (kh / "powers/registries/user-added.json").write_text('{"powers":[],"version":"1.0.0"}')
     plugins = [f(root) for f in (fx_skills_only, fx_commands, fx_hooks, fx_flat_hooks, fx_mcp, fx_agents, fx_bulk, fx_guidance)]
+    fx_agent_plugin(root)
     mk = fx_marketplace(root / "m1", plugins)
     tests = [test_skills_only, test_commands, test_hooks, test_flat_hooks, test_mcp, test_agents,
-             test_bulk, test_guidance, test_overrides, test_untrusted_names, test_project_local, test_guards]
+             test_bulk, test_guidance, test_overrides, test_agent_plugin_source, test_untrusted_names,
+             test_project_local, test_guards]
     print(f"isolated environment: {kh}")
     for t in tests:
         if a.filt and a.filt not in t.__name__:


### PR DESCRIPTION
## Summary
Follow-up to #256, from running the first-use flow end to end in a fresh `kiro-cli --v3`.

- **CLI-only install.** kiro-cli has no command to add a Power (`/powers` only lists). README now documents self-install from the clone: `python3 skills/import-plugins/scripts/kiro-port.py port --from . plugin-importer --as power`. Two fixes made that work: a source that is already an Agent Plugin (root `plugin.json` with `$schema`) keeps its own manifest — author `keywords`/`version` are no longer replaced by name-derived ones — and is not run through `${CLAUDE_PLUGIN_ROOT}` substitution, which was corrupting the converter's own script on self-install.
- **MCP registration.** kiro-cli does not read a Power's `mcp.json`; it reads `~/.kiro/settings/mcp.json` → `powers.mcpServers["power-<power>-<server>"]`, the entry the IDE installer writes. Without it the Power activates but "reports no tools". `register()` now writes those entries for `stdio` servers, `unregister()` removes them; remote servers are skipped and reported. Verified live: `power-playwright-playwright ● running 24 tools`.
- `kiro-mapping.md` updated accordingly; CHANGELOG entries added.

## Test plan
- [x] `python3 tests/regression-test.py` — 78 checks (3 new: stdio server registered, remote skipped, unport removes)
- [x] Fresh-CLI flow: self-install → `/powers` → import eli5 (skill) + ponytail (Power) → restart → both fire → import playwright from `anthropics/claude-plugins-official` → restart → `/mcp` shows the Power's server running